### PR TITLE
feat(STONEINTG-849): write all Integration-PLR-creation errors to snapshot annotation

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -512,20 +512,20 @@ func (a *Adapter) RequeueIfYoungerThanThreshold(retErr error) (controller.Operat
 }
 
 func (a *Adapter) HandlePipelineCreationError(err error, integrationTestScenario *v1beta2.IntegrationTestScenario, testStatuses *intgteststat.SnapshotIntegrationTestStatuses) (controller.OperationResult, error) {
+	a.logger.Error(err, "pipelineRun failed during creation due to",
+		"integrationScenario.Name", integrationTestScenario.Name)
+	testStatuses.UpdateTestStatusIfChanged(
+		integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
+		fmt.Sprintf("Creation of pipelineRun failed during creation due to: %s.", err))
+	itsErr := gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
+	if itsErr != nil {
+		a.logger.Error(err, "Failed to write Test Status into Snapshot")
+		return controller.RequeueWithError(itsErr)
+	}
+
 	if clienterrors.IsInvalid(err) {
-		a.logger.Error(err, "pipelineRun failed during creation due to invalid resource",
-			"integrationScenario.Name", integrationTestScenario.Name)
-		testStatuses.UpdateTestStatusIfChanged(
-			integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
-			fmt.Sprintf("Creation of pipelineRun failed during creation due to invalid resource: %s.", err))
-		itsErr := gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
-		if itsErr != nil {
-			a.logger.Error(err, "Failed to write Test Status into Snapshot")
-			return controller.RequeueWithError(err)
-		}
 		return controller.StopProcessing()
 	}
-	a.logger.Error(err, "Failed to create pipelineRun for snapshot and scenario",
-		"integrationScenario.Name", integrationTestScenario.Name)
+
 	return controller.RequeueWithError(err)
 }

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -511,7 +511,7 @@ func (a *Adapter) RequeueIfYoungerThanThreshold(retErr error) (controller.Operat
 }
 
 func (a *Adapter) HandlePipelineCreationError(err error, integrationTestScenario *v1beta2.IntegrationTestScenario, testStatuses *intgteststat.SnapshotIntegrationTestStatuses) (controller.OperationResult, error) {
-	a.logger.Error(err, "pipelineRun failed during creation due to",
+	a.logger.Error(err, "Failed to create pipelineRun for snapshot and scenario",
 		"integrationScenario.Name", integrationTestScenario.Name)
 	testStatuses.UpdateTestStatusIfChanged(
 		integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -220,15 +220,14 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 			} else {
 				pipelineRun, err := a.createIntegrationPipelineRun(a.application, &integrationTestScenario, a.snapshot)
 				if err != nil {
-					if clienterrors.IsInvalid(err) {
-						a.logger.Error(err, "pipelineRun failed during creation due to invalid resource",
-							"integrationScenario.Name", integrationTestScenario.Name)
-						testStatuses.UpdateTestStatusIfChanged(
-							integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
-							fmt.Sprintf("Creation of pipelineRun failed during creation due to invalid resource: %s.", err))
-					} else {
-						a.logger.Error(err, "Failed to create pipelineRun for snapshot and scenario",
-							"integrationScenario.Name", integrationTestScenario.Name)
+					a.logger.Error(err, "Failed to create pipelineRun for snapshot and scenario",
+						"integrationScenario.Name", integrationTestScenario.Name)
+
+					testStatuses.UpdateTestStatusIfChanged(
+						integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
+						fmt.Sprintf("Creation of pipelineRun failed during creation due to: %s.", err))
+
+					if !clienterrors.IsInvalid(err) {
 						errsForPLRCreation = errors.Join(errsForPLRCreation, err)
 					}
 					continue

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -761,7 +761,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
 
-			expectedLogEntry := "failed during creation due to invalid resource"
+			expectedLogEntry := "Failed to create pipelineRun for snapshot and scenario"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 


### PR DESCRIPTION
* This commit now ensures that all the errors that occur while Integration PLR creation, are logged into the Snapshot's status annotation.
* Earlier only Invalid-type errors were logged, leaving behind other types of error from the annotation.
* This made it difficult for users to understand what went wrong, because annotation was, in some cases, stuck on "Pending" status.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/redhat-appstudio/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
