### PR TITLE
fix(STONEINTG-863): removed bugged snapshot concurrent requests metric

### DIFF
--- a/config/grafana/dashboards/integration-service-dashboard.json
+++ b/config/grafana/dashboards/integration-service-dashboard.json
@@ -436,7 +436,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 9
+        "y": 17
       },
       "type": "graph",
       "title": "#5 Latency of Release Creation",
@@ -541,7 +541,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 9
+        "y": 17
       },
       "type": "timeseries",
       "title": "[Violations] #5 Latency of Release Creation",
@@ -633,7 +633,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 25
       },
       "id": 16,
       "panels": [],
@@ -687,10 +687,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 9,
+        "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 26
       },
       "id": 2,
       "options": {
@@ -736,7 +736,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 26
       },
       "hiddenSeries": false,
       "id": 4,
@@ -838,7 +838,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 34
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -887,101 +887,6 @@
       "yBucketSize": null
     },
     {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "description": "Total number of concurrent snapshot attempts",
-      "fieldConfig": {
-        "defaults": {},
-        "overrides": []
-      },
-      "fill": 1,
-      "fillGradient": 0,
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 34
-      },
-      "hiddenSeries": false,
-      "id": 12,
-      "legend": {
-        "avg": false,
-        "current": false,
-        "max": false,
-        "min": false,
-        "show": true,
-        "total": false,
-        "values": false
-      },
-      "lines": true,
-      "linewidth": 1,
-      "nullPointMode": "null",
-      "options": {
-        "alertThreshold": true
-      },
-      "percentage": false,
-      "pluginVersion": "7.5.17",
-      "pointradius": 2,
-      "points": false,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "exemplar": true,
-          "expr": "integration_svc_snapshot_attempt_concurrent_requests",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "{{ pod }}",
-          "refId": "A"
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeRegions": [],
-      "timeShift": null,
-      "title": "Snapshot Attempt Concurrent Requests",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
       "cards": {
         "cardPadding": null,
         "cardRound": null
@@ -1003,7 +908,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 42
+        "y": 34
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1072,8 +977,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 50
+        "x": 0,
+        "y": 42
       },
       "heatmap": {},
       "hideZeroBuckets": true,
@@ -1126,7 +1031,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 26
+        "y": 42
       },
       "type": "graph",
       "title": "Work Queue Depth",
@@ -1227,8 +1132,8 @@
       "gridPos": {
         "h": 8,
         "w": 12,
-        "x": 12,
-        "y": 26
+        "x": 0,
+        "y": 50
       },
       "type": "graph",
       "title": "Work Queue Duration Seconds",
@@ -1332,7 +1237,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 66
+        "y": 50
       },
       "type": "heatmap",
       "title": "Latency of Release Creation in Seconds",

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -28,7 +28,6 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
-	"github.com/konflux-ci/integration-service/pkg/metrics"
 	"github.com/konflux-ci/integration-service/tekton"
 	"github.com/konflux-ci/operator-toolkit/controller"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
@@ -120,7 +119,6 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 		result, err = a.handleSnapshotCreationFailure(&canRemoveFinalizer, err)
 		return result, err
 	}
-	go metrics.RegisterNewSnapshot()
 
 	a.logger.LogAuditEvent("Created new Snapshot", expectedSnapshot, h.LogActionAdd,
 		"snapshot.Name", expectedSnapshot.Name,

--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -24,7 +24,6 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
-	"github.com/konflux-ci/integration-service/pkg/metrics"
 	"github.com/konflux-ci/operator-toolkit/controller"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -148,7 +147,6 @@ func (a *Adapter) createUpdatedSnapshot(snapshotComponents *[]applicationapiv1al
 		return nil, err
 	}
 
-	go metrics.RegisterNewSnapshot()
 	return snapshot, nil
 }
 

--- a/pkg/metrics/integration.go
+++ b/pkg/metrics/integration.go
@@ -59,13 +59,6 @@ var (
 		},
 	)
 
-	SnapshotConcurrentTotal = prometheus.NewGauge(
-		prometheus.GaugeOpts{
-			Name: "integration_svc_snapshot_attempt_concurrent_requests",
-			Help: "Total number of concurrent snapshot attempts",
-		},
-	)
-
 	SnapshotDurationSeconds = prometheus.NewHistogramVec(
 		prometheus.HistogramOpts{
 			Name:    "integration_svc_snapshot_attempt_duration_seconds",
@@ -108,13 +101,11 @@ func RegisterCompletedSnapshot(conditiontype, reason string, startTime metav1.Ti
 		"reason": reason,
 	}
 
-	SnapshotConcurrentTotal.Sub(1)
 	SnapshotDurationSeconds.With(labels).Observe(completionTime.Sub(startTime.Time).Seconds())
 	SnapshotTotal.With(labels).Inc()
 }
 
 func RegisterInvalidSnapshot(conditiontype, reason string) {
-	SnapshotConcurrentTotal.Dec()
 	SnapshotTotal.With(prometheus.Labels{
 		"type":   conditiontype,
 		"reason": reason,
@@ -128,10 +119,6 @@ func RegisterPipelineRunStarted(snapshotCreatedTime metav1.Time, pipelineRunStar
 
 func RegisterIntegrationResponse(duration time.Duration) {
 	IntegrationSvcResponseSeconds.Observe(duration.Seconds())
-}
-
-func RegisterNewSnapshot() {
-	SnapshotConcurrentTotal.Inc()
 }
 
 func RegisterNewIntegrationPipelineRun() {
@@ -149,7 +136,6 @@ func (m *IntegrationMetrics) InitMetrics(registerer prometheus.Registerer) error
 		SnapshotCreatedToPipelineRunStartedSeconds,
 		IntegrationSvcResponseSeconds,
 		IntegrationPipelineRunTotal,
-		SnapshotConcurrentTotal,
 		SnapshotDurationSeconds,
 		SnapshotTotal,
 		ReleaseLatencySeconds,


### PR DESCRIPTION
* removed the snapshot concurrent attempts metric and references within adapters and updated test file accordingly.
* adjusted panel positions and fixed inconsistent height and x/y positioning.

One test has had to be changed as it couldn't be entirely removed wholesale without breaking tests and I'm not sure why.
(see It("registers the pipeline run start time'.", func())

Note: This drops code coverage in tests by 2% but this is expected

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
