### PR TITLE
feat(STONEINTG-657): allow RFC3339 timestamps in integration-service

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -94,7 +94,7 @@ var testResultSchema = `{
     },
     "timestamp": {
       "type": "string",
-      "pattern": "^[0-9]{10}$"
+      "pattern": "^[0-9]{10}$|^((?:(\\d{4}-\\d{2}-\\d{2})T(\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?))(Z|[\\+-]\\d{2}:\\d{2})?)$"
     },
     "successes": {
       "type": "integer",

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -163,7 +163,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0
@@ -208,7 +208,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "FAILURE",
-											"timestamp": "1665405317",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 1,
 											"successes": 0,
 											"warnings": 0
@@ -246,6 +246,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 		Expect(k8sClient.Create(ctx, skippedTaskRun)).Should(Succeed())
 
+		// The skipped taskRun uses the deprecated UNIX timestamp format which
+		// needs to be supported for backwards compatibility
 		skippedTaskRun.Status = tektonv1.TaskRunStatus{
 			TaskRunStatusFields: tektonv1.TaskRunStatusFields{
 				StartTime:      &metav1.Time{Time: now.Add(5 * time.Minute)},
@@ -301,7 +303,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 							"result": "WARNING",
-							"timestamp": "1665405320",
+							"timestamp": "2024-05-22T06:42:21+00:00",
 							"failures": 0,
 							"successes": 0,
 							"warnings": 1

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0
@@ -233,7 +233,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "FAILURE",
-											"timestamp": "1665405317",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 1,
 											"successes": 0,
 											"warnings": 0

--- a/internal/controller/buildpipeline/buildpipeline_controller_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller_test.go
@@ -127,7 +127,7 @@ var _ = Describe("PipelineController", func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
@@ -224,7 +224,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0
@@ -271,7 +271,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "FAILURE",
-											"timestamp": "1665405317",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 1,
 											"successes": 0,
 											"warnings": 0

--- a/internal/controller/integrationpipeline/integrationpipeline_controller_test.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_controller_test.go
@@ -167,7 +167,7 @@ var _ = Describe("Integration PipelineController", func() {
 						Name: "TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Loader", Ordered, func() {
 						Name: "HACBS_TEST_OUTPUT",
 						Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Formatters", func() {
 				now.Add(time.Minute*5).Add(time.Second*30),
 				`{
 					"result": "SUCCESS",
-					"timestamp": "1665405318",
+					"timestamp": "2024-05-22T06:42:21+00:00",
 					"namespace": "example-namespace-1",
 					"successes": 2,
 					"warnings": 1,
@@ -107,7 +107,7 @@ var _ = Describe("Formatters", func() {
 				now.Add(time.Second*4),
 				`{
 					"result": "FAILURE",
-					"timestamp": "1665405318",
+					"timestamp": "2024-05-22T06:42:21+00:00",
 					"namespace": "example-namespace-3",
 					"successes": 0,
 					"warnings": 0,
@@ -121,7 +121,7 @@ var _ = Describe("Formatters", func() {
 				now.Add(time.Second*5),
 				`{
 					"result": "WARNING",
-					"timestamp": "1665405318",
+					"timestamp": "2024-05-22T06:42:21+00:00",
 					"namespace": "example-namespace-4",
 					"successes": 0,
 					"warnings": 1,
@@ -135,7 +135,7 @@ var _ = Describe("Formatters", func() {
 				now,
 				`{
 					"result": "SKIPPED",
-					"timestamp": "1665405318",
+					"timestamp": "2024-05-22T06:42:21+00:00",
 					"namespace": "example-namespace-5",
 					"successes": 0,
 					"warnings": 0,
@@ -148,7 +148,7 @@ var _ = Describe("Formatters", func() {
 				now.Add(time.Second*7),
 				`{
 					"result": "ERROR",
-					"timestamp": "1665405318",
+					"timestamp": "2024-05-22T06:42:21+00:00",
 					"namespace": "example-namespace-6",
 					"successes": 0,
 					"warnings": 0,

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Status Adapter", func() {
 							Name: "TEST_OUTPUT",
 							Value: *tektonv1.NewStructuredValues(`{
 											"result": "SUCCESS",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 10,
 											"warnings": 0
@@ -153,7 +153,7 @@ var _ = Describe("Status Adapter", func() {
 							Name: "TEST_OUTPUT",
 							Value: *tektonv1.NewStructuredValues(`{
 											"result": "FAILURE",
-											"timestamp": "1665405317",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 1,
 											"successes": 0,
 											"warnings": 0
@@ -196,7 +196,7 @@ var _ = Describe("Status Adapter", func() {
 							Name: "TEST_OUTPUT",
 							Value: *tektonv1.NewStructuredValues(`{
 											"result": "SKIPPED",
-											"timestamp": "1665405318",
+											"timestamp": "2024-05-22T06:42:21+00:00",
 											"failures": 0,
 											"successes": 0,
 											"warnings": 0


### PR DESCRIPTION
* Support the RFC3339 timestamps in TASK_OUTPUT json schema
* Keep the support for UNIX timestamps for backwards compatibility

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
