### PR TITLE
feat(STONEINTG-998): support group snapshot

### DIFF
--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -114,6 +114,34 @@ flowchart TD
   mark_snapshot_invalid           -->      continue_processing4
 
 
+  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGroupSnapshotExist() function
+
+  %% Node definitions
+  ensure5(Process further if: Snapshot has <b>neither</b> push event type label <br><b>nor</b> PRGroupCreation annotation)
+  validate_build_pipelinerun{Did all gotten build pipelineRun <br>under the same group <br>succeed <b>and</b> <br>component snapshot are already created?}
+  annotate_component_snapshot(<b>Annotate</b> component snapshot)
+  get_component_snapshots_and_sort(<b>Iterate</b> all application components and <br><b>get<b/> all component snapshots <br>for each component under the same pr group sha <br>then <b>sort</b> snapshots)
+  can_find_snapshotComponent_from_latest_snapshot(<b>Can</b> find the latest snapshot with open pull/merge request?)
+  add_snapshot_to_group_snapshot_candidate(<b>Add</b> snapshotComponent of component <br>to group snapshot components candidate)
+  get_snapshotComponent_from_gcl(<b>Get</b> snapshotComponent from <br>Global Candidate List)
+  create_group_snapshot(<b>Create</b> group snapshot for snasphotComponents)
+  annotate_component_snapshots_under_prgroupsha(<b>Annotate<b> component snapshots which <b>have</b> <br>snapshotComponent added to group snapshot)
+  continue_processing5(Controller continues processing...)
+
+  %% Node connections
+  predicate                              ---->    |"EnsureGroupSnapshotExist()"|ensure5
+  ensure5                                -->      validate_build_pipelinerun
+  validate_build_pipelinerun             --Yes--> get_component_snapshots_and_sort
+  validate_build_pipelinerun             --No-->  annotate_component_snapshot
+  get_component_snapshots_and_sort       -->      can_find_snapshotComponent_from_latest_snapshot
+  can_find_snapshotComponent_from_latest_snapshot  --Yes--> add_snapshot_group_snapshot_candidate
+  can_find_snapshotComponent_from_latest_snapshot  --No-->  get_snapshotComponent_from_gcl
+  add_snapshot_to_group_snapshot_candidate   -->        create_group_snapshot
+  get_snapshotComponent_from_gcl             -->        create_group_snapshot
+  create_group_snapshot                   -->        annotate_component_snapshots_under_prgroupsha
+  annotate_component_snapshots_under_prgroupsha -->  continue_processing5
+  annotate_component_snapshot                   -->  continue_processing5
+
   %% Assigning styles to nodes
   class predicate Amber;
   class encountered_error1,encountered_error31,encountered_error32,encountered_error5 Red;

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 
+	"strconv"
 	"time"
 
 	"github.com/konflux-ci/integration-service/gitops"
@@ -39,19 +40,26 @@ import (
 var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	var (
-		hasApp      *applicationapiv1alpha1.Application
-		hasComp     *applicationapiv1alpha1.Component
-		hasSnapshot *applicationapiv1alpha1.Snapshot
-		sampleImage string
+		hasApp          *applicationapiv1alpha1.Application
+		hasComp         *applicationapiv1alpha1.Component
+		hasSnapshot     *applicationapiv1alpha1.Snapshot
+		hasComSnapshot1 *applicationapiv1alpha1.Snapshot
+		hasComSnapshot2 *applicationapiv1alpha1.Snapshot
+		hasComSnapshot3 *applicationapiv1alpha1.Snapshot
+		sampleImage     string
 	)
 
 	const (
-		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		namespace       = "default"
-		applicationName = "application-sample"
-		componentName   = "component-sample"
-		snapshotName    = "snapshot-sample"
-		SampleCommit    = "a2ba645d50e471d5f084b"
+		SampleRepoLink      = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		namespace           = "default"
+		applicationName     = "application-sample"
+		componentName       = "component-sample"
+		snapshotName        = "snapshot-sample"
+		hasComSnapshot1Name = "hascomsnapshot1-sample"
+		hasComSnapshot2Name = "hascomsnapshot2-sample"
+		hasComSnapshot3Name = "hascomsnapshot3-sample"
+		SampleCommit        = "a2ba645d50e471d5f084b"
+		plrstarttime        = 1775992257
 	)
 	BeforeAll(func() {
 		hasApp = &applicationapiv1alpha1.Application{
@@ -123,12 +131,132 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			}, hasSnapshot)
 			return err
 		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		hasComSnapshot1 = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hasComSnapshot1Name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:       hasComSnapshot1Name,
+					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+				},
+				Annotations: map[string]string{
+					"test.appstudio.openshift.io/pr-last-update": "2023-08-26T17:57:50+02:00",
+					gitops.BuildPipelineRunStartTime:             strconv.Itoa(plrstarttime),
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component1",
+						ContainerImage: "test-image",
+					},
+					{
+						Name:           componentName,
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComSnapshot1)).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      hasComSnapshot1.Name,
+				Namespace: namespace,
+			}, hasComSnapshot1)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		hasComSnapshot2 = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hasComSnapshot2Name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:       hasComSnapshot2Name,
+					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+				},
+				Annotations: map[string]string{
+					"test.appstudio.openshift.io/pr-last-update": "2023-08-26T17:57:50+02:00",
+					gitops.BuildPipelineRunStartTime:             strconv.Itoa(plrstarttime + 100),
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component1",
+						ContainerImage: "test-image",
+					},
+					{
+						Name:           componentName,
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComSnapshot2)).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      hasComSnapshot2.Name,
+				Namespace: namespace,
+			}, hasComSnapshot2)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		hasComSnapshot3 = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hasComSnapshot3Name,
+				Namespace: namespace,
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:       hasComSnapshot3Name,
+					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+				},
+				Annotations: map[string]string{
+					"test.appstudio.openshift.io/pr-last-update": "2023-08-26T17:57:50+02:00",
+					gitops.BuildPipelineRunStartTime:             strconv.Itoa(plrstarttime + 200),
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component1",
+						ContainerImage: "test-image",
+					},
+					{
+						Name:           componentName,
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComSnapshot3)).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      hasComSnapshot3.Name,
+				Namespace: namespace,
+			}, hasComSnapshot3)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
 	})
 
 	AfterEach(func() {
 		err := k8sClient.Delete(ctx, hasComp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComSnapshot1)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComSnapshot2)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComSnapshot3)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -712,4 +840,71 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		})
 	})
 
