### PR TITLE
feat(STONEINTG-997): save build PLR info to build PLR and snapshot metadata

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -12,6 +12,7 @@ flowchart TD
   %% Node definitions
 predicate((PREDICATE: <br> Filter events related to <br> PipelineRuns))
 new_pipeline_run{Pipeline created?}
+new_pipeline_run_without_prgroup{PR group is added to pipelineRun metadata?}
 get_pipeline_run{Pipeline updated?}
 failed_pipeline_run{Pipeline failed?}
 finalizer_exists{Does the finalizer already exist?}
@@ -24,15 +25,20 @@ add_finalizer(Add finalizer to build PLR)
 remove_finalizer(Remove finalizer from build PLR)
 error[Return error]
 continue[Continue processing]
+update_metadata(add PR group info to build pipelineRun metadata)
 
 %% Node connections
 predicate                        --> get_pipeline_run
 predicate                       -->  new_pipeline_run
+predicate                       -->  new_pipeline_run_without_prgroup
 predicate                       -->  failed_pipeline_run
 new_pipeline_run           --Yes-->  finalizer_exists
 finalizer_exists           --No-->   add_finalizer
 add_finalizer                    --> continue
 failed_pipeline_run        --Yes --> remove_finalizer
+new_pipeline_run_without_prgroup --No  --> update_metadata
+new_pipeline_run_without_prgroup --Yes  --> continue
+update_metadata                    --> continue
 get_pipeline_run           --Yes --> retrieve_associated_entity
 get_pipeline_run           --No  --> error
 retrieve_associated_entity --No  --> error

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -76,6 +76,15 @@ const (
 	// SnapshotStatusReportAnnotation contains metadata of tests related to status reporting to git provider
 	SnapshotStatusReportAnnotation = "test.appstudio.openshift.io/git-reporter-status"
 
+	// PRGroupAnnotation contains the pr group name
+	PRGroupAnnotation = "test.appstudio.openshift.io/pr-group"
+
+	// PRGroupHashLabel contains the pr group name in sha format
+	PRGroupHashLabel = "test.appstudio.openshift.io/pr-group-sha"
+
+	// BuildPipelineRunStartTime contains the start time of build pipelineRun
+	BuildPipelineRunStartTime = "test.appstudio.openshift.io/pipelinerunstarttime"
+
 	// BuildPipelineRunPrefix contains the build pipeline run related labels and annotations
 	BuildPipelineRunPrefix = "build.appstudio"
 

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -117,6 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsurePipelineIsFinalized,
+		adapter.EnsurePRGroupAnnotated,
 		adapter.EnsureSnapshotExists,
 	})
 }
@@ -124,6 +125,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
+	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureSnapshotExists() (controller.OperationResult, error)
 }
 

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tekton_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"knative.dev/pkg/apis"
+	v1 "knative.dev/pkg/apis/duck/v1"
+	"time"
+
+	tekton "github.com/konflux-ci/integration-service/tekton"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("build pipeline", func() {
+
+	var (
+		buildPipelineRun *tektonv1.PipelineRun
+	)
+
+	BeforeEach(func() {
+		buildPipelineRun = &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipelinerun-build-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pipelines.appstudio.openshift.io/type":    "build",
+					"pipelines.openshift.io/used-by":           "build-cloud",
+					"pipelines.openshift.io/runtime":           "nodejs",
+					"pipelines.openshift.io/strategy":          "s2i",
+					"appstudio.openshift.io/component":         "component-sample",
+					"build.appstudio.redhat.com/target_branch": "main",
+					"pipelinesascode.tekton.dev/event-type":    "pull_request",
+				},
+				Annotations: map[string]string{
+					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					"pipelinesascode.tekton.dev/on-target-branch":   "[main,master]",
+					"build.appstudio.openshift.io/repo":             "https://github.com/devfile-samples/devfile-sample-go-basic?rev=c713067b0e65fb3de50d1f7c457eb51c2ab0dbb0",
+					"foo":                                           "bar",
+					"chains.tekton.dev/signed":                      "true",
+					"pipelinesascode.tekton.dev/source-branch":      "sourceBranch",
+					"pipelinesascode.tekton.dev/url-org":            "redhat",
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{
+				PipelineRef: &tektonv1.PipelineRef{
+					Name: "build-pipeline-pass",
+					ResolverRef: tektonv1.ResolverRef{
+						Resolver: "bundle",
+						Params: tektonv1.Params{
+							{Name: "bundle",
+								Value: tektonv1.ParamValue{Type: "string", StringVal: "quay.io/redhat-appstudio/example-tekton-bundle:test"},
+							},
+							{Name: "name",
+								Value: tektonv1.ParamValue{Type: "string", StringVal: "test-task"},
+							},
+						},
+					},
+				},
+				Params: []tektonv1.Param{
+					{
+						Name: "output-image",
+						Value: tektonv1.ParamValue{
+							Type:      tektonv1.ParamTypeString,
+							StringVal: "quay.io/redhat-appstudio/example-tekton-bundle:test",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, buildPipelineRun)).Should(Succeed())
+
+		buildPipelineRun.Status = tektonv1.PipelineRunStatus{
+			PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+				StartTime: &metav1.Time{Time: time.Now()},
+			},
+			Status: v1.Status{
+				Conditions: v1.Conditions{
+					apis.Condition{
+						Reason: "Completed",
+						Status: "True",
+						Type:   apis.ConditionSucceeded,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, buildPipelineRun)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+	})
+
+	Context("When a build pipelineRun exists", func() {
+		It("can get PR group from build pipelineRun", func() {
+			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
+			Expect(prGroup).To(Equal("sourceBranch"))
+			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
+		})
+
+		It("can get PR group from build pipelineRun is source branch is main", func() {
+			buildPipelineRun.Annotations[tekton.PipelineAsCodeSourceBranchAnnotation] = "main"
+			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
+			Expect(prGroup).To(Equal("main-redhat"))
+			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
+		})
+
+		It("can get PR group from build pipelineRun is source branch has @ charactor", func() {
+			buildPipelineRun.Annotations[tekton.PipelineAsCodeSourceBranchAnnotation] = "myfeature@change1"
+			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
+			Expect(prGroup).To(Equal("myfeature"))
+			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
1. Add EnsurePRGroupAnnotated() to build pipelineRun adapter and save build source branch info to build PLR metadata as below
      * save pr group to annotation test.appstudio.openshift.io/pr-group
      * save pr group in hash format to label test.appstudio.openshift.io/pr-group-sha
    
2.Save build PLR start time to snapshot annotation test.appstudio.openshift.io/pipelinerunstarttime

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
