### PR TITLE
fix(STONEINTG-897): don't require chains for failed build PLRs

### DIFF
--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -81,7 +81,7 @@ func BuildPipelineRunFailedPredicate() predicate.Predicate {
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			return IsBuildPipelineRun(e.ObjectNew) &&
-				isChainsDoneWithPipelineRun(e.ObjectNew) &&
+				helpers.HasPipelineRunFinished(e.ObjectNew) &&
 				!helpers.HasPipelineRunSucceeded(e.ObjectNew)
 		},
 	}


### PR DESCRIPTION
* It's not guaranteed that a failed build pipelineRun will be processed by Tekton chains
* The integration service still needs to process those pipelineRuns in order to remove their finalizers

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
