### PR TITLE
fix(STONEINTG-998): fix pipeline as code event

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -633,7 +633,8 @@ func CompareSnapshots(expectedSnapshot *applicationapiv1alpha1.Snapshot, foundSn
 func IsSnapshotCreatedByPACPushEvent(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	return metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodePushType) ||
 		metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodeGLPushType) ||
-		!metadata.HasLabel(snapshot, PipelineAsCodeEventTypeLabel)
+		!metadata.HasLabel(snapshot, PipelineAsCodeEventTypeLabel) ||
+		!metadata.HasLabel(snapshot, PipelineAsCodePullRequestAnnotation)
 }
 
 // IsSnapshotCreatedBySamePACEvent checks if the two snapshot are created by the same PAC event

--- a/gitops/snapshot_predicate_test.go
+++ b/gitops/snapshot_predicate_test.go
@@ -119,9 +119,10 @@ var _ = Describe("Predicates", Ordered, func() {
 				Name:      snapshotAnnotationNew,
 				Namespace: namespace,
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:                     gitops.SnapshotComponentType,
-					gitops.SnapshotComponentLabel:                componentName,
-					"pac.test.appstudio.openshift.io/event-type": "pull_request",
+					gitops.SnapshotTypeLabel:                       gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:                  componentName,
+					"pac.test.appstudio.openshift.io/event-type":   "pull_request",
+					"pac.test.appstudio.openshift.io/pull-request": "1",
 				},
 				Annotations: map[string]string{
 					gitops.SnapshotTestsStatusAnnotation: "[{\"scenario\":\"scenario-1\",\"status\":\"TestPassed\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"completionTime\":\"2023-07-26T17:57:49+02:00\",\"details\": \"test pass\"}]",

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -137,9 +137,10 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Name:      hasComSnapshot1Name,
 				Namespace: namespace,
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
-					gitops.SnapshotComponentLabel:       hasComSnapshot1Name,
-					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+					gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:              hasComSnapshot1Name,
+					gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+					gitops.PipelineAsCodePullRequestAnnotation: "1",
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update": "2023-08-26T17:57:50+02:00",
@@ -175,9 +176,10 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Name:      hasComSnapshot2Name,
 				Namespace: namespace,
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
-					gitops.SnapshotComponentLabel:       hasComSnapshot2Name,
-					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+					gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:              hasComSnapshot2Name,
+					gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+					gitops.PipelineAsCodePullRequestAnnotation: "1",
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update": "2023-08-26T17:57:50+02:00",
@@ -213,9 +215,10 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Name:      hasComSnapshot3Name,
 				Namespace: namespace,
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
-					gitops.SnapshotComponentLabel:       hasComSnapshot3Name,
-					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+					gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:              hasComSnapshot3Name,
+					gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+					gitops.PipelineAsCodePullRequestAnnotation: "1",
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update": "2023-08-26T17:57:50+02:00",
@@ -547,6 +550,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(reasons).To(HaveLen(1))
 
 		hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
+		hasSnapshot.Labels[gitops.PipelineAsCodePullRequestAnnotation] = "1"
 		canBePromoted, reasons = gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())
 		Expect(reasons).To(HaveLen(2))
@@ -818,6 +822,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 				// A component Snapshot for pull request event referencing the component-sample
 				hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
+				hasSnapshot.Labels[gitops.PipelineAsCodePullRequestAnnotation] = "1"
 				filteredScenarios = gitops.FilterIntegrationTestScenariosWithContext(&allScenarios, hasSnapshot)
 				Expect(*filteredScenarios).To(HaveLen(6))
 

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -136,9 +136,10 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				Name:      "snapshot-sample",
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:            "component",
-					gitops.SnapshotComponentLabel:       hasComp.Name,
-					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePullRequestType,
+					gitops.SnapshotTypeLabel:                   "component",
+					gitops.SnapshotComponentLabel:              hasComp.Name,
+					gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+					gitops.PipelineAsCodePullRequestAnnotation: "1",
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -260,7 +261,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					"appstudio.openshift.io/component":         "component-sample",
 					"build.appstudio.redhat.com/target_branch": "main",
 					"pipelinesascode.tekton.dev/event-type":    "pull_request",
-					customLabel:                                "custom-label",
+					"pipelinesascode.tekton.dev/pull-request":  "1",
+					customLabel: "custom-label",
 				},
 				Annotations: map[string]string{
 					"appstudio.redhat.com/updateComponentOnSuccess": "false",

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
@@ -583,6 +583,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						gitops.SnapshotTypeLabel:                     "component",
 						gitops.SnapshotComponentLabel:                hasComp.Name,
 						"pac.test.appstudio.openshift.io/event-type": "pull_request",
+						gitops.PipelineAsCodePullRequestAnnotation:   "1",
 					},
 					Annotations: map[string]string{
 						gitops.PipelineAsCodeInstallationIDAnnotation: "123",

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -285,9 +285,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Name:      "snapshotpr-sample",
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:            "component",
-					gitops.SnapshotComponentLabel:       "component-sample",
-					gitops.PipelineAsCodeEventTypeLabel: "pull_request",
+					gitops.SnapshotTypeLabel:                   "component",
+					gitops.SnapshotComponentLabel:              "component-sample",
+					gitops.PipelineAsCodeEventTypeLabel:        "pull_request",
+					gitops.PipelineAsCodePullRequestAnnotation: "1",
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -410,6 +411,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					"pac.test.appstudio.openshift.io/url-org":        "testorg",
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					gitops.PipelineAsCodeSHALabel:                    "sha",
+					gitops.PipelineAsCodePullRequestAnnotation:       "1",
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
@@ -456,6 +458,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					"pac.test.appstudio.openshift.io/url-org":        "testorg",
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					gitops.PipelineAsCodeSHALabel:                    "sha",
+					gitops.PipelineAsCodePullRequestAnnotation:       "1",
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
@@ -492,6 +495,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					"pac.test.appstudio.openshift.io/url-org":        "testorg",
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					gitops.PipelineAsCodeSHALabel:                    "sha",
+					gitops.PipelineAsCodePullRequestAnnotation:       "1",
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
@@ -876,6 +880,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			gitops.SetSnapshotIntegrationStatusAsInvalid(hasSnapshot, "snapshot invalid")
 			hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
+			hasSnapshot.Labels[gitops.PipelineAsCodePullRequestAnnotation] = "1"
 			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeFalse())
 			Expect(gitops.IsSnapshotValid(hasSnapshot)).To(BeFalse())
 

