### PR TITLE
feat(HACBS-2127): mark new releases as automated

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -116,6 +116,14 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - releases/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
   - snapshots
   verbs:
   - create

--- a/controllers/snapshot/snapshot_adapter.go
+++ b/controllers/snapshot/snapshot_adapter.go
@@ -398,6 +398,14 @@ func (a *Adapter) createMissingReleasesForReleasePlans(application *applicationa
 			}
 			a.logger.LogAuditEvent("Created a new Release", newRelease, h.LogActionAdd,
 				"releasePlan.Name", releasePlan.Name)
+
+			patch := client.MergeFrom(newRelease.DeepCopy())
+			newRelease.SetAutomated()
+			err = a.client.Status().Patch(a.context, newRelease, patch)
+			if err != nil {
+				return err
+			}
+			a.logger.Info("Marked Release status automated", "release.Name", newRelease.Name)
 		}
 	}
 	return nil

--- a/controllers/snapshot/snapshot_controller.go
+++ b/controllers/snapshot/snapshot_controller.go
@@ -59,6 +59,7 @@ func NewSnapshotReconciler(client client.Client, logger *logr.Logger, scheme *ru
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargetclasses,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=deploymenttargetclaims,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=environments,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=releases/status,verbs=get;update;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a
 	github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471
-	github.com/redhat-appstudio/release-service v0.0.0-20230504094255-035afad2cab8
+	github.com/redhat-appstudio/release-service v0.0.0-20230511145849-bde1cdcbb60b
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.0
 	github.com/tektoncd/pipeline v0.45.0
 	github.com/tonglil/buflogr v1.0.1
@@ -54,7 +54,7 @@ require (
 	github.com/google/go-github/v48 v48.2.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 // indirect
+	github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 // indirect
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.15.0 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,8 @@ github.com/google/pprof v0.0.0-20200212024743-f11f1df84d12/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38 h1:yAJXTCF9TqKcTiHJAE8dj7HMvPfh66eeA2JYW7eFpSE=
-github.com/google/pprof v0.0.0-20210407192527-94a9f03dee38/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3 h1:2XF1Vzq06X+inNqgJ9tRnGuw+ZVCB3FazXODD6JE1R8=
+github.com/google/pprof v0.0.0-20230510103437-eeec1cb781c3/go.mod h1:79YE0hCXdHag9sBkw2o+N/YnZtTkXi0UT9Nnixa5eYk=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
@@ -217,7 +217,6 @@ github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.13 h1:lFzP57bqS/wsqKssCGmtLAb8A0wKjLGrve2q3PPVcBk=
 github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK2O4oXg=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
@@ -317,8 +316,8 @@ github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a h
 github.com/redhat-appstudio/application-api v0.0.0-20230427114540-a91722251e0a/go.mod h1:LpcTNLCDMf1CUNTw2bgTiz8M49sUsN2F9T7bOSKcJEo=
 github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471 h1:BB/XtDbzL4txupSVRkPvGf1Jm5tFsK+/yKgLQuDIDc0=
 github.com/redhat-appstudio/operator-goodies v0.0.0-20221130140446-010c05bd7471/go.mod h1:sfJSn4B9LcaWhIxnRXWs2olpJNdLZ+Nnb7hTSj98Fv8=
-github.com/redhat-appstudio/release-service v0.0.0-20230504094255-035afad2cab8 h1:Kdf2mTIYG1qvVEAu7drpt90wV/MmyogSasdrvpXDNvI=
-github.com/redhat-appstudio/release-service v0.0.0-20230504094255-035afad2cab8/go.mod h1:a2jPi276KqDvkRw0lcjOSV3MFZxEh8BLOPD63vm2oeg=
+github.com/redhat-appstudio/release-service v0.0.0-20230511145849-bde1cdcbb60b h1:96jgqIR8Otx2vrLZscvNo3gFlX2d9P/mkbx5Trkm8tQ=
+github.com/redhat-appstudio/release-service v0.0.0-20230511145849-bde1cdcbb60b/go.mod h1:a2jPi276KqDvkRw0lcjOSV3MFZxEh8BLOPD63vm2oeg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=

--- a/release/releaseplan.go
+++ b/release/releaseplan.go
@@ -18,8 +18,10 @@ package release
 
 import (
 	"context"
+
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	releasev1alpha1 "github.com/redhat-appstudio/release-service/api/v1alpha1"
+	releasemetadata "github.com/redhat-appstudio/release-service/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
@@ -33,6 +35,9 @@ func NewReleaseForReleasePlan(releasePlan *releasev1alpha1.ReleasePlan, snapshot
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: snapshot.Name + "-",
 			Namespace:    snapshot.Namespace,
+			Labels: map[string]string{
+				releasemetadata.AutomatedLabel: "true",
+			},
 		},
 		Spec: releasev1alpha1.ReleaseSpec{
 			Snapshot:    snapshot.Name,

--- a/release/releaseplan_test.go
+++ b/release/releaseplan_test.go
@@ -74,9 +74,10 @@ var _ = Describe("Release functions for managing Releases", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
-	It("ensures the Release can be created for ReleasePlan", func() {
+	It("ensures the Release can be created for ReleasePlan and is labelled as automated", func() {
 		createdRelease := integrationservicerelease.NewReleaseForReleasePlan(releasePlan, hasSnapshot)
 		Expect(createdRelease.Spec.ReleasePlan).To(Equal(releasePlan.Name))
+		Expect(createdRelease.GetLabels()[releasemetadata.AutomatedLabel]).To(Equal("true"))
 	})
 
 	It("ensures the matching Release can be found for ReleasePlan", func() {


### PR DESCRIPTION
As part of the release service's efforts to track which user created a release, the integration service should mark releases that it creates as automated. This information lets the release service know that a user did not manually created it. Automated is set both as a label and in the status to prevent users from falsely marking a release as automated.