### PR TITLE
fix(STONEINTG-861): get Konflux console name from env

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -22,6 +22,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -35,9 +36,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
-
-// NamePrefix is a common name prefix for this service.
-const NamePrefix = "Red Hat Konflux"
 
 // ScenarioReportStatus keep report status of git provider for the particular scenario
 type ScenarioReportStatus struct {
@@ -286,7 +284,9 @@ func (s *Status) generateTestReport(ctx context.Context, detail intgteststat.Int
 		return nil, fmt.Errorf("failed to generate summary message: %w", err)
 	}
 
-	fullName := fmt.Sprintf("%s / %s", NamePrefix, detail.ScenarioName)
+	consoleName := getConsoleName()
+
+	fullName := fmt.Sprintf("%s / %s", consoleName, detail.ScenarioName)
 	if snapshot.Labels[gitops.SnapshotComponentLabel] != "" {
 		fullName = fmt.Sprintf("%s / %s", fullName, snapshot.Labels[gitops.SnapshotComponentLabel])
 	}
@@ -370,4 +370,12 @@ func GenerateSummary(state intgteststat.IntegrationTestStatus, snapshotName, sce
 	summary = fmt.Sprintf("Integration test for snapshot %s and scenario %s %s", snapshotName, scenarioName, statusDesc)
 
 	return summary, nil
+}
+
+func getConsoleName() string {
+	consoleName := os.Getenv("CONSOLE_NAME")
+	if consoleName == "" {
+		return "Integration Service"
+	}
+	return consoleName
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -310,9 +310,12 @@ var _ = Describe("Status Adapter", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		mockReporter = status.NewMockReporterInterface(ctrl)
 		mockReporter.EXPECT().GetReporterName().Return("mocked-reporter").AnyTimes()
+
+		os.Setenv("CONSOLE_NAME", "Red Hat Konflux")
 	})
 	AfterEach(func() {
 		os.Setenv("CONSOLE_URL", "")
+		os.Setenv("CONSOLE_NAME", "")
 	})
 
 	It("can get reporters from a snapshot", func() {
@@ -381,11 +384,12 @@ var _ = Describe("Status Adapter", func() {
 	})
 
 	It("report expected textual data for InProgress test scenario", func() {
+		os.Setenv("CONSOLE_NAME", "Konflux Staging")
 		hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"testPipelineRunName\":\"test-pipelinerun\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]"
 		t, err := time.Parse(time.RFC3339, "2023-07-26T16:57:49+02:00")
 		Expect(err).NotTo(HaveOccurred())
 		expectedTestReport := status.TestReport{
-			FullName:            "Red Hat Konflux / scenario1 / component-sample",
+			FullName:            "Konflux Staging / scenario1 / component-sample",
 			ScenarioName:        "scenario1",
 			SnapshotName:        "snapshot-sample",
 			ComponentName:       "component-sample",


### PR DESCRIPTION
* get Konflux console name from environment variable

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