+	Context("Group snapshot creation tests", func() {
+		When("Snapshot has snapshot type label", func() {
+			prGroup := "feature1"
+			prGroupSha := "feature1hash"
+			BeforeEach(func() {
+				hasComSnapshot1.Labels[gitops.PRGroupHashLabel] = prGroupSha
+				hasComSnapshot1.Annotations[gitops.PRGroupAnnotation] = prGroup
+				hasComSnapshot1.Annotations[gitops.PRGroupCreationAnnotation] = "group snapshot is created"
+			})
+
+			It("make sure pr group annotation/label can be found in group", func() {
+				Expect(gitops.GetPRGroupFromSnapshot(hasComSnapshot1)).To(Equal(prGroup))
+				Expect(gitops.GetPRGroupHashFromSnapshot(hasComSnapshot1)).To(Equal(prGroupSha))
+				Expect(gitops.HasPRGroupProcessed(hasComSnapshot1)).To(BeTrue())
+			})
+
+			It("Can find the correct snapshotComponent for the given component name", func() {
+				FoundSnapshotComponent := gitops.FindMatchingSnapshotComponent(hasComSnapshot1, hasComp)
+				Expect(FoundSnapshotComponent.Name).To(Equal(hasComp.Name))
+			})
+
+			It("Can sort the snapshots according to annotation test.appstudio.openshift.io/pipelinerunstarttime", func() {
+				snapshots := []applicationapiv1alpha1.Snapshot{*hasComSnapshot1, *hasComSnapshot2, *hasComSnapshot3}
+				sortedSnapshots := gitops.SortSnapshots(snapshots)
+				Expect(sortedSnapshots[0].Name).To(Equal(hasComSnapshot3.Name))
+				snapshots = []applicationapiv1alpha1.Snapshot{*hasComSnapshot2, *hasComSnapshot1, *hasComSnapshot3}
+				sortedSnapshots = gitops.SortSnapshots(snapshots)
+				Expect(sortedSnapshots[0].Name).To(Equal(hasComSnapshot3.Name))
+			})
+
+			It("Can notify all component snapshots group snapshot creation status", func() {
+				Expect(metadata.HasAnnotation(hasComSnapshot2, gitops.PRGroupCreationAnnotation)).To(BeFalse())
+				Expect(metadata.HasAnnotation(hasComSnapshot3, gitops.PRGroupCreationAnnotation)).To(BeFalse())
+				componentSnapshotInfos := []gitops.ComponentSnapshotInfo{
+					{
+						Namespace:        "default",
+						Component:        hasComSnapshot2Name,
+						BuildPipelineRun: "plr2",
+						Snapshot:         hasComSnapshot2.Name,
+					},
+					{
+						Namespace:        "default",
+						Component:        hasComSnapshot1Name,
+						BuildPipelineRun: "plr3",
+						Snapshot:         hasComSnapshot3.Name,
+					},
+				}
+				err := gitops.NotifyComponentSnapshotsInGroupSnapshot(ctx, k8sClient, componentSnapshotInfos, "group snapshot created")
+
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, types.NamespacedName{
+						Name:      hasComSnapshot2.Name,
+						Namespace: namespace,
+					}, hasComSnapshot2)
+					return metadata.HasAnnotationWithValue(hasComSnapshot2, gitops.PRGroupCreationAnnotation, "group snapshot created")
+				}, time.Second*10).Should(BeTrue())
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, types.NamespacedName{
+						Name:      hasComSnapshot3.Name,
+						Namespace: namespace,
+					}, hasComSnapshot3)
+					return metadata.HasAnnotationWithValue(hasComSnapshot3, gitops.PRGroupCreationAnnotation, "group snapshot created")
+				}, time.Second*10).Should(BeTrue())
+				Expect(err).ShouldNot(HaveOccurred())
+			})
+		})
+	})
 })

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -369,9 +369,9 @@ func (a *Adapter) updatePipelineRunWithCustomizedError(canRemoveFinalizer *bool,
 // addPRGroupToBuildPLRMetadata will add pr-group info gotten from souce-branch to annotation
 // and also the string in sha format to metadata label
 func (a *Adapter) addPRGroupToBuildPLRMetadata(pipelineRun *tektonv1.PipelineRun) error {
-	prGroupName := tekton.GetPRGroupNameFromBuildPLR(pipelineRun)
-	if prGroupName != "" {
-		prGroupHashName := tekton.GenerateSHA(prGroupName)
+	prGroup := tekton.GetPRGroupFromBuildPLR(pipelineRun)
+	if prGroup != "" {
+		prGroupHash := tekton.GenerateSHA(prGroup)
 
 		return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 			var err error
@@ -382,8 +382,8 @@ func (a *Adapter) addPRGroupToBuildPLRMetadata(pipelineRun *tektonv1.PipelineRun
 
 			patch := client.MergeFrom(pipelineRun.DeepCopy())
 
-			_ = metadata.SetAnnotation(&pipelineRun.ObjectMeta, gitops.PRGroupAnnotation, prGroupName)
-			_ = metadata.SetLabel(&pipelineRun.ObjectMeta, gitops.PRGroupHashLabel, prGroupHashName)
+			_ = metadata.SetAnnotation(&pipelineRun.ObjectMeta, gitops.PRGroupAnnotation, prGroup)
+			_ = metadata.SetLabel(&pipelineRun.ObjectMeta, gitops.PRGroupHashLabel, prGroupHash)
 
 			return a.client.Patch(a.context, pipelineRun, patch)
 		})

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -21,9 +21,11 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"time"
 
 	"github.com/tonglil/buflogr"
+	"go.uber.org/mock/gomock"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -32,12 +34,16 @@ import (
 
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/integration-service/status"
 	"github.com/konflux-ci/integration-service/tekton"
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
+	"github.com/konflux-ci/operator-toolkit/metadata"
 	releasev1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	releasemetadata "github.com/konflux-ci/release-service/metadata"
 	applicationapiv1alpha1 "github.com/redhat-appstudio/application-api/api/v1alpha1"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"knative.dev/pkg/apis"
+	v1 "knative.dev/pkg/apis/duck/v1"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -60,22 +66,34 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		hasApp                                    *applicationapiv1alpha1.Application
 		hasComp                                   *applicationapiv1alpha1.Component
 		hasCompMissingImageDigest                 *applicationapiv1alpha1.Component
+		hasCom1                                   *applicationapiv1alpha1.Component
+		hasCom3                                   *applicationapiv1alpha1.Component
 		hasSnapshot                               *applicationapiv1alpha1.Snapshot
 		hasSnapshotPR                             *applicationapiv1alpha1.Snapshot
 		hasOverRideSnapshot                       *applicationapiv1alpha1.Snapshot
 		hasInvalidSnapshot                        *applicationapiv1alpha1.Snapshot
 		hasInvalidOverrideSnapshot                *applicationapiv1alpha1.Snapshot
+		hasComSnapshot1                           *applicationapiv1alpha1.Snapshot
+		hasComSnapshot2                           *applicationapiv1alpha1.Snapshot
+		hasComSnapshot3                           *applicationapiv1alpha1.Snapshot
 		integrationTestScenario                   *v1beta2.IntegrationTestScenario
 		integrationTestScenarioForInvalidSnapshot *v1beta2.IntegrationTestScenario
 		env                                       *applicationapiv1alpha1.Environment
+		buildPipelineRun1                         *tektonv1.PipelineRun
 	)
 	const (
-		SampleRepoLink  = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		sample_image    = "quay.io/redhat-appstudio/sample-image"
-		sample_revision = "random-value"
-		sampleDigest    = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-		customLabel     = "custom.appstudio.openshift.io/custom-label"
-		sourceRepoRef   = "db2c043b72b3f8d292ee0e38768d0a94859a308b"
+		SampleRepoLink      = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		sample_image        = "quay.io/redhat-appstudio/sample-image"
+		sample_revision     = "random-value"
+		sampleDigest        = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		customLabel         = "custom.appstudio.openshift.io/custom-label"
+		sourceRepoRef       = "db2c043b72b3f8d292ee0e38768d0a94859a308b"
+		hasComSnapshot1Name = "hascomsnapshot1-sample"
+		hasComSnapshot2Name = "hascomsnapshot2-sample"
+		hasComSnapshot3Name = "hascomsnapshot3-sample"
+		prGroup             = "feature1"
+		prGroupSha          = "feature1hash"
+		plrstarttime        = 1775992257
 	)
 
 	BeforeAll(func() {
@@ -165,6 +183,52 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Create(ctx, hasComp)).Should(Succeed())
+
+		hasCom1 = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component1-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  "component1-sample",
+				Application:    "application-sample",
+				ContainerImage: sample_image + "@" + sampleDigest,
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL: SampleRepoLink,
+						},
+					},
+				},
+			},
+			Status: applicationapiv1alpha1.ComponentStatus{
+				LastBuiltCommit: "",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasCom1)).Should(Succeed())
+
+		hasCom3 = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "component3-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  "component3-sample",
+				Application:    "application-sample",
+				ContainerImage: sample_image + "@" + sampleDigest,
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL: SampleRepoLink,
+						},
+					},
+				},
+			},
+			Status: applicationapiv1alpha1.ComponentStatus{
+				LastBuiltCommit: "",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasCom3)).Should(Succeed())
 
 		hasCompMissingImageDigest = &applicationapiv1alpha1.Component{
 			ObjectMeta: metav1.ObjectMeta{
@@ -333,6 +397,174 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			}, hasSnapshot)
 			return err
 		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		hasComSnapshot1 = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hasComSnapshot1Name,
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:                         gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:                    hasCom1.Name,
+					gitops.PipelineAsCodeEventTypeLabel:              gitops.PipelineAsCodePullRequestType,
+					gitops.PRGroupHashLabel:                          prGroupSha,
+					"pac.test.appstudio.openshift.io/url-org":        "testorg",
+					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
+					gitops.PipelineAsCodeSHALabel:                    "sha",
+				},
+				Annotations: map[string]string{
+					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
+					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime),
+					gitops.PRGroupAnnotation:                      prGroup,
+					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
+					gitops.PipelineAsCodePullRequestAnnotation:    "1",
+					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component1",
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+					{
+						Name:           hasComp.Name,
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasComSnapshot1)).Should(Succeed())
+
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      hasComSnapshot1.Name,
+				Namespace: "default",
+			}, hasComSnapshot1)
+			return err
+		}, time.Second*10).ShouldNot(HaveOccurred())
+
+		hasComSnapshot2 = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hasComSnapshot2Name,
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:                         gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:                    hasCom1.Name,
+					gitops.PipelineAsCodeEventTypeLabel:              gitops.PipelineAsCodePullRequestType,
+					gitops.PRGroupHashLabel:                          prGroupSha,
+					"pac.test.appstudio.openshift.io/url-org":        "testorg",
+					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
+					gitops.PipelineAsCodeSHALabel:                    "sha",
+				},
+				Annotations: map[string]string{
+					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
+					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 100),
+					gitops.PRGroupAnnotation:                      prGroup,
+					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
+					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           hasCom1.Name,
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+					{
+						Name:           hasComp.Name,
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+				},
+			},
+		}
+
+		hasComSnapshot3 = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      hasComSnapshot3Name,
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:                         gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:                    hasCom3.Name,
+					gitops.PipelineAsCodeEventTypeLabel:              gitops.PipelineAsCodePullRequestType,
+					gitops.PRGroupHashLabel:                          prGroupSha,
+					"pac.test.appstudio.openshift.io/url-org":        "testorg",
+					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
+					gitops.PipelineAsCodeSHALabel:                    "sha",
+				},
+				Annotations: map[string]string{
+					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
+					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 200),
+					gitops.PRGroupAnnotation:                      prGroup,
+					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
+					gitops.PipelineAsCodePullRequestAnnotation:    "1",
+					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: hasApp.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           hasCom3.Name,
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+					{
+						Name:           hasComp.Name,
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+				},
+			},
+		}
+
+		buildPipelineRun1 = &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pipelinerun-build-running1",
+				Namespace: "default",
+				Labels: map[string]string{
+					"pipelines.appstudio.openshift.io/type":    "build",
+					"pipelines.openshift.io/used-by":           "build-cloud",
+					"pipelines.openshift.io/runtime":           "nodejs",
+					"pipelines.openshift.io/strategy":          "s2i",
+					"appstudio.openshift.io/component":         "component-sample",
+					"pipelinesascode.tekton.dev/event-type":    "pull_request",
+					"build.appstudio.redhat.com/target_branch": "main",
+					"test.appstudio.openshift.io/pr-group-sha": prGroupSha,
+				},
+				Annotations: map[string]string{
+					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					"pipelinesascode.tekton.dev/on-target-branch":   "[main,master]",
+					"build.appstudio.openshift.io/repo":             "https://github.com/devfile-samples/devfile-sample-go-basic?rev=c713067b0e65fb3de50d1f7c457eb51c2ab0dbb0",
+					"test.appstudio.openshift.io/pr-group":          prGroup,
+				},
+			},
+			Spec: tektonv1.PipelineRunSpec{
+				PipelineRef: &tektonv1.PipelineRef{
+					Name: "build-pipeline-pass",
+					ResolverRef: tektonv1.ResolverRef{
+						Resolver: "bundle",
+						Params: tektonv1.Params{
+							{Name: "bundle",
+								Value: tektonv1.ParamValue{Type: "string", StringVal: "quay.io/redhat-appstudio/example-tekton-bundle:test"},
+							},
+							{Name: "name",
+								Value: tektonv1.ParamValue{Type: "string", StringVal: "test-task"},
+							},
+						},
+					},
+				},
+				Params: []tektonv1.Param{
+					{
+						Name: "output-image",
+						Value: tektonv1.ParamValue{
+							Type:      tektonv1.ParamTypeString,
+							StringVal: sample_image + "@" + sampleDigest,
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, buildPipelineRun1)).Should(Succeed())
 	})
 
 	AfterEach(func() {
@@ -343,6 +575,14 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		err = k8sClient.Delete(ctx, hasOverRideSnapshot)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasInvalidOverrideSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComSnapshot1)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComSnapshot2)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasComSnapshot3)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, buildPipelineRun1)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -356,6 +596,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		err = k8sClient.Delete(ctx, integrationTestScenario)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, testReleasePlan)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasCom1)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasCom3)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -1294,6 +1538,307 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(result.RequeueRequest).To(BeFalse())
+		})
+	})
+
+	When("Adapter is created for component snapshot with pr group", func() {
+		It("ensures component snapshot will not be processed if it is not from pull/merge request", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			hasComSnapshot1.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePushType
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("The snapshot is not created by PAC pull request"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("ensures component snapshot will not be processed if it has been processed", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			hasComSnapshot1.Annotations[gitops.PRGroupCreationAnnotation] = "processed"
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("The PR group info has been processed for this component snapshot"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("ensures component snapshot will not be processed if it has no pr group sha label", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			Expect(metadata.DeleteLabel(hasComSnapshot1, gitops.PRGroupHashLabel)).ShouldNot(HaveOccurred())
+			Expect(metadata.HasLabel(hasComSnapshot1, gitops.PRGroupHashLabel)).To(BeFalse())
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("Failed to get PR group hash from snapshot"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadata.HasAnnotation(hasComSnapshot1, gitops.PRGroupCreationAnnotation)).To(BeTrue())
+		})
+
+		It("ensures component snapshot will not be processed if it has no pr group annotation", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			Expect(metadata.DeleteAnnotation(hasComSnapshot1, gitops.PRGroupAnnotation)).ShouldNot(HaveOccurred())
+			Expect(metadata.HasAnnotation(hasComSnapshot1, gitops.PRGroupAnnotation)).To(BeFalse())
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("Failed to get PR group from snapshot"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadata.HasAnnotation(hasComSnapshot1, gitops.PRGroupCreationAnnotation)).To(BeTrue())
+		})
+
+		It("Calling en when there is running build PLR belonging to the same pr group sha", func() {
+			buildPipelineRun1.Status = tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					Results: []tektonv1.PipelineRunResult{},
+				},
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Running",
+							Status: "Unknown",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun1)).Should(Succeed())
+
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{*buildPipelineRun1},
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("is still running, won't create group snapshot"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadata.HasAnnotation(hasComSnapshot1, gitops.PRGroupCreationAnnotation)).To(BeTrue())
+		})
+
+		It("Calling en when there is failed build PLR belonging to the same pr group sha", func() {
+			buildPipelineRun1.Status = tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					Results: []tektonv1.PipelineRunResult{},
+				},
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "failed",
+							Status: "False",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun1)).Should(Succeed())
+
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{*buildPipelineRun1},
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("failed, won't create group snapshot"))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(metadata.HasAnnotation(hasComSnapshot1, gitops.PRGroupCreationAnnotation)).To(BeTrue())
+		})
+
+		It("Calling en when there is successful build PLR belonging to the same pr group sha but component snapshot is not created", func() {
+			buildPipelineRun1.Status = tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					Results: []tektonv1.PipelineRunResult{},
+				},
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "succeeded",
+							Status: "True",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun1)).Should(Succeed())
+
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{*buildPipelineRun1},
+				},
+			})
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring("has succeeded but component snapshot has not been created now"))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("Ensure group snasphot can be created", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockStatus := status.NewMockStatusInterface(ctrl)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), hasComSnapshot2).Return(true, nil)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), hasComSnapshot3).Return(true, nil)
+			// mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).Return(true, nil)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
+
+			adapter = NewAdapter(ctx, hasComSnapshot1, hasApp, log, loader.NewMockLoader(), k8sClient)
+
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{},
+				},
+				{
+					ContextKey: loader.ApplicationComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasCom1, *hasCom3},
+				},
+			})
+
+			// create 3 snasphots here because we need to get snapshot twice so that we can't use the mocked snapshot
+			Expect(k8sClient.Create(adapter.context, hasComSnapshot2)).Should(Succeed())
+			Eventually(func() error {
+				err := k8sClient.Get(adapter.context, types.NamespacedName{
+					Name:      hasComSnapshot2.Name,
+					Namespace: "default",
+				}, hasComSnapshot2)
+				return err
+			}, time.Second*10).ShouldNot(HaveOccurred())
+			Expect(k8sClient.Create(adapter.context, hasComSnapshot3)).Should(Succeed())
+			Eventually(func() error {
+				err := k8sClient.Get(adapter.context, types.NamespacedName{
+					Name:      hasComSnapshot3.Name,
+					Namespace: "default",
+				}, hasComSnapshot3)
+				return err
+			}, time.Second*10).ShouldNot(HaveOccurred())
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(buf.String()).Should(ContainSubstring(""))
+			Expect(err).ToNot(HaveOccurred())
+			fmt.Fprintf(GinkgoWriter, "-------test: %v\n", buf.String())
+			Eventually(func() bool {
+				_ = k8sClient.Get(adapter.context, types.NamespacedName{
+					Name:      hasComSnapshot2.Name,
+					Namespace: "default",
+				}, hasComSnapshot2)
+				return metadata.HasAnnotation(hasComSnapshot2, gitops.PRGroupCreationAnnotation) &&
+					Expect(hasComSnapshot2.Annotations[gitops.PRGroupCreationAnnotation]).Should(ContainSubstring("is created for pr group"))
+			}, time.Second*10).Should(BeTrue())
+			Eventually(func() bool {
+				_ = k8sClient.Get(adapter.context, types.NamespacedName{
+					Name:      hasComSnapshot3.Name,
+					Namespace: "default",
+				}, hasComSnapshot3)
+				return metadata.HasAnnotation(hasComSnapshot3, gitops.PRGroupCreationAnnotation) &&
+					Expect(hasComSnapshot3.Annotations[gitops.PRGroupCreationAnnotation]).Should(ContainSubstring("is created for pr group"))
+			}, time.Second*10).Should(BeTrue())
 		})
 	})
 })

