### PR TITLE
feat(STONEINTG-953): copy test and custom labels/annotations

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -41,6 +41,12 @@ const (
 	// PipelinesAsCodePrefix contains the prefix applied to labels and annotations copied from Pipelines as Code resources.
 	PipelinesAsCodePrefix = "pac.test.appstudio.openshift.io"
 
+	// TestLabelPrefix contains the prefix applied to labels and annotations related to testing.
+	TestLabelPrefix = "test.appstudio.openshift.io"
+
+	// CustomLabelPrefix contains the prefix applied to custom user-defined labels and annotations.
+	CustomLabelPrefix = "custom.appstudio.openshift.io"
+
 	// SnapshotTypeLabel contains the type of the Snapshot.
 	SnapshotTypeLabel = "test.appstudio.openshift.io/type"
 
@@ -819,9 +825,9 @@ func ResetSnapshotStatusConditions(ctx context.Context, adapterClient client.Cli
 	return nil
 }
 
-// CopySnapshotLabelsAndAnnotation coppies labels and annotations from build pipelineRun or tested snapshot
+// CopySnapshotLabelsAndAnnotations coppies labels and annotations from build pipelineRun or tested snapshot
 // into regular snapshot
-func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, componentName string, source *metav1.ObjectMeta, prefix string) {
+func CopySnapshotLabelsAndAnnotations(application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, componentName string, source *metav1.ObjectMeta, prefixes []string) {
 
 	if snapshot.Labels == nil {
 		snapshot.Labels = map[string]string{}
@@ -839,9 +845,11 @@ func CopySnapshotLabelsAndAnnotation(application *applicationapiv1alpha1.Applica
 	_ = metadata.CopyLabelsWithPrefixReplacement(source, &snapshot.ObjectMeta, "pipelinesascode.tekton.dev", PipelinesAsCodePrefix)
 	_ = metadata.CopyAnnotationsWithPrefixReplacement(source, &snapshot.ObjectMeta, "pipelinesascode.tekton.dev", PipelinesAsCodePrefix)
 
-	// Copy labels and annotations prefixed with defined prefix
-	_ = metadata.CopyLabelsByPrefix(source, &snapshot.ObjectMeta, prefix)
-	_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
+	for _, prefix := range prefixes {
+		// Copy labels and annotations prefixed with defined prefix
+		_ = metadata.CopyLabelsByPrefix(source, &snapshot.ObjectMeta, prefix)
+		_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
+	}
 
 }
 

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -210,7 +210,8 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 		return nil, err
 	}
 
-	gitops.CopySnapshotLabelsAndAnnotation(application, snapshot, a.component.Name, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
+	prefixes := []string{gitops.BuildPipelineRunPrefix, gitops.TestLabelPrefix, gitops.CustomLabelPrefix}
+	gitops.CopySnapshotLabelsAndAnnotations(application, snapshot, a.component.Name, &pipelineRun.ObjectMeta, prefixes)
 
 	snapshot.Labels[gitops.BuildPipelineRunNameLabel] = pipelineRun.Name
 	if pipelineRun.Status.CompletionTime != nil {

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -563,13 +563,6 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 	}
 
 	pipelineRun := pipelineRunBuilder.AsPipelineRun()
-	// copy PipelineRun PAC annotations/labels from snapshot to integration test PipelineRuns
-	_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix)
-	_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.PipelinesAsCodePrefix)
-
-	// Copy build labels and annotations prefixed with build.appstudio from snapshot to integration test PipelineRuns
-	_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
-	_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &pipelineRun.ObjectMeta, gitops.BuildPipelineRunPrefix)
 
 	err := ctrl.SetControllerReference(snapshot, pipelineRun, a.client.Scheme())
 	if err != nil {

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -37,8 +37,17 @@ const (
 	// PipelinesLabelPrefix is the prefix of the pipelines label
 	PipelinesLabelPrefix = "pipelines.appstudio.openshift.io"
 
-	// TestLabelPrefix is the prefix of the test labels
+	// TestLabelPrefix contains the prefix applied to labels and annotations related to testing.
 	TestLabelPrefix = "test.appstudio.openshift.io"
+
+	// PipelinesAsCodePrefix contains the prefix applied to labels and annotations copied from Pipelines as Code resources.
+	PipelinesAsCodePrefix = "pac.test.appstudio.openshift.io"
+
+	// BuildPipelineRunPrefix contains the build pipeline run related labels and annotations
+	BuildPipelineRunPrefix = "build.appstudio"
+
+	// CustomLabelPrefix contains the prefix applied to custom user-defined labels and annotations.
+	CustomLabelPrefix = "custom.appstudio.openshift.io"
 
 	// resource labels for snapshot, application and component
 	ResourceLabelSuffix = "appstudio.openshift.io"
@@ -202,6 +211,14 @@ func (r *IntegrationPipelineRun) WithSnapshot(snapshot *applicationapiv1alpha1.S
 	componentLabel, found := snapshot.GetLabels()[ComponentNameLabel]
 	if found {
 		r.ObjectMeta.Labels[ComponentNameLabel] = componentLabel
+	}
+
+	// copy PipelineRun PAC, build, test and custom annotations/labels from Snapshot to integration test PipelineRun
+	prefixes := []string{PipelinesAsCodePrefix, BuildPipelineRunPrefix, TestLabelPrefix, CustomLabelPrefix}
+	for _, prefix := range prefixes {
+		// Copy labels and annotations prefixed with defined prefix
+		_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &r.ObjectMeta, prefix)
+		_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &r.ObjectMeta, prefix)
 	}
 
 	return r

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -196,8 +196,9 @@ var _ = Describe("Integration pipeline", func() {
 				Name:      "snapshot-sample",
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:      "component",
-					gitops.SnapshotComponentLabel: "component-sample",
+					gitops.SnapshotTypeLabel:                   "component",
+					gitops.SnapshotComponentLabel:              "component-sample",
+					gitops.CustomLabelPrefix + "/custom-label": "custom-label",
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -357,6 +358,10 @@ var _ = Describe("Integration pipeline", func() {
 				To(Equal(hasSnapshot.Name))
 			Expect(newIntegrationPipelineRun.Labels["appstudio.openshift.io/component"]).
 				To(Equal(hasComp.Name))
+			Expect(newIntegrationPipelineRun.Labels[gitops.CustomLabelPrefix+"/custom_label"]).
+				To(Equal(hasSnapshot.Labels[gitops.CustomLabelPrefix+"/custom_label"]))
+			Expect(newIntegrationPipelineRun.Labels[gitops.SnapshotTypeLabel]).
+				To(Equal(hasSnapshot.Labels[gitops.SnapshotTypeLabel]))
 		})
 
 		It("can append labels coming from Application to IntegrationPipelineRun and making sure that label values matches application", func() {


### PR DESCRIPTION
* Copy custom.appstudio.openshift.io prefixed labels and annotations from build pipelineRuns to Snapshots
* Copy all labels and annotations prefixed with test.appstudio.openshift.io/ and custom.appstudio.openshift.io/ from the Snapshot to integration pipelineRuns

Example labels in a build pipelineRun (reduced for readability):
![image](https://github.com/konflux-ci/integration-service/assets/34320458/e05a4155-9d25-4d14-9d2d-e5a9d47aa3a4)

Example Snapshot's labels created for that build pipelineRun:
![image](https://github.com/konflux-ci/integration-service/assets/34320458/8b2c7655-9cc1-489c-a402-07001031bbf2)

Example of the copied labels in the integration pipelineRun:
![image](https://github.com/konflux-ci/integration-service/assets/34320458/28956ae1-7c81-41c4-8053-02dc9c4e31ea)


## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
