### PR TITLE
fix(STONEINTG-980): consider target branch when overwriting ITS

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -127,6 +127,9 @@ const (
 	// PipelineAsCodeRepoURLAnnotation is the URL to the git repository which triggered the pipelinerun in build service.
 	PipelineAsCodeRepoURLAnnotation = PipelinesAsCodePrefix + "/repo-url"
 
+	// PipelineAsCodeTargetBranchAnnotation is the SHA of the git revision which triggered the pipelinerun in build service.
+	PipelineAsCodeTargetBranchAnnotation = PipelinesAsCodePrefix + "/branch"
+
 	// PipelineAsCodeInstallationIDAnnotation is the GitHub App installation ID for the git repo which triggered the pipelinerun in build service.
 	PipelineAsCodeInstallationIDAnnotation = PipelinesAsCodePrefix + "/installation-id"
 
@@ -734,7 +737,7 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, applicati
 	}
 	snapshot := NewSnapshot(application, &snapshotComponents)
 
-	// expose the source repo URL in the snapshot as annotation do we don't have to do lookup in integration tests
+	// expose the source repo URL and SHA in the snapshot as annotation do we don't have to do lookup in integration tests
 	if newComponentSource.GitSource != nil {
 		if err := metadata.SetAnnotation(snapshot, SnapshotGitSourceRepoURLAnnotation, newComponentSource.GitSource.URL); err != nil {
 			return nil, fmt.Errorf("failed to set annotation %s: %w", SnapshotGitSourceRepoURLAnnotation, err)

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -600,6 +600,13 @@ func shouldUpdateIntegrationTestGitResolver(integrationTestScenario *v1beta2.Int
 	annotations := snapshot.GetAnnotations()
 	params := resolverParamsToMap(testResolverRef.Params)
 
+	// if target revision sha differs from source revision sha we do not want to overwrite it
+	targetRevision := annotations[gitops.PipelineAsCodeTargetBranchAnnotation]
+	sourceRevision := params[tekton.TektonResolverGitParamRevision]
+	if targetRevision != sourceRevision {
+		return false
+	}
+
 	if urlVal, ok := params[tekton.TektonResolverGitParamURL]; ok {
 		// urlVal may or may not have git suffix specified :')
 		return urlToGitUrl(urlVal) == urlToGitUrl(annotations[gitops.PipelineAsCodeRepoURLAnnotation])


### PR DESCRIPTION
Integration Service was overwriting the revision sha of the integration test scenarios targeting a specific sha with the sha of the source branch. In situations where the source branch sha differs from the ITS within the PR, the sha from the target branch will be used to create the PLR.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
