### PR TITLE
chore(STONEINTG-888): added CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+* @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @dheerajodha @14rcole @jencull @chipspeak
+

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,46 +12,15 @@ updates:
     commit-message:
       # Prefix all commit messages with "chore(Dockerfile): "
       prefix: "chore(Dockerfile): "
-    # Add reviewers
-    reviewers:
-      - "dirgim"
-      - "hongweiliu17"
-      - "jsztuka"
-      - "Josh-Everett"
-      - "kasemAlem"
-      - "sonam1412"
-      - "dheerajodha"
-      - "14rcole"
-      - "chipspeak"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     commit-message:
       prefix: "chore(actions): "
-    reviewers:
-      - "dirgim"
-      - "hongweiliu17"
-      - "jsztuka"
-      - "Josh-Everett"
-      - "kasemAlem"
-      - "sonam1412"
-      - "dheerajodha"
-      - "14rcole"
-      - "chipspeak"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
       interval: daily
     commit-message:
       prefix: "chore(go): "
-    reviewers:
-      - "dirgim"
-      - "hongweiliu17"
-      - "jsztuka"
-      - "Josh-Everett"
-      - "kasemAlem"
-      - "sonam1412"
-      - "dheerajodha"
-      - "14rcole"
-      - "chipspeak"


### PR DESCRIPTION

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
