### PR TITLE
feat(STONEINTG-1033): extend group test info fields

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -152,6 +152,9 @@ const (
 	// PipelineAsCodeTargetProjectIDAnnotation is the target project ID for gitlab
 	PipelineAsCodeTargetProjectIDAnnotation = PipelinesAsCodePrefix + "/target-project-id"
 
+	// PipelineAsCodeRepoUrlAnnotation is the target project Repo Url
+	PipelineAsCodeRepoUrlAnnotation = PipelinesAsCodePrefix + "/repo-url"
+
 	// PipelineAsCodeSHAAnnotation is the commit which triggered the pipelinerun in build service.
 	PipelineAsCodeSHAAnnotation = PipelinesAsCodePrefix + "/sha"
 
@@ -244,6 +247,10 @@ type ComponentSnapshotInfo struct {
 	BuildPipelineRun string `json:"buildPipelineRun"`
 	// The built component snapshot from build PLR
 	Snapshot string `json:"snapshot"`
+	// The repo url for each component
+	RepoUrl string `json:"repoUrl"`
+	// Pull/Merge request number for updated component
+	PullRequestNumber string `json:"pullRequestNumber"`
 }
 
 const componentSnapshotInfosSchema = `{
@@ -262,6 +269,12 @@ const componentSnapshotInfosSchema = `{
           "type": "string"
         },
         "snapshot": {
+          "type": "string"
+        },
+        "repoUrl": {
+          "type": "string"
+        },
+        "pullRequestNumber": {
           "type": "string"
         }
       },

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -909,16 +909,20 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Expect(metadata.HasAnnotation(hasComSnapshot3, gitops.PRGroupCreationAnnotation)).To(BeFalse())
 				componentSnapshotInfos := []gitops.ComponentSnapshotInfo{
 					{
-						Namespace:        "default",
-						Component:        hasComSnapshot2Name,
-						BuildPipelineRun: "plr2",
-						Snapshot:         hasComSnapshot2.Name,
+						Namespace:         "default",
+						Component:         hasComSnapshot2Name,
+						BuildPipelineRun:  "plr2",
+						Snapshot:          hasComSnapshot2.Name,
+						RepoUrl:           SampleRepoLink,
+						PullRequestNumber: "1",
 					},
 					{
-						Namespace:        "default",
-						Component:        hasComSnapshot1Name,
-						BuildPipelineRun: "plr3",
-						Snapshot:         hasComSnapshot3.Name,
+						Namespace:         "default",
+						Component:         hasComSnapshot1Name,
+						BuildPipelineRun:  "plr3",
+						Snapshot:          hasComSnapshot3.Name,
+						RepoUrl:           SampleRepoLink,
+						PullRequestNumber: "1",
 					},
 				}
 				err := gitops.NotifyComponentSnapshotsInGroupSnapshot(ctx, k8sClient, componentSnapshotInfos, "group snapshot created")

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -909,13 +909,15 @@ func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Appli
 				return nil, nil, err
 			}
 			if isPRMROpened {
-				a.logger.Info("PR/MR in snapshot is opend, will find snapshotComponent and add to groupSnapshot")
+				a.logger.Info("PR/MR in snapshot is opened, will find snapshotComponent and add to groupSnapshot")
 				snapshotComponent := gitops.FindMatchingSnapshotComponent(&snapshot, &applicationComponent)
 				componentSnapshotInfos = append(componentSnapshotInfos, gitops.ComponentSnapshotInfo{
-					Component:        applicationComponent.Name,
-					BuildPipelineRun: snapshot.Labels[gitops.BuildPipelineRunNameLabel],
-					Snapshot:         snapshot.Name,
-					Namespace:        a.snapshot.Namespace,
+					Component:         applicationComponent.Name,
+					BuildPipelineRun:  snapshot.Labels[gitops.BuildPipelineRunNameLabel],
+					Snapshot:          snapshot.Name,
+					Namespace:         a.snapshot.Namespace,
+					RepoUrl:           snapshot.Annotations[gitops.PipelineAsCodeRepoUrlAnnotation],
+					PullRequestNumber: snapshot.Annotations[gitops.PipelineAsCodePullRequestAnnotation],
 				})
 				snapshotComponents = append(snapshotComponents, snapshotComponent)
 				break

--- a/internal/controller/statusreport/statusreport_adapter_test.go
+++ b/internal/controller/statusreport/statusreport_adapter_test.go
@@ -752,7 +752,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			hasPRSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]"
 			hasPRSnapshot.Annotations["test.appstudio.openshift.io/git-reporter-status"] = "{\"scenarios\":{\"scenario1\":{\"lastUpdateTime\":\"2023-08-26T17:57:49+02:00\"}}}"
