### PR TITLE
fix: update component source revision during override

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -356,6 +356,11 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 			if err != nil {
 				return controller.RequeueWithError(err)
 			}
+			// update .Status.LastBuiltCommit for each snapshotComponent in override snapshot
+			err = a.updateComponentSource(a.context, a.client, componentToUpdate, &snapshotComponent)
+			if err != nil {
+				return controller.RequeueWithError(err)
+			}
 		}
 	}
 

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -263,6 +263,14 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					{
 						Name:           hasComp.Name,
 						ContainerImage: sample_image + "@" + sampleDigest,
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									URL:      SampleRepoLink,
+									Revision: sample_revision,
+								},
+							},
+						},
 					},
 					{
 						Name: "nonexisting-component",
@@ -270,6 +278,14 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					{
 						Name:           hasCompMissingImageDigest.Name,
 						ContainerImage: sample_image,
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									URL:      SampleRepoLink,
+									Revision: sample_revision,
+								},
+							},
+						},
 					},
 				},
 			},
@@ -479,7 +495,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(result.CancelRequest).To(BeFalse())
 			expectedLogEntry = "Updated .Spec.ContainerImage of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			// don't update Glocal Candidate List for the component included in a override snapshot but doesn't existw
+			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+			// don't update Global Candidate List for the component included in a override snapshot but doesn't existw
 			expectedLogEntry = "Failed to get component from applicaion, won't update global candidate list for this component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "containerImage cannot be updated to component Global Candidate List due to invalid digest in containerImage"


### PR DESCRIPTION
* When promoting components from an override Snapshot, update the component source revision if available

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
