### PR TITLE
fix(STONEINTG-998): don't release group snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -581,6 +581,10 @@ func CanSnapshotBePromoted(snapshot *applicationapiv1alpha1.Snapshot) (bool, []s
 			canBePromoted = false
 			reasons = append(reasons, "the Snapshot was created for a PaC pull request event")
 		}
+		if IsGroupSnapshot(snapshot) {
+			canBePromoted = false
+			reasons = append(reasons, "the Snapshot is group snapshot")
+		}
 	}
 	return canBePromoted, reasons
 }
@@ -1081,6 +1085,7 @@ func SetAnnotationAndLabelForGroupSnapshot(groupSnapshot *applicationapiv1alpha1
 		return nil, err
 	}
 	groupSnapshot.Labels[SnapshotTypeLabel] = SnapshotGroupType
+	groupSnapshot.Labels[PRGroupHashLabel] = componentSnapshot.Labels[PRGroupHashLabel]
 	groupSnapshot.Labels[ApplicationNameLabel] = componentSnapshot.Spec.Application
 
 	return groupSnapshot, nil


### PR DESCRIPTION
* don't release group snapshot since it is created for PR/MR
* label group snapshot with pr-group-sha

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
