### PR TITLE
feat(STONINTG-896): prevent creation of ITS with snapshot set manually

### DIFF
--- a/api/v1beta2/integrationtestscenario_webhook.go
+++ b/api/v1beta2/integrationtestscenario_webhook.go
@@ -38,13 +38,23 @@ var _ webhook.Validator = &IntegrationTestScenario{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (r *IntegrationTestScenario) ValidateCreate() (warnings admission.Warnings, err error) {
 	// We use the DNS-1035 format for application names, so ensure it conforms to that specification
-
 	if len(validation.IsDNS1035Label(r.Name)) != 0 {
 		return nil, field.Invalid(field.NewPath("metadata").Child("name"), r.Name,
 			"an IntegrationTestScenario resource name must start with a lower case "+
 				"alphabetical character, be under 63 characters, and can only consist "+
 				"of lower case alphanumeric characters or ‘-’")
 	}
+
+	// see stoneintg-896
+	for _, param := range r.Spec.Params {
+		if param.Name == "SNAPSHOT" {
+			return nil, field.Invalid(field.NewPath("Spec").Child("Params"), param.Name,
+				"an IntegrationTestScenario resource should not have the SNAPSHOT "+
+					"param manually defined because it will be automatically generated"+
+					"by the integration service")
+		}
+	}
+
 	return nil, nil
 }
 

--- a/api/v1beta2/integrationtestscenario_webhook_test.go
+++ b/api/v1beta2/integrationtestscenario_webhook_test.go
@@ -82,4 +82,10 @@ var _ = Describe("IntegrationTestScenario webhook", func() {
 		integrationTestScenario.Name = "this-name-is-too-long-it-has-64-characters-and-we-allow-max-63ch"
 		Expect(k8sClient.Create(ctx, integrationTestScenario)).ShouldNot(Succeed())
 	})
+
+	It("should fail to create scenario with snapshot parameter set", func() {
+		integrationTestScenario.Spec.Params = append(integrationTestScenario.Spec.Params, PipelineParameter{Name: "SNAPSHOT"})
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).ShouldNot(Succeed())
+	})
+
 })


### PR DESCRIPTION
Add additonal webhook validation added to ITS to prevent creation of ITS with the snapshot param set manually.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