--- a/internal/controller/statusreport/statusreport_adapter_test.go
+++ b/internal/controller/statusreport/statusreport_adapter_test.go
@@ -161,6 +161,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.SnapshotComponentLabel:                    "component-sample",
 					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
 					gitops.PipelineAsCodeEventTypeLabel:              "pull_request",
+					gitops.PipelineAsCodePullRequestAnnotation:       "1",
 					"pac.test.appstudio.openshift.io/url-org":        "testorg",
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					"pac.test.appstudio.openshift.io/sha":            "testsha",

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -99,11 +99,12 @@ var _ = Describe("Loader", Ordered, func() {
 				Name:      snapshotName,
 				Namespace: "default",
 				Labels: map[string]string{
-					gitops.SnapshotTypeLabel:            "component",
-					gitops.SnapshotComponentLabel:       "component-sample",
-					gitops.BuildPipelineRunNameLabel:    "pipelinerun-sample",
-					gitops.PRGroupHashLabel:             "featuresha",
-					gitops.PipelineAsCodeEventTypeLabel: "pull_request",
+					gitops.SnapshotTypeLabel:                   "component",
+					gitops.SnapshotComponentLabel:              "component-sample",
+					gitops.BuildPipelineRunNameLabel:           "pipelinerun-sample",
+					gitops.PRGroupHashLabel:                    "featuresha",
+					gitops.PipelineAsCodeEventTypeLabel:        "pull_request",
+					gitops.PipelineAsCodePullRequestAnnotation: "1",
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -42,14 +42,8 @@ const (
 	// PipelineAsCodeSourceRepoOrg is the repo org build PLR is triggered by
 	PipelineAsCodeSourceRepoOrg = "pipelinesascode.tekton.dev/url-org"
 
-	// PipelineAsCodeEventTypeLabel is the type of event which triggered the pipelinerun in build service
-	PipelineAsCodeEventTypeLabel = "pipelinesascode.tekton.dev/event-type"
-
-	// PipelineAsCodePushType is the type of push event which triggered the pipelinerun in build service
-	PipelineAsCodePushType = "push"
-
-	// PipelineAsCodeGLPushType is the type of gitlab push event which triggered the pipelinerun in build service
-	PipelineAsCodeGLPushType = "Push"
+	// PipelineAsCodePullRequestLabel is the type of event which triggered the pipelinerun in build service
+	PipelineAsCodePullRequestLabel = "pipelinesascode.tekton.dev/pull-request"
 )
 
 // AnnotateBuildPipelineRun sets annotation for a build pipelineRun in defined context and returns that pipeline
@@ -126,7 +120,5 @@ func GenerateSHA(str string) string {
 
 // IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
 func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
-	return metadata.HasLabelWithValue(plr, PipelineAsCodeEventTypeLabel, PipelineAsCodePushType) ||
-		metadata.HasLabelWithValue(plr, PipelineAsCodeEventTypeLabel, PipelineAsCodeGLPushType) ||
-		!metadata.HasLabel(plr, PipelineAsCodeEventTypeLabel)
+	return !metadata.HasLabel(plr, PipelineAsCodePullRequestLabel)
 }

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -47,6 +47,7 @@ var _ = Describe("build pipeline", func() {
 					"pipelines.openshift.io/strategy":          "s2i",
 					"appstudio.openshift.io/component":         "component-sample",
 					"build.appstudio.redhat.com/target_branch": "main",
+					"pipelinesascode.tekton.dev/pull-request":  "1",
 					"pipelinesascode.tekton.dev/event-type":    "pull_request",
 				},
 				Annotations: map[string]string{


### PR DESCRIPTION
* fix IsSnapshotCreatedByPACPushEvent and IsPLRCreatedByPACPushEvent since incoming event can trigger pull-request and push event plr

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
