### PR TITLE
fix: improve details message for notfound PLR in status report

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -332,7 +332,7 @@ func (s *Status) generateText(ctx context.Context, integrationTestStatusDetail i
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				s.logger.Error(err, "Failed to fetch pipelineRun", "pipelineRun.Name", pipelineRunName)
-				text := fmt.Sprintf("%s\n\n\n(Failed to fetch test result details.)", integrationTestStatusDetail.Details)
+				text := fmt.Sprintf("%s\n\n\n(Failed to fetch test result details because pipelineRun %s/%s can not be found.)", integrationTestStatusDetail.Details, namespace, pipelineRunName)
 				return text, nil
 			}
 


### PR DESCRIPTION
Coming from [slack thread](https://redhat-internal.slack.com/archives/C030SGP2VB9/p1725365370664139) and https://github.com/konflux-ci/e2e-tests/pull/1363/checks?check_run_id=29611513385
Add pipelineRun name to details then we can have a chance to debug it next time
    
Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
