### PR TITLE
test(KFLUXBUGS-1556): test slimmer test suites with  branch pairing

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -16,6 +16,16 @@ metadata:
   name: integration-service-on-pull-request
   namespace: rhtap-integration-tenant
 spec:
+  taskRunSpecs:
+    - pipelineTaskName: build-container
+      stepSpecs:
+        - name: build
+          computeResources:
+            requests:
+              memory: 512Mi
+              cpu: 250m
+            limits:
+              memory: 4Gi
   params:
   - name: dockerfile
     value: Dockerfile

--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -150,6 +150,8 @@ func (a *Adapter) createUpdatedSnapshot(snapshotComponents *[]applicationapiv1al
 	return snapshot, nil
 }
 
+// isComponentMarkedForDeletion returns true if the given object has a
+// non-zero deletionTimestamp on it, and return false otherwise.
 func isComponentMarkedForDeletion(object client.Object) bool {
 	if comp, ok := object.(*applicationapiv1alpha1.Component); ok {
 		return !comp.ObjectMeta.DeletionTimestamp.IsZero()


### PR DESCRIPTION
* This commit is a dummy commit, I just wanted to open a PR in this repo,
* And test it against an already-open PR#1349 on e2e-tests repo.
* Since the names of branches of this PR and the PR on e2e-tests repo is same, we'll be able to test them together.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
