### PR TITLE
chore: fix panic due to incorrect logging

### DIFF
--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -131,7 +131,7 @@ func (a *Adapter) EnsureSnapshotFinishedAllTests() (controller.OperationResult, 
 	if err != nil {
 		return controller.RequeueWithError(err)
 	}
-	a.logger.Info("Found %d required integration test scenarios", len(*integrationTestScenarios))
+	a.logger.Info(fmt.Sprintf("Found %d required integration test scenarios", len(*integrationTestScenarios)))
 
 	testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(a.snapshot)
 	if err != nil {


### PR DESCRIPTION
* The previous way of logging is causing a panic:
```
{"level":"dpanic","ts":"2024-05-16T04:28:59Z","logger":"controllers.statusreport","caller":"statusreport/statusreport_adapter.go:134","msg":"odd number of arguments passed as key-value pairs for logging","snapshot":{"name":"integ-app-xuce-hdngm","namespace":"stat-rep-kxmp-tenant"},"application":"stat-rep-kxmp-tenant/integ-app-xuce","ignored key":2,"stacktrace":"github.com/konflux-ci/integration-service/internal/controller/statusreport.(*Adapter).EnsureSnapshotFinishedAllTests
```
as seen in [our controller logs](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/logs/periodic-ci-redhat-appstudio-infra-deployments-main-appstudio-e2e-tests-periodic/1790955678383214592/artifacts/appstudio-e2e-tests-periodic/gather-extra/artifacts/pods/integration-service_integration-service-controller-manager-7c5c78865c-dw6gf_manager.log) as part of a CI job.

* This commit modifies the log.info() to take in a single string instead, and no key-value pairs.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
