### PR TITLE
chore(STONEINTG-938): Improve error reporting and log annotation value for better debuggability

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -265,11 +265,12 @@ func (s *Status) ReportSnapshotStatus(ctx context.Context, reporter ReporterInte
 			return fmt.Errorf("failed to update status: %w", err)
 		}
 		srs.SetLastUpdateTime(integrationTestStatusDetail.ScenarioName, integrationTestStatusDetail.LastUpdateTime)
-
 	}
 	if err := WriteSnapshotReportStatus(ctx, s.client, snapshot, srs); err != nil {
 		return fmt.Errorf("failed to write snapshot report status metadata: %w", err)
 	}
+
+	s.logger.Info(fmt.Sprintf("Successfully updated the %s annotation", gitops.SnapshotStatusReportAnnotation), "snapshotReportStatus.value", srs)
 
 	return nil
 }


### PR DESCRIPTION
* We're logging the value of the struct to help
  us with debugging in case of race conditions.
* We'll be requeueing in case we hit an error
  while updating the "git-reporter-status" anntn
* This will log silent errors, and help us debug.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
