### PR TITLE
feat(STONEINTG-882): make component optional in snapshot controllers

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -267,12 +267,12 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		var buf bytes.Buffer
 
 		It("can create a new Adapter instance", func() {
-			Expect(reflect.TypeOf(NewAdapter(ctx, hasSnapshot, hasApp, hasComp, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
+			Expect(reflect.TypeOf(NewAdapter(ctx, hasSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 		})
 
 		It("ensures the integrationTestPipelines are created", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -409,7 +409,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).To(Succeed())
 			Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -494,7 +494,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeFalse())
 
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			Eventually(func() bool {
 				result, err := adapter.EnsureAllReleasesExist()
 				return !result.CancelRequest && err == nil
@@ -583,7 +583,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("Ensure error is logged when experiencing error when fetching ITS for application", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -617,7 +617,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		It("Mark snapshot as pass when required ITS is not found", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -649,7 +649,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
 					ContextKey: loader.ApplicationContextKey,
@@ -763,7 +763,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			var buf bytes.Buffer
 
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(ctx, hasInvalidSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasInvalidSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -804,7 +804,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			var buf bytes.Buffer
 
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 
 			helpers.SetScenarioIntegrationStatusAsInvalid(integrationTestScenarioForInvalidSnapshot, "invalid")
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
@@ -863,7 +863,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("Cancel request when GetAutoReleasePlansForApplication returns an error", func() {
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			// Mock the context with error for AutoReleasePlansContextKey
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 				{
@@ -880,7 +880,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 
 		It("Returns RequeueWithError if the snapshot is less than three hours old", func() {
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			testErr := fmt.Errorf("something went wrong with the release")
 
 			result, err := adapter.RequeueIfYoungerThanThreshold(testErr)
@@ -896,7 +896,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			// and returns a time.Time.  Why?  Who knows.  We want the latter, so we add -3 hours here
 			hasSnapshot.CreationTimestamp = metav1.NewTime(time.Now().Add(-1 * SnapshotRetryTimeout))
 
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			testErr := fmt.Errorf("something went wrong with the release")
 
 			result, err := adapter.RequeueIfYoungerThanThreshold(testErr)
@@ -920,7 +920,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = integrationTestScenario.Name
 
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+				adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
@@ -1014,7 +1014,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = integrationTestScenario.Name
 
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+				adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,
@@ -1098,7 +1098,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				hasSnapshot.Labels[gitops.SnapshotIntegrationTestRun] = integrationTestScenario.Name
 
 				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-				adapter = NewAdapter(ctx, hasSnapshot, hasApp, hasComp, log, loader.NewMockLoader(), k8sClient)
+				adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
 						ContextKey: loader.ApplicationContextKey,

--- a/internal/controller/snapshot/snapshot_controller.go
+++ b/internal/controller/snapshot/snapshot_controller.go
@@ -20,10 +20,8 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/konflux-ci/integration-service/cache"
-	"github.com/konflux-ci/integration-service/tekton"
-
 	"github.com/go-logr/logr"
+	"github.com/konflux-ci/integration-service/cache"
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
@@ -123,16 +121,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	logger = logger.WithApp(*application)
 
-	var component *applicationapiv1alpha1.Component
-	err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
-		component, err = loader.GetComponentFromSnapshot(ctx, r.Client, snapshot)
-		return err
-	})
-	if err != nil {
-		return helpers.HandleLoaderError(logger, err, fmt.Sprintf("Component or '%s' label", tekton.ComponentNameLabel), "Snapshot")
-	}
-
-	adapter := NewAdapter(ctx, snapshot, application, component, logger, loader, r.Client)
+	adapter := NewAdapter(ctx, snapshot, application, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureAllReleasesExist,

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -183,8 +183,8 @@ func (r *IntegrationPipelineRun) WithExtraParams(params []v1beta2.PipelineParame
 	return r
 }
 
-// WithSnapshot adds a param containing the Snapshot as a json string
-// to the integration PipelineRun.
+// WithSnapshot adds a param containing the Snapshot as a json string to the integration PipelineRun.
+// It also adds the Snapshot name label and copies the Component name label if it exists
 func (r *IntegrationPipelineRun) WithSnapshot(snapshot *applicationapiv1alpha1.Snapshot) *IntegrationPipelineRun {
 	// We ignore the error here because none should be raised when marshalling the spec of a CRD.
 	// If we end up deciding it is useful, we will need to pass the errors through the chain and
@@ -200,6 +200,11 @@ func (r *IntegrationPipelineRun) WithSnapshot(snapshot *applicationapiv1alpha1.S
 		r.ObjectMeta.Labels = map[string]string{}
 	}
 	r.ObjectMeta.Labels[SnapshotNameLabel] = snapshot.Name
+
+	componentLabel, found := snapshot.GetLabels()[ComponentNameLabel]
+	if found {
+		r.ObjectMeta.Labels[ComponentNameLabel] = componentLabel
+	}
 
 	return r
 }
@@ -234,13 +239,10 @@ func (r *IntegrationPipelineRun) WithIntegrationAnnotations(its *v1beta2.Integra
 	return r
 }
 
-// WithApplicationAndComponent adds the name of both application and component as lables to the Integration PipelineRun.
-func (r *IntegrationPipelineRun) WithApplicationAndComponent(application *applicationapiv1alpha1.Application, component *applicationapiv1alpha1.Component) *IntegrationPipelineRun {
+// WithApplication adds the name of application as a label to the Integration PipelineRun.
+func (r *IntegrationPipelineRun) WithApplication(application *applicationapiv1alpha1.Application) *IntegrationPipelineRun {
 	if r.ObjectMeta.Labels == nil {
 		r.ObjectMeta.Labels = map[string]string{}
-	}
-	if component != nil {
-		r.ObjectMeta.Labels[ComponentNameLabel] = component.Name
 	}
 	r.ObjectMeta.Labels[ApplicationNameLabel] = application.Name
 

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -295,7 +295,7 @@ var _ = Describe("Integration pipeline", func() {
 		newIntegrationBundlePipelineRun = tekton.NewIntegrationPipelineRun(prefix, namespace, *integrationTestScenarioBundle).
 			WithIntegrationLabels(integrationTestScenarioBundle).
 			WithSnapshot(hasSnapshot).
-			WithApplicationAndComponent(hasApp, hasComp)
+			WithApplication(hasApp)
 		Expect(k8sClient.Create(ctx, newIntegrationBundlePipelineRun.AsPipelineRun())).Should(Succeed())
 
 		enterpriseContractPipelineRun = tekton.NewIntegrationPipelineRun(prefix, namespace, *enterpriseContractTestScenario).
@@ -303,7 +303,7 @@ var _ = Describe("Integration pipeline", func() {
 			WithIntegrationAnnotations(enterpriseContractTestScenario).
 			WithSnapshot(hasSnapshot).
 			WithExtraParams(enterpriseContractTestScenario.Spec.Params).
-			WithApplicationAndComponent(hasApp, hasComp)
+			WithApplication(hasApp)
 		Expect(k8sClient.Create(ctx, enterpriseContractPipelineRun.AsPipelineRun())).Should(Succeed())
 
 		os.Setenv("PIPELINE_TIMEOUT", "2h")
@@ -414,16 +414,16 @@ var _ = Describe("Integration pipeline", func() {
 				To(Equal(integrationTestScenarioGit.Namespace))
 		})
 
-		It("can append labels that comes from Snapshot to IntegrationPipelineRun and make sure that label value matches the snapshot name", func() {
+		It("can append labels that comes from Snapshot to IntegrationPipelineRun and make sure that label value matches the snapshot and component names", func() {
 			newIntegrationPipelineRun.WithSnapshot(hasSnapshot)
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/snapshot"]).
 				To(Equal(hasSnapshot.Name))
-		})
-
-		It("can append labels coming from Application and Component to IntegrationPipelineRun and making sure that label values matches application and component names", func() {
-			newIntegrationPipelineRun.WithApplicationAndComponent(hasApp, hasComp)
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/component"]).
 				To(Equal(hasComp.Name))
+		})
+
+		It("can append labels coming from Application to IntegrationPipelineRun and making sure that label values matches application", func() {
+			newIntegrationPipelineRun.WithApplication(hasApp)
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/application"]).
 				To(Equal(hasApp.Name))
 		})


### PR DESCRIPTION
* Remove "component" from the Snapshot adapter and try to retreive it only when updating the Global Candidate List
* Update the integration pipeline creation logic to only copy the component label from the Snapshot and not require the component CR

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
