### PR TITLE
fix(STONE-876): catch admission validation error

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -522,9 +522,14 @@ func (a *Adapter) HandlePipelineCreationError(err error, integrationTestScenario
 		return controller.RequeueWithError(itsErr)
 	}
 
+	if strings.Contains(err.Error(), "admission webhook") && strings.Contains(err.Error(), "denied the request") {
+		//Stop processing in case the error runs in admission webhook validation error:
+		//failed to call client.Create to create pipelineRun for snapshot
+		//<snapshot-name>: admission webhook \"validation.webhook.pipeline.tekton.dev\" denied the request: validation failed: <reason>
+		return controller.StopProcessing()
+	}
 	if clienterrors.IsInvalid(err) {
 		return controller.StopProcessing()
 	}
-
 	return controller.RequeueWithError(err)
 }


### PR DESCRIPTION
Goal is to prevent reconcialtion being in infinite look retrying to create pipelinerun. We will catch this specific action when the webhook validation failed and report test status as invalid.
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