--- a/internal/controller/snapshot/snapshot_controller.go
+++ b/internal/controller/snapshot/snapshot_controller.go
@@ -117,6 +117,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(ctx, snapshot, application, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
+		adapter.EnsureGroupSnapshotExist,
 		adapter.EnsureOverrideSnapshotValid,
 		adapter.EnsureAllReleasesExist,
 		adapter.EnsureGlobalCandidateImageUpdated,
@@ -127,6 +128,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
+	EnsureGroupSnapshotExist() (controller.OperationResult, error)
 	EnsureAllReleasesExist() (controller.OperationResult, error)
 	EnsureRerunPipelineRunsExist() (controller.OperationResult, error)
 	EnsureIntegrationPipelineRunsExist() (controller.OperationResult, error)

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -55,6 +55,8 @@ const (
 	AllTaskRunsWithMatchingPipelineRunLabelContextKey
 	GetPipelineRunContextKey
 	GetComponentContextKey
+	GetBuildPLRContextKey
+	GetComponentSnapshotsKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -212,4 +214,22 @@ func (l *mockLoader) GetComponent(ctx context.Context, c client.Client, name, na
 		return l.loader.GetComponent(ctx, c, name, namespace)
 	}
 	return toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentContextKey, &applicationapiv1alpha1.Component{})
+}
+
+// GetPipelineRunsWithPRGroupHash returns the resource and error passed as values of the context.
+func (l *mockLoader) GetPipelineRunsWithPRGroupHash(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, prGroupHash string) (*[]tektonv1.PipelineRun, error) {
+	if ctx.Value(GetBuildPLRContextKey) == nil {
+		return l.loader.GetPipelineRunsWithPRGroupHash(ctx, c, snapshot, prGroupHash)
+	}
+	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetBuildPLRContextKey, []tektonv1.PipelineRun{})
+	return &pipelineRuns, err
+}
+
+// GetMatchingComponentSnapshotsForComponentAndPRGroupHash returns the resource and error passed as values of the context
+func (l *mockLoader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, componentName, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+	if ctx.Value(GetComponentSnapshotsKey) == nil {
+		return l.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, c, snapshot, componentName, prGroupHash)
+	}
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
+	return &snapshots, err
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -290,4 +290,34 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("When calling GetPipelineRunsWithPRGroupHash", func() {
+		It("returns resource and error from the context", func() {
+			plrs := []tektonv1.PipelineRun{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetBuildPLRContextKey,
+					Resource:   plrs,
+				},
+			})
+			resource, err := loader.GetPipelineRunsWithPRGroupHash(mockContext, nil, nil, "")
+			Expect(resource).To(Equal(&plrs))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("When calling GetMatchingComponentSnapshotsForComponentAndPRGroupHash", func() {
+		It("returns resource and error from the context", func() {
+			snapshots := []applicationapiv1alpha1.Snapshot{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetComponentSnapshotsKey,
+					Resource:   snapshots,
+				},
+			})
+			resource, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(mockContext, nil, nil, "", "")
+			Expect(resource).To(Equal(&snapshots))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/status/mock_status.go
+++ b/status/mock_status.go
@@ -54,6 +54,51 @@ func (mr *MockStatusInterfaceMockRecorder) GetReporter(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetReporter", reflect.TypeOf((*MockStatusInterface)(nil).GetReporter), arg0)
 }
 
+// IsMRInSnapshotOpened mocks base method.
+func (m *MockStatusInterface) IsMRInSnapshotOpened(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsMRInSnapshotOpened", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsMRInSnapshotOpened indicates an expected call of IsMRInSnapshotOpened.
+func (mr *MockStatusInterfaceMockRecorder) IsMRInSnapshotOpened(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsMRInSnapshotOpened", reflect.TypeOf((*MockStatusInterface)(nil).IsMRInSnapshotOpened), arg0, arg1, arg2)
+}
+
+// IsPRInSnapshotOpened mocks base method.
+func (m *MockStatusInterface) IsPRInSnapshotOpened(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPRInSnapshotOpened", arg0, arg1, arg2)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsPRInSnapshotOpened indicates an expected call of IsPRInSnapshotOpened.
+func (mr *MockStatusInterfaceMockRecorder) IsPRInSnapshotOpened(arg0, arg1, arg2 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPRInSnapshotOpened", reflect.TypeOf((*MockStatusInterface)(nil).IsPRInSnapshotOpened), arg0, arg1, arg2)
+}
+
+// IsPRMRInSnapshotOpened mocks base method.
+func (m *MockStatusInterface) IsPRMRInSnapshotOpened(arg0 context.Context, arg1 *v1alpha1.Snapshot) (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IsPRMRInSnapshotOpened", arg0, arg1)
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IsPRMRInSnapshotOpened indicates an expected call of IsPRMRInSnapshotOpened.
+func (mr *MockStatusInterfaceMockRecorder) IsPRMRInSnapshotOpened(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPRMRInSnapshotOpened", reflect.TypeOf((*MockStatusInterface)(nil).IsPRMRInSnapshotOpened), arg0, arg1)
+}
+
 // ReportSnapshotStatus mocks base method.
 func (m *MockStatusInterface) ReportSnapshotStatus(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) error {
 	m.ctrl.T.Helper()
@@ -62,7 +107,7 @@ func (m *MockStatusInterface) ReportSnapshotStatus(arg0 context.Context, arg1 Re
 	return ret0
 }
 
-// ReportSnapshotStatus indicates an expected call of ReportSnapshotStatus.
+// ReportSnapshotStatus indicates an expected call of ReportSnapshot
 func (mr *MockStatusInterfaceMockRecorder) ReportSnapshotStatus(arg0, arg1, arg2 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportSnapshotStatus", reflect.TypeOf((*MockStatusInterface)(nil).ReportSnapshotStatus), arg0, arg1, arg2)

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -85,7 +85,7 @@ func NewCheckRunStatusUpdater(
 	}
 }
 
-func (cru *CheckRunStatusUpdater) getAppCredentials(ctx context.Context, object client.Object) (*appCredentials, error) {
+func GetAppCredentials(ctx context.Context, k8sclient client.Client, object client.Object) (*appCredentials, error) {
 	var err error
 	var found bool
 	appInfo := appCredentials{}
@@ -97,7 +97,7 @@ func (cru *CheckRunStatusUpdater) getAppCredentials(ctx context.Context, object 
 
 	// Get the global pipelines as code secret
 	pacSecret := v1.Secret{}
-	err = cru.k8sClient.Get(ctx, types.NamespacedName{Namespace: integrationNS, Name: PACSecret}, &pacSecret)
+	err = k8sclient.Get(ctx, types.NamespacedName{Namespace: integrationNS, Name: PACSecret}, &pacSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -124,7 +124,7 @@ func (cru *CheckRunStatusUpdater) getAppCredentials(ctx context.Context, object 
 
 // Authenticate Github Client with application credentials
 func (cru *CheckRunStatusUpdater) Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
-	creds, err := cru.getAppCredentials(ctx, snapshot)
+	creds, err := GetAppCredentials(ctx, cru.k8sClient, snapshot)
 	cru.creds = creds
 
 	if err != nil {

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -182,6 +182,13 @@ func (c *MockGitHubClient) GetAllCommitStatusesForRef(
 	return []*ghapi.RepoStatus{repoStatus}, nil
 }
 
+func (c *MockGitHubClient) GetPullRequest(ctx context.Context, owner string, repo string, prID int) (*ghapi.PullRequest, error) {
+	var id int64 = 60
+	var state = "opened"
+	pullRequest := &ghapi.PullRequest{ID: &id, State: &state}
+	return pullRequest, nil
+}
+
 var _ = Describe("GitHubReporter", func() {
 
 	var reporter *status.GitHubReporter

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -106,9 +106,9 @@ func AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(ctx context.Context, p
 	return AnnotateBuildPipelineRun(ctx, pipelineRun, h.CreateSnapshotAnnotationName, string(jsonResult), cl)
 }
 
-// GetPRGroupNameFromBuildPLR gets the PR group from the substring before @ from
+// GetPRGroupFromBuildPLR gets the PR group from the substring before @ from
 // the source-branch pac annotation, for main, it generate PR group with {source-branch}-{url-org}
-func GetPRGroupNameFromBuildPLR(pipelineRun *tektonv1.PipelineRun) string {
+func GetPRGroupFromBuildPLR(pipelineRun *tektonv1.PipelineRun) string {
 	if prGroup, found := pipelineRun.ObjectMeta.Annotations[PipelineAsCodeSourceBranchAnnotation]; found {
 		if prGroup == MainBranch || prGroup == MasterBranch && metadata.HasAnnotation(pipelineRun, PipelineAsCodeSourceRepoOrg) {
 			prGroup = prGroup + "-" + pipelineRun.ObjectMeta.Annotations[PipelineAsCodeSourceRepoOrg]

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -112,21 +112,21 @@ var _ = Describe("build pipeline", func() {
 	Context("When a build pipelineRun exists", func() {
 		It("can get PR group from build pipelineRun", func() {
 			Expect(tekton.IsPLRCreatedByPACPushEvent(buildPipelineRun)).To(BeFalse())
-			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
+			prGroup := tekton.GetPRGroupFromBuildPLR(buildPipelineRun)
 			Expect(prGroup).To(Equal("sourceBranch"))
 			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
 		})
 
 		It("can get PR group from build pipelineRun is source branch is main", func() {
 			buildPipelineRun.Annotations[tekton.PipelineAsCodeSourceBranchAnnotation] = "main"
-			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
+			prGroup := tekton.GetPRGroupFromBuildPLR(buildPipelineRun)
 			Expect(prGroup).To(Equal("main-redhat"))
 			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
 		})
 
 		It("can get PR group from build pipelineRun is source branch has @ charactor", func() {
 			buildPipelineRun.Annotations[tekton.PipelineAsCodeSourceBranchAnnotation] = "myfeature@change1"
-			prGroup := tekton.GetPRGroupNameFromBuildPLR(buildPipelineRun)
+			prGroup := tekton.GetPRGroupFromBuildPLR(buildPipelineRun)
 			Expect(prGroup).To(Equal("myfeature"))
 			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
 		})


### PR DESCRIPTION
* Create group snapshot for the component snapshots with opened PR and  belonging to the same pr group once a component snasphot is created for PR
* Set group to snapshot type to group snapshot
* Set event-type to pull-request to group snapshot
* Set pr-group annotation and pr-group-sha label from component snasphot to group snapshot

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
