### PR TITLE
chore: update build-definitions references to new org

### DIFF
--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -160,7 +160,7 @@ var _ = Describe("Integration pipeline", func() {
 					Params: []v1beta2.ResolverParameter{
 						{
 							Name:  "url",
-							Value: "https://github.com/redhat-appstudio/build-definitions.git",
+							Value: "https://github.com/konflux-ci/build-definitions.git",
 						},
 						{
 							Name:  "revision",


### PR DESCRIPTION
[STONEBLD-2339](https://issues.redhat.com//browse/STONEBLD-2339)

The build-definitions repo has moved from github.com/redhat-appstudio to
github.com/konflux-ci. Update references accordingly.

Signed-off-by: Adam Cmiel <acmiel@redhat.com>
