### PR TITLE
Run integration test from pr

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -119,6 +119,9 @@ const (
 	// PipelineAsCodeTargetProjectIDAnnotation is the target project ID for gitlab
 	PipelineAsCodeTargetProjectIDAnnotation = PipelinesAsCodePrefix + "/target-project-id"
 
+	// PipelineAsCodeSHAAnnotation is the commit which triggered the pipelinerun in build service.
+	PipelineAsCodeSHAAnnotation = PipelinesAsCodePrefix + "/sha"
+
 	// PipelineAsCodePushType is the type of push event which triggered the pipelinerun in build service
 	PipelineAsCodePushType = "push"
 

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -453,6 +453,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err).To(BeNil())
 		Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field or missing valid digest")
 		Expect(snapshot.Spec.Components[0].Name).To(Equal(hasComp.Name), "The built component should have been added to the snapshot")
+		Expect(snapshot.GetAnnotations()).To(HaveKeyWithValue(gitops.SnapshotGitSourceRepoURLAnnotation, componentSource.GitSource.URL), "The git source repo URL annotation is added")
 	})
 
 	It("ensure error is returned if the ContainerImage digest is invalid", func() {

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -47,6 +47,15 @@ const (
 
 	// PipelineTypeTest is the type for PipelineRuns created to run an integration Pipeline
 	PipelineTypeTest = "test"
+
+	// Name of tekton resolver for git
+	TektonResolverGit = "git"
+
+	// Name of tekton git resolver param url
+	TektonResolverGitParamURL = "url"
+
+	// Name of tekton git resolver param revision
+	TektonResolverGitParamRevision = "revision"
 )
 
 var (
@@ -116,6 +125,24 @@ func NewIntegrationPipelineRun(prefix, namespace string, integrationTestScenario
 		},
 	}
 	return &IntegrationPipelineRun{pipelineRun}
+}
+
+// Updates git resolver values parameters with values of params specified in the input map
+// updates only exsitings parameters, doens't create new ones
+func (iplr *IntegrationPipelineRun) WithUpdatedTestsGitResolver(params map[string]string) *IntegrationPipelineRun {
+	if iplr.Spec.PipelineRef.ResolverRef.Resolver != TektonResolverGit {
+		// if the resolver is not git-resolver, we cannot update the git ref
+		return iplr
+	}
+
+	for originalParamIndex, originalParam := range iplr.Spec.PipelineRef.ResolverRef.Params {
+		if _, ok := params[originalParam.Name]; ok {
+			// remeber to use the original index to update the value, we cannot update value given by range directly
+			iplr.Spec.PipelineRef.ResolverRef.Params[originalParamIndex].Value.StringVal = params[originalParam.Name]
+		}
+	}
+
+	return iplr
 }
 
 // WithFinalizer adds a Finalizer on the Integration PipelineRun


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
