### PR TITLE
fix(stoneintg-971): reconciliation invalid image digest err

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -111,8 +111,7 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 
 	expectedSnapshot, err := a.prepareSnapshotForPipelineRun(a.pipelineRun, a.component, a.application)
 	if err != nil {
-		result, err = a.updatePipelineRunWithCustomizedError(&canRemoveFinalizer, err, a.context, a.pipelineRun, a.client, a.logger)
-		return controller.RequeueWithError(err)
+		return a.updatePipelineRunWithCustomizedError(&canRemoveFinalizer, err, a.context, a.pipelineRun, a.client, a.logger)
 	}
 
 	err = a.client.Create(a.context, expectedSnapshot)
@@ -361,7 +360,7 @@ func (a *Adapter) updatePipelineRunWithCustomizedError(canRemoveFinalizer *bool,
 		}
 		logger.Error(cerr, "Build PipelineRun failed with error, should be fixed and re-run manually", "pipelineRun.Name", pipelineRun.Name)
 		*canRemoveFinalizer = true
-		return controller.ContinueProcessing()
+		return controller.StopProcessing()
 	}
 	return controller.RequeueOnErrorOrContinue(cerr)
 

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -662,7 +662,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(helpers.IsInvalidImageDigestError(err)).To(BeTrue())
 			Eventually(func() bool {
 				result, err := adapter.EnsureSnapshotExists()
-				return !result.CancelRequest && err == nil
+				return result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
 			Expect(adapter.pipelineRun.GetAnnotations()[helpers.CreateSnapshotAnnotationName]).ToNot(BeNil())
 			var info map[string]string
@@ -1005,7 +1005,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 
 				Eventually(func() bool {
 					result, err := adapter.EnsureSnapshotExists()
-					return !result.CancelRequest && err == nil
+					return result.CancelRequest && err == nil
 				}, time.Second*10).Should(BeTrue())
 				// Ensure the PLR on the control plane does not have finalizer
 				Eventually(func() bool {


### PR DESCRIPTION
stop reconciliation when creating snapshot meets invalid image digest error

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
