### PR TITLE
fix(STONEINTG-960): show conditions in webUI

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -20,10 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"reflect"
 	"sort"
 	"time"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -139,6 +140,11 @@ func (t *TaskRun) GetStartTime() time.Time {
 		return time.Time{}
 	}
 	return t.trStatus.StartTime.Time
+}
+
+// GetStatusCondition returns the status condition of the TaskRun.
+func (t *TaskRun) GetStatusCondition(conditionName string) *apis.Condition {
+	return t.trStatus.GetCondition(apis.ConditionType(conditionName))
 }
 
 // GetDuration returns the time it took to execute the Task.


### PR DESCRIPTION
This PR prevents reporting empty string to webUI when PLR finishes. In case that TEST_OUTPUT is nil, we check status conditions for given taskrun and report it.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
