### PR TITLE
fix(KFLUXBUGS-1355): skip components with invalid images

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -667,6 +667,15 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, applicati
 
 		var componentSource *applicationapiv1alpha1.ComponentSource
 		if applicationComponent.Name == component.Name {
+			// if the containerImage doesn't have a valid digest, we cannot construct a Snapshot
+			// for the given component
+			err := ValidateImageDigest(newContainerImage)
+			if err != nil {
+				log.Error(err, "component cannot be added to snapshot for application due to invalid digest in containerImage",
+					"component.Name", applicationComponent.Name,
+					"newContainerImage", newContainerImage)
+				return nil, errors.Join(helpers.NewInvalidImageDigestError(component.Name, newContainerImage), err)
+			}
 			containerImage = newContainerImage
 			componentSource = newComponentSource
 		} else {
@@ -687,7 +696,7 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, applicati
 			err := ValidateImageDigest(containerImage)
 			if err != nil {
 				log.Error(err, "component cannot be added to snapshot for application due to invalid digest in containerImage", "component.Name", applicationComponent.Name)
-				return nil, errors.Join(helpers.NewInvalidImageDigestError(component.Name, containerImage), err)
+				continue
 			}
 			snapshotComponents = append(snapshotComponents, applicationapiv1alpha1.SnapshotComponent{
 				Name:           applicationComponent.Name,

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -473,6 +473,49 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(err.Error()).Should(ContainSubstring("quay.io/redhat-appstudio/sample-image@invaliDigest is invalid container image digest from component component-sample"))
 	})
 
+	It("ensure that an existing component with invalid image won't be added to the new Snapshot", func() {
+		validImagePullSpec := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		invalidImagePullSpec := "quay.io/redhat-appstudio/sample-image"
+
+		hasComp2 := &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "second-component",
+				Namespace: namespace,
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  "second-component",
+				Application:    applicationName,
+				ContainerImage: invalidImagePullSpec,
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      SampleRepoLink,
+							Revision: SampleCommit,
+						},
+					},
+				},
+			},
+		}
+		componentSource := &applicationapiv1alpha1.ComponentSource{
+			ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+				GitSource: &applicationapiv1alpha1.GitSource{
+					URL:      SampleRepoLink,
+					Revision: SampleCommit,
+				},
+			},
+		}
+		allApplicationComponents := &[]applicationapiv1alpha1.Component{*hasComp, *hasComp2}
+		snapshot, err := gitops.PrepareSnapshot(ctx, k8sClient, hasApp, allApplicationComponents, hasComp, validImagePullSpec, componentSource)
+		Expect(snapshot).NotTo(BeNil())
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(snapshot.Spec.Components).To(HaveLen(1))
+		for _, snapshotComponent := range snapshot.Spec.Components {
+			snapshotComponent := snapshotComponent
+			Expect(snapshotComponent.ContainerImage).NotTo(Equal(invalidImagePullSpec))
+		}
+	})
+
 	It("Return false when the image url contains invalid digest", func() {
 		imageUrl := "quay.io/redhat-appstudio/sample-image:latest"
 		Expect(gitops.ValidateImageDigest(imageUrl)).NotTo(BeNil())


### PR DESCRIPTION
* Don't return an error when constructing a Snapshot in case one of the existing (non-built) components has an invalid image reference in their GCL (spec.containerImage)
* Do return an error in case the newly built image is invalid

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
