### PR TITLE
fix: set a proper image name for the controller

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -8,3 +8,10 @@ configMapGenerator:
 - name: manager-config
   files:
   - controller_manager_config.yaml
+
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+images:
+  - name: controller
+    newName: quay.io/redhat-appstudio/integration-service
+    newTag: next


### PR DESCRIPTION
Without this, infra-deployments will always use controller:latest.

Signed-off-by: David Moreno García <damoreno@redhat.com>