### PR TITLE
chore(STONEINTG-972): update integration team members

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,7 @@ updates:
       - "sonam1412"
       - "dheerajodha"
       - "14rcole"
+      - "chipspeak"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -37,6 +38,7 @@ updates:
       - "sonam1412"
       - "dheerajodha"
       - "14rcole"
+      - "chipspeak"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
@@ -52,3 +54,4 @@ updates:
       - "sonam1412"
       - "dheerajodha"
       - "14rcole"
+      - "chipspeak"


### PR DESCRIPTION
* Add chipspeak (Patrick O'Connor) to team members configuration

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
