### PR TITLE
feat(STONEINTG-997): annotate pr group for pr PLR only

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -154,6 +154,11 @@ func (a *Adapter) EnsurePipelineIsFinalized() (controller.OperationResult, error
 // is added to build pipelineRun metadata label and annotation once it is created,
 // then these label and annotation will be copied to component snapshot when it is created
 func (a *Adapter) EnsurePRGroupAnnotated() (controller.OperationResult, error) {
+	if tekton.IsPLRCreatedByPACPushEvent(a.pipelineRun) {
+		a.logger.Info("build pipelineRun is not created by pull/merge request, no need to annotate")
+		return controller.ContinueProcessing()
+	}
+
 	if metadata.HasLabel(a.pipelineRun, gitops.PRGroupHashLabel) && metadata.HasAnnotation(a.pipelineRun, gitops.PRGroupAnnotation) {
 		a.logger.Info("build pipelineRun has had pr group info in metadata, no need to update")
 		return controller.ContinueProcessing()

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -1040,14 +1040,15 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				Expect(result.CancelRequest).To(BeFalse())
 				Expect(result.RequeueRequest).To(BeFalse())
 
-				err = adapter.client.Get(adapter.context, types.NamespacedName{
-					Namespace: buildPipelineRun.Namespace,
-					Name:      buildPipelineRun.Name,
-				}, existingBuildPLR)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(metadata.HasAnnotation(existingBuildPLR, gitops.PRGroupAnnotation)).To(BeTrue())
+				Eventually(func() bool {
+					_ = adapter.client.Get(adapter.context, types.NamespacedName{
+						Namespace: buildPipelineRun.Namespace,
+						Name:      buildPipelineRun.Name,
+					}, existingBuildPLR)
+					return metadata.HasAnnotation(existingBuildPLR, gitops.PRGroupAnnotation) && metadata.HasLabel(existingBuildPLR, gitops.PRGroupHashLabel)
+				}, time.Second*10).Should(BeTrue())
+
 				Expect(existingBuildPLR.Annotations).Should(HaveKeyWithValue(Equal(gitops.PRGroupAnnotation), Equal("sourceBranch")))
-				Expect(metadata.HasLabel(existingBuildPLR, gitops.PRGroupHashLabel)).To(BeTrue())
 				Expect(existingBuildPLR.Labels[gitops.PRGroupHashLabel]).NotTo(BeNil())
 			})
 		})

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -41,6 +41,15 @@ const (
 
 	// PipelineAsCodeSourceRepoOrg is the repo org build PLR is triggered by
 	PipelineAsCodeSourceRepoOrg = "pipelinesascode.tekton.dev/url-org"
+
+	// PipelineAsCodeEventTypeLabel is the type of event which triggered the pipelinerun in build service
+	PipelineAsCodeEventTypeLabel = "pipelinesascode.tekton.dev/event-type"
+
+	// PipelineAsCodePushType is the type of push event which triggered the pipelinerun in build service
+	PipelineAsCodePushType = "push"
+
+	// PipelineAsCodeGLPushType is the type of gitlab push event which triggered the pipelinerun in build service
+	PipelineAsCodeGLPushType = "Push"
 )
 
 // AnnotateBuildPipelineRun sets annotation for a build pipelineRun in defined context and returns that pipeline
@@ -113,4 +122,11 @@ func GetPRGroupNameFromBuildPLR(pipelineRun *tektonv1.PipelineRun) string {
 func GenerateSHA(str string) string {
 	hash := sha256.Sum256([]byte(str))
 	return fmt.Sprintf("%x", hash)[0:62]
+}
+
+// IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
+func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
+	return metadata.HasLabelWithValue(plr, PipelineAsCodeEventTypeLabel, PipelineAsCodePushType) ||
+		metadata.HasLabelWithValue(plr, PipelineAsCodeEventTypeLabel, PipelineAsCodeGLPushType) ||
+		!metadata.HasLabel(plr, PipelineAsCodeEventTypeLabel)
 }

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -111,6 +111,7 @@ var _ = Describe("build pipeline", func() {
 
 	Context("When a build pipelineRun exists", func() {
 		It("can get PR group from build pipelineRun", func() {
+			Expect(tekton.IsPLRCreatedByPACPushEvent(buildPipelineRun)).To(BeFalse())
 			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
 			Expect(prGroup).To(Equal("sourceBranch"))
 			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())


### PR DESCRIPTION
* annotate/label pr group info for pr PLR only

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
