### PR TITLE
feat(STONEINTG-961): remove composite snapshot

### DIFF
--- a/docs/statusreport-controller.md
+++ b/docs/statusreport-controller.md
@@ -15,9 +15,7 @@ flowchart TD
   get_required_scenarios(Get all required <br> IntegrationTestScenarios)
   parse_snapshot_status(Parse the Snapshot's <br> status annotation)
   check_finished_tests{Did Snapshot <br> finish all required <br> integration tests?}
-  check_supersede{Does Snapshot need <br> to be superseded <br> with a composite Snapshot?}
   check_passed_tests{Did Snapshot <br> pass all required <br> integration tests?}
-  create_snapshot(Create composite Snapshot)
   update_status(Update Snapshot status accordingly)
   continue_processing_tests(Controller continues processing)
 
@@ -26,11 +24,7 @@ flowchart TD
   predicate                    ---->    |"EnsureSnapshotFinishedAllTests()"|get_required_scenarios
   get_required_scenarios        --->    parse_snapshot_status
   parse_snapshot_status         --->    check_finished_tests
-  check_finished_tests      --Yes-->    check_supersede
-  check_finished_tests       --No-->    continue_processing_tests
-  check_supersede           --Yes-->    create_snapshot
-  check_supersede            --No-->    check_passed_tests
-  create_snapshot               --->    update_status
+  check_finished_tests          --->    continue_processing_tests
   check_passed_tests        --Yes-->    update_status
   check_passed_tests         --No-->    update_status
   update_status                ---->    continue_processing_tests

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -83,9 +83,6 @@ const (
 	// SnapshotComponentType is the type of Snapshot which was created for a single component build.
 	SnapshotComponentType = "component"
 
-	// SnapshotCompositeType is the type of Snapshot which was created for multiple components.
-	SnapshotCompositeType = "composite"
-
 	// SnapshotOverrideType is the type of Snapshot which was created for override Global Candidate List.
 	SnapshotOverrideType = "override"
 
@@ -823,8 +820,8 @@ func ResetSnapshotStatusConditions(ctx context.Context, adapterClient client.Cli
 }
 
 // CopySnapshotLabelsAndAnnotation coppies labels and annotations from build pipelineRun or tested snapshot
-// into regular or composite snapshot
-func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, componentName string, source *metav1.ObjectMeta, prefix string, isComposite bool) {
+// into regular snapshot
+func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, componentName string, source *metav1.ObjectMeta, prefix string) {
 
 	if snapshot.Labels == nil {
 		snapshot.Labels = map[string]string{}
@@ -833,11 +830,7 @@ func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Applica
 	if snapshot.Annotations == nil {
 		snapshot.Annotations = map[string]string{}
 	}
-	if !isComposite {
-		snapshot.Labels[SnapshotTypeLabel] = SnapshotComponentType
-	} else {
-		snapshot.Labels[SnapshotTypeLabel] = SnapshotCompositeType
-	}
+	snapshot.Labels[SnapshotTypeLabel] = SnapshotComponentType
 
 	snapshot.Labels[SnapshotComponentLabel] = componentName
 	snapshot.Labels[ApplicationNameLabel] = application.Name

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -210,7 +210,7 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 		return nil, err
 	}
 
-	gitops.CopySnapshotLabelsAndAnnotation(application, snapshot, a.component.Name, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix, false)
+	gitops.CopySnapshotLabelsAndAnnotation(application, snapshot, a.component.Name, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
 
 	snapshot.Labels[gitops.BuildPipelineRunNameLabel] = pipelineRun.Name
 	if pipelineRun.Status.CompletionTime != nil {

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -415,7 +415,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(copyToSnapshot).NotTo(BeNil())
 
-			gitops.CopySnapshotLabelsAndAnnotation(hasApp, copyToSnapshot, hasComp.Name, &buildPipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix, false)
+			gitops.CopySnapshotLabelsAndAnnotation(hasApp, copyToSnapshot, hasComp.Name, &buildPipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
 			Expect(copyToSnapshot.Labels[gitops.SnapshotTypeLabel]).To(Equal(gitops.SnapshotComponentType))
 			Expect(copyToSnapshot.Labels[gitops.SnapshotComponentLabel]).To(Equal(hasComp.Name))
 			Expect(copyToSnapshot.Labels[gitops.ApplicationNameLabel]).To(Equal(hasApp.Name))

--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -135,11 +135,6 @@ func (a *Adapter) createUpdatedSnapshot(snapshotComponents *[]applicationapiv1al
 	if snapshot.Labels == nil {
 		snapshot.Labels = map[string]string{}
 	}
-	snapshotType := gitops.SnapshotCompositeType
-	if len(*snapshotComponents) == 1 {
-		snapshotType = gitops.SnapshotComponentType
-	}
-	snapshot.Labels[gitops.SnapshotTypeLabel] = snapshotType
 
 	err := ctrl.SetControllerReference(a.application, snapshot, a.client.Scheme())
 	if err != nil {


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)

 I've been a little vicious about composite snapshot code removal.
 Updated diagram containing composite snapshot also.
 Feel free to address what needs to remain.