### PR TITLE
fix(STONEINTG-815): remove ephemeral env cleanup code

### DIFF
--- a/docs/integration_pipeline_controller.md
+++ b/docs/integration_pipeline_controller.md
@@ -16,15 +16,11 @@ flowchart TD
   is_snapshot_of_pr_event{Is <br> Snapshot created<br> for Pull requests?}
   is_plr_finished_or_getting_deleted{Is <br> Integration PLR <br> finished or marked for<br> deletion?}
   remove_finalizer(Remove <br> `test.appstudio.openshift.io/pipelinerun`<br> finalizer)
-  clean_environment(Clean up ephemeral environment <br> if testing finished)
   error(Return error)
-  requeue(Requeue)
   continue1(Continue processing)
-  continue2(Continue processing)
 
   %% Node connections
   predicate                                   --> get_resources
-  predicate                                   --> clean_environment
   get_resources     --No                      --> error
   get_resources     --Yes                     --> report_status_snapshot
   report_status_snapshot                      --> is_snapshot_of_pr_event
@@ -33,8 +29,6 @@ flowchart TD
   is_plr_finished_or_getting_deleted --Yes    --> remove_finalizer
   is_plr_finished_or_getting_deleted --No     --> continue1
   remove_finalizer                            --> continue1
-  clean_environment --No                      --> requeue
-  clean_environment --yes                     ---> continue2
 
   %% Assigning styles to nodes
   class predicate Amber;

--- a/docs/scenario-controller.md
+++ b/docs/scenario-controller.md
@@ -20,15 +20,14 @@ flowchart TD
   environment_exists{"Environment exists <br> in same namespace <br> as IntegrationTestScenario?"}
   update_scenario_status_valid(Update IntegrationTestScenario <br>status to valid)
   update_scenario_status_invalid(Update IntegrationTestScenario <br>status to invalid)
-  get_any_environments_for_scenario{Get any existing ephemeral Environments for the <br>IntegrationTestScenario}
-  cleanup_all_found_environments(Clean up all found ephemeral Environments)
-  remove_finalizer(Remove the finalizer from IntegrationTestScenario)
+  remove_historical_finalizer(Check for and remove<br>historical IntegrationTestScenario <br> finalizer)
   complete_reconciliation(Complete reconciliation for <br>IntegrationTestScenario)
   continue_reconciliation(Continue with next reconciliation)
 
 
   %% Node connections
-  predicate                        ---->    |"EnsureCreatedScenarioIsValid()"| application_exists
+  predicate                        ---->    |"EnsureCreatedScenarioIsValid()"| remove_historical_finalizer
+  remove_historical_finalizer      -->      application_exists
   application_exists               --No-->  update_scenario_status_invalid
   application_exists               --Yes--> set_owner_reference
   set_owner_reference              -->      environment_defined
@@ -39,13 +38,6 @@ flowchart TD
   update_scenario_status_valid     -->      complete_reconciliation
   complete_reconciliation          -->      continue_reconciliation
   update_scenario_status_invalid   -->      continue_reconciliation
-
-%% Node connections
-predicate                          -->      |"EnsureDeletedScenarioResourcesAreCleanedUp()"| get_any_environments_for_scenario
-get_any_environments_for_scenario  --Yes--> cleanup_all_found_environments
-get_any_environments_for_scenario  --No-->  remove_finalizer
-cleanup_all_found_environments     -->      remove_finalizer
-remove_finalizer                   -->      continue_reconciliation
 
    %% Assigning styles to nodes
   class predicate Amber;

--- a/internal/controller/integrationpipeline/integrationpipeline_controller.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_controller.go
@@ -118,14 +118,12 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureStatusReportedInSnapshot,
-		adapter.EnsureEphemeralEnvironmentsCleanedUp,
 	})
 }
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
 	EnsureStatusReportedInSnapshot() (controller.OperationResult, error)
-	EnsureEphemeralEnvironmentsCleanedUp() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -82,7 +82,6 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureCreatedScenarioIsValid,
-		adapter.EnsureDeletedScenarioResourcesAreCleanedUp,
 	})
 }
 
@@ -105,7 +104,6 @@ func (r *Reconciler) getApplicationFromScenario(context context.Context, scenari
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
 	EnsureCreatedScenarioIsValid() (controller.OperationResult, error)
-	EnsureDeletedScenarioResourcesAreCleanedUp() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.


### PR DESCRIPTION
Remove code associated with EnsureEphemeralEnvironmentsCleanedUp().

- Remove EnsureEphemeralEnvironmentsCleanedUp()to stop cleanup ephemeral environment
- Stop adding finalizers to IntegrationTestScenarios
- Remove the related functions and related unittests
- Update all related documentation, diagram

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
