### PR TITLE
chore: remove BASE_IMAGES_DIGESTS from konflux pipelines

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -241,8 +241,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -268,8 +266,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST

--- a/.tekton/integration-service-push.yaml
+++ b/.tekton/integration-service-push.yaml
@@ -238,8 +238,6 @@ spec:
       params:
       - name: BINARY_IMAGE
         value: $(params.output-image)
-      - name: BASE_IMAGES
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       runAfter:
       - build-container
       taskRef:
@@ -265,8 +263,6 @@ spec:
         workspace: workspace
     - name: deprecated-base-image-check
       params:
-      - name: BASE_IMAGES_DIGESTS
-        value: $(tasks.build-container.results.BASE_IMAGES_DIGESTS)
       - name: IMAGE_URL
         value: $(tasks.build-container.results.IMAGE_URL)
       - name: IMAGE_DIGEST


### PR DESCRIPTION
* Migration to the 0.2 version of the buildah task requires removing the BASE_IMAGES_DIGESTS result since it will stop being emitted
* See [migration](https://togithub.com/redhat-appstudio/build-definitions/blob/main/task/buildah/0.2/MIGRATION.md) instructions for more details

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
