### PR TITLE
chore(checklist): adding maintainers checklist

### DIFF
--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,0 +1,5 @@
+## Maintainers will complete the following section
+
+- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
+- [ ] Code coverage from testing does not decrease and new code is covered
+- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


### PR DESCRIPTION
This checklist is to make sure we don't forgot any critical areas of contribution.

Project maintainers (reviewers) must check checklist items before merging