### PR TITLE
feat(STONEINTG-892): support new override snapshot

### DIFF
--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -42,8 +42,8 @@ flowchart TD
   %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGlobalCandidateImageUpdated() function
 
   %% Node definitions
-  ensure2(Process further if: Component is not nil & <br>Snapshot was not created by <br>PAC Pull Request Event & <br> Snapshot wasn't added to Global Candidate List)
-  update_container_image("<b>Update</b> the '.spec.containerImage' field of the given <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].containerImage field")
+  ensure2(Process further if: <br>Snapshot was not created by PAC Pull Request Event OR <br>an override snapshot was created <br>& Snapshot wasn't added to Global Candidate List)
+  update_container_image("<b>Get</b> all components of snapshot and <br><b>Update</b> the '.spec.containerImage' field of the <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].containerImage field")
   update_last_built_commit("<b>Update</b> the '.status.lastBuiltCommit' field of the given <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].source.git.revision field")
   mark_snapshot_added_to_GCL(<b>Mark</b> the Snapshot as AddedToGlobalCandidateList)
   continue_processing2(Controller continues processing...)

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -86,6 +86,9 @@ const (
 	// SnapshotCompositeType is the type of Snapshot which was created for multiple components.
 	SnapshotCompositeType = "composite"
 
+	// SnapshotOverrideType is the type of Snapshot which was created for override Global Candidate List.
+	SnapshotOverrideType = "override"
+
 	// PipelineAsCodeEventTypeLabel is the type of event which triggered the pipelinerun in build service
 	PipelineAsCodeEventTypeLabel = PipelinesAsCodePrefix + "/event-type"
 
@@ -842,4 +845,17 @@ func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Applica
 	_ = metadata.CopyLabelsByPrefix(source, &snapshot.ObjectMeta, prefix)
 	_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
 
+}
+
+// IsOverrideSnapshot returns true if snapshot label 'test.appstudio.openshift.io/type' is 'override'
+func IsOverrideSnapshot(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return metadata.HasLabelWithValue(snapshot, SnapshotTypeLabel, SnapshotOverrideType)
+}
+
+func IsComponentSnapshot(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return metadata.HasLabelWithValue(snapshot, SnapshotTypeLabel, SnapshotComponentType)
+}
+
+func IsComponentSnapshotCreatedByPACPushEvent(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return IsComponentSnapshot(snapshot) && IsSnapshotCreatedByPACPushEvent(snapshot)
 }

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -241,6 +241,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures the Snapshots status can be marked as component added to global candidate list", func() {
 		Expect(gitops.IsSnapshotMarkedAsAddedToGlobalCandidateList(hasSnapshot)).To(BeFalse())
+		Expect(gitops.IsComponentSnapshotCreatedByPACPushEvent(hasSnapshot)).To(BeTrue())
 
 		err := gitops.MarkSnapshotAsAddedToGlobalCandidateList(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).To(BeNil())
@@ -558,4 +559,19 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	})
 
+	Context("Override snapshot tests", func() {
+		When("Snapshot has snapshot type label", func() {
+			var overrideSnapshot *applicationapiv1alpha1.Snapshot
+			BeforeEach(func() {
+				overrideSnapshot = hasSnapshot.DeepCopy()
+				overrideSnapshot.Labels[gitops.SnapshotTypeLabel] = gitops.SnapshotOverrideType
+			})
+
+			It("make sure correct label is returned in overrideSnapshot", func() {
+				isOverrideSnapshot := gitops.IsOverrideSnapshot(overrideSnapshot)
+				Expect(isOverrideSnapshot).To(BeTrue())
+			})
+		})
+
+	})
 })


### PR DESCRIPTION
* introduce a new type of snapshot: override
* update global candidate list if a override snapshot contains the component with valid digest

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
