### PR TITLE
fix(STONEINTG-1048): stop reconciliation when failing to get pr status

### DIFF
--- a/git/github/github.go
+++ b/git/github/github.go
@@ -529,7 +529,7 @@ func (c *Client) CreateCommitStatus(ctx context.Context, owner string, repo stri
 func (c *Client) GetPullRequest(ctx context.Context, owner string, repo string, prID int) (*ghapi.PullRequest, error) {
 	pr, _, err := c.GetPullRequestsService().Get(ctx, owner, repo, prID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pull request for GitHub owner/repo/pull %s/%s/%d: %w", owner, repo, prID, err)
+		return nil, fmt.Errorf("failed to get pull request for owner/repo/pull %s/%s/%d: %w", owner, repo, prID, err)
 	}
 
 	return pr, err

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -603,6 +603,10 @@ func (a *Adapter) EnsureGroupSnapshotExist() (controller.OperationResult, error)
 
 	groupSnapshot, componentSnapshotInfos, err := a.prepareGroupSnapshot(a.application, prGroupHash)
 	if err != nil {
+		if strings.Contains(err.Error(), "failed to get pull request for") {
+			// Stop processing in case the repo was removed/moved, and we reach 404 when trying to find the status of pull request
+			return controller.StopProcessing()
+		}
 		a.logger.Error(err, "Failed to prepare group snapshot")
 		return controller.RequeueWithError(err)
 	}


### PR DESCRIPTION
When gitlab/github repo is deleted group snapshot creation fails while attempting to get the pr status from the repo.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
