### PR TITLE
feat(STONEINTG-881): update GCL once push snapshot is created for component

### DIFF
--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -42,7 +42,7 @@ flowchart TD
   %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGlobalCandidateImageUpdated() function
 
   %% Node definitions
-  ensure2(Process further if: Component is not nil & <br>Snapshot testing succeeded & <br>Snapshot was not created by <br>PAC Pull Request Event & <br> Snapshot wasn't added to Global Candidate List)
+  ensure2(Process further if: Component is not nil & <br>Snapshot was not created by <br>PAC Pull Request Event & <br> Snapshot wasn't added to Global Candidate List)
   update_container_image("<b>Update</b> the '.spec.containerImage' field of the given <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].containerImage field")
   update_last_built_commit("<b>Update</b> the '.status.lastBuiltCommit' field of the given <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].source.git.revision field")
   mark_snapshot_added_to_GCL(<b>Mark</b> the Snapshot as AddedToGlobalCandidateList)

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -279,14 +279,10 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 }
 
 // EnsureGlobalCandidateImageUpdated is an operation that ensure the ContainerImage in the Global Candidate List
-// being updated when the Snapshot passed all the integration tests
+// being updated when the Snapshot is created
 func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResult, error) {
 	if a.component == nil || !gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
 		a.logger.Info("The Snapshot wasn't created for a single component push event, not updating the global candidate list.")
-		return controller.ContinueProcessing()
-	}
-	if !gitops.HaveAppStudioTestsSucceeded(a.snapshot) {
-		a.logger.Info("The Snapshot hasn't yet passed all required integration tests, not updating the global candidate list.")
 		return controller.ContinueProcessing()
 	}
 	if gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(a.snapshot) {

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -345,9 +345,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("ensures global Component Image will not be updated in the PR context", func() {
-			err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshotPR, "test passed")
-			Expect(err).To(Succeed())
-			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshotPR)).To(BeTrue())
 			adapter.snapshot = hasSnapshotPR
 
 			Eventually(func() bool {
@@ -359,7 +356,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
 		})
 
-		It("no error from ensuring global Component Image updated when AppStudio Tests failed", func() {
+		It("ensures global Component Image updated when AppStudio Tests failed", func() {
 			err := gitops.MarkSnapshotAsFailed(ctx, k8sClient, hasSnapshot, "test failed")
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
@@ -368,8 +365,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			Expect(hasComp.Spec.ContainerImage).To(Equal(""))
-			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
+			Expect(hasComp.Spec.ContainerImage).To(Equal(sample_image))
+			Expect(hasComp.Status.LastBuiltCommit).To(Equal(sample_revision))
 		})
 
 		It("ensures global Component Image updated when AppStudio Tests succeeded", func() {


### PR DESCRIPTION
* Update global component list once the push snapshot is created for component, don't wait for the successful integration test any more

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
