### PR TITLE
fix(stoneintg-924): intermittent unittest failure missing application…

### DIFF
--- a/internal/controller/snapshot/snapshot_controller_test.go
+++ b/internal/controller/snapshot/snapshot_controller_test.go
@@ -198,6 +198,15 @@ var _ = Describe("SnapshotController", func() {
 		hasSnapshot.Spec.Application = string("im-a-ghost")
 		Expect(k8sClient.Update(ctx, hasSnapshot)).Should(Succeed())
 
+		// Use Eventually to ensure the update has been applied
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: hasSnapshot.Namespace,
+				Name:      hasSnapshot.Name,
+			}, hasSnapshot)
+			return err == nil && hasSnapshot.Spec.Application == "im-a-ghost"
+		}, time.Second*20, time.Second*2).Should(BeTrue())
+
 		result, err := snapshotReconciler.Reconcile(ctx, req)
 		Expect(result).To(Equal(ctrl.Result{}))
 		Expect(err).To(BeNil())


### PR DESCRIPTION
… index

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
