### PR TITLE
fix(STONEINTG-936): change git-provider label to annotation

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -89,6 +89,9 @@ const (
 	// PipelineAsCodeGitProviderLabel is the git provider which triggered the pipelinerun in build service.
 	PipelineAsCodeGitProviderLabel = PipelinesAsCodePrefix + "/git-provider"
 
+	// PipelineAsCodeGitProviderAnnotation is the git provider which triggered the pipelinerun in build service.
+	PipelineAsCodeGitProviderAnnotation = PipelinesAsCodePrefix + "/git-provider"
+
 	// PipelineAsCodeSHALabel is the commit which triggered the pipelinerun in build service.
 	PipelineAsCodeSHALabel = PipelinesAsCodePrefix + "/sha"
 

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -537,7 +537,8 @@ func generateGithubCommitState(state intgteststat.IntegrationTestStatus) (string
 
 // Detect if GitHubReporter can be used
 func (r *GitHubReporter) Detect(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType)
+	return metadata.HasAnnotationWithValue(snapshot, gitops.PipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeGitHubProviderType) ||
+		metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType)
 }
 
 // Initialize github reporter. Must be called before updating status

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -198,7 +198,6 @@ var _ = Describe("GitHubReporter", func() {
 					"test.appstudio.openshift.io/type":               "component",
 					"appstudio.openshift.io/component":               "component-sample",
 					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
-					"pac.test.appstudio.openshift.io/git-provider":   "github",
 					"pac.test.appstudio.openshift.io/url-org":        "devfile-sample",
 					"pac.test.appstudio.openshift.io/url-repository": "devfile-sample-go-basic",
 					"pac.test.appstudio.openshift.io/sha":            "12a4a35ccd08194595179815e4646c3a6c08bb77",
@@ -207,6 +206,7 @@ var _ = Describe("GitHubReporter", func() {
 				Annotations: map[string]string{
 					"build.appstudio.redhat.com/commit_sha":         "6c65b2fcaea3e1a0a92476c8b5dc89e92a85f025",
 					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					"pac.test.appstudio.openshift.io/git-provider":  "github",
 					"pac.test.appstudio.openshift.io/repo-url":      "https://github.com/devfile-sample/devfile-sample-go-basic",
 				},
 			},
@@ -257,6 +257,12 @@ var _ = Describe("GitHubReporter", func() {
 		})
 
 		It("can detect if github reporter should be used", func() {
+			hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "github"
+			Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+
+			hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "not-github"
+			Expect(reporter.Detect(hasSnapshot)).To(BeFalse())
+
 			hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "github"
 			Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
 

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -56,7 +56,8 @@ var _ ReporterInterface = (*GitLabReporter)(nil)
 
 // Detect if snapshot has been created from gitlab provider
 func (r *GitLabReporter) Detect(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitLabProviderType)
+	return metadata.HasAnnotationWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitLabProviderType) ||
+		metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeGitLabProviderType)
 }
 
 // GetReporterName returns the reporter name

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -69,7 +69,6 @@ var _ = Describe("GitLabReporter", func() {
 					"test.appstudio.openshift.io/type":               "component",
 					"appstudio.openshift.io/component":               "component-sample",
 					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
-					"pac.test.appstudio.openshift.io/git-provider":   "gitlab",
 					"pac.test.appstudio.openshift.io/url-org":        "devfile-sample",
 					"pac.test.appstudio.openshift.io/url-repository": "devfile-sample-go-basic",
 					"pac.test.appstudio.openshift.io/sha":            "12a4a35ccd08194595179815e4646c3a6c08bb77",
@@ -78,6 +77,7 @@ var _ = Describe("GitLabReporter", func() {
 				Annotations: map[string]string{
 					"build.appstudio.redhat.com/commit_sha":             digest,
 					"appstudio.redhat.com/updateComponentOnSuccess":     "false",
+					"pac.test.appstudio.openshift.io/git-provider":      "gitlab",
 					"pac.test.appstudio.openshift.io/repo-url":          repoUrl,
 					"pac.test.appstudio.openshift.io/target-project-id": targetProjectID,
 					"pac.test.appstudio.openshift.io/source-project-id": sourceProjectID,
@@ -111,6 +111,12 @@ var _ = Describe("GitLabReporter", func() {
 
 	It("can detect if gitlab reporter should be used", func() {
 		reporter := status.NewGitLabReporter(log, mockK8sClient)
+		hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "gitlab"
+		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+
+		hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "not-gitlab"
+		Expect(reporter.Detect(hasSnapshot)).To(BeFalse())
+
 		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "gitlab"
 		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
 


### PR DESCRIPTION
* The pac.test.appstudio.openshift.io/git-provider was moved to be an annotation in newer versions of Tekton

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