-			hasPRSnapshot.Annotations["test.appstudio.openshift.io/group-test-info"] = "[{\"namespace\":\"default\",\"component\":\"devfile-sample-java-springboot-basic-8969\",\"buildPipelineRun\":\"build-plr-java-qjfxz\",\"snapshot\":\"app-8969-bbn7d\"},{\"namespace\":\"default\",\"component\":\"devfile-sample-go-basic-8969\",\"buildPipelineRun\":\"build-plr-go-jmsjq\",\"snapshot\":\"app-8969-kzq2l\"}]"
+			hasPRSnapshot.Annotations["test.appstudio.openshift.io/group-test-info"] = "[{\"namespace\":\"default\",\"component\":\"devfile-sample-java-springboot-basic-8969\",\"buildPipelineRun\":\"build-plr-java-qjfxz\",\"snapshot\":\"app-8969-bbn7d\",\"pullRuestNumber\":\"1\",\"repoUrl\":\"https://example.com\"},{\"namespace\":\"default\",\"component\":\"devfile-sample-go-basic-8969\",\"buildPipelineRun\":\"build-plr-go-jmsjq\",\"snapshot\":\"app-8969-kzq2l\",\"pullRuestNumber\":\"1\",\"repoUrl\":\"https://example.com\"}]"
 			adapter = NewAdapter(ctx, hasPRSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
 			err := adapter.ReportSnapshotStatus(adapter.snapshot)

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -319,6 +319,7 @@ var _ = Describe("Formatters", func() {
 
 	When("componentSnapshotInfos is not nil", func() {
 		var taskRun *helpers.TaskRun
+		SampleRepoLink := "https://github.com/example"
 		BeforeEach(func() {
 			now := time.Now()
 			taskRun = newTaskRunWithoutAppStudioTestOutput(
@@ -329,27 +330,33 @@ var _ = Describe("Formatters", func() {
 		})
 		componentSnapshotInfos := []*gitops.ComponentSnapshotInfo{
 			{
-				Component:        "com1",
-				Snapshot:         "snapshot1",
-				BuildPipelineRun: "buildPLR1",
-				Namespace:        "default",
+				Component:         "com1",
+				Snapshot:          "snapshot1",
+				BuildPipelineRun:  "buildPLR1",
+				Namespace:         "default",
+				RepoUrl:           SampleRepoLink,
+				PullRequestNumber: "1",
 			},
 			{
-				Component:        "com2",
-				Snapshot:         "snapshot2",
-				BuildPipelineRun: "buildPLR2",
-				Namespace:        "default",
+				Component:         "com2",
+				Snapshot:          "snapshot2",
+				BuildPipelineRun:  "buildPLR2",
+				Namespace:         "default",
+				RepoUrl:           SampleRepoLink,
+				PullRequestNumber: "1",
 			},
 			{
-				Component:        "com3",
-				Snapshot:         "snapshot3",
-				BuildPipelineRun: "buildPLR3",
-				Namespace:        "default",
+				Component:         "com3",
+				Snapshot:          "snapshot3",
+				BuildPipelineRun:  "buildPLR3",
+				Namespace:         "default",
+				RepoUrl:           SampleRepoLink,
+				PullRequestNumber: "1",
 			},
 		}
 		It("component snapshot info is generated", func() {
 			text, err := status.FormatTestsSummary([]*helpers.TaskRun{taskRun}, pipelineRun.Name, pipelineRun.Namespace, componentSnapshotInfos, logr.Discard())
-			Expect(text).To(ContainSubstring("| com1 | snapshot1 |"))
+			Expect(text).To(ContainSubstring("| com3 | snapshot3 | <a href=\"https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/buildPLR3\">buildPLR3</a> | <a href=\"https://github.com/example/-/merge_requests/1\">example</a> |"))
 			Expect(err).To(Succeed())
 		})
 	})


### PR DESCRIPTION
* Extend group test info in group snapshot to include repourl and pr

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
