### PR TITLE
fix(KFLUXBUGS-1340):  add branch param from fork to snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -77,6 +77,9 @@ const (
 	// SnapshotGitSourceRepoURLAnnotation contains URL of the git source repository (usually needed for forks)
 	SnapshotGitSourceRepoURLAnnotation = "test.appstudio.openshift.io/source-repo-url"
 
+	// PipelineAsCodeGitProviderAnnotation contains the git provider attached via PaC (e.g., github, gitlab)
+	PipelineAsCodeGitSourceURLAnnotation = PipelinesAsCodePrefix + "/source-repo-url"
+
 	// SnapshotStatusReportAnnotation contains metadata of tests related to status reporting to git provider
 	SnapshotStatusReportAnnotation = "test.appstudio.openshift.io/git-reporter-status"
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -756,7 +756,7 @@ func shouldUpdateIntegrationTestGitResolver(integrationTestScenario *v1beta2.Int
 func getGitResolverUpdateMap(snapshot *applicationapiv1alpha1.Snapshot) map[string]string {
 	annotations := snapshot.GetAnnotations()
 	return map[string]string{
-		tekton.TektonResolverGitParamURL:      urlToGitUrl(annotations[gitops.SnapshotGitSourceRepoURLAnnotation]), // should have .git in url for consistency and compatibility
+		tekton.TektonResolverGitParamURL:      urlToGitUrl(annotations[gitops.PipelineAsCodeGitSourceURLAnnotation]), // should have .git in url for consistency and compatibility
 		tekton.TektonResolverGitParamRevision: annotations[gitops.PipelineAsCodeSHAAnnotation],
 	}
 }

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -983,9 +983,11 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 						foundRevision = true
 						Expect(param.Value.StringVal).To(Equal(sourceRepoRef))
 					}
+
 				}
 				Expect(foundUrl).To(BeTrue())
 				Expect(foundRevision).To(BeTrue())
+
 			})
 
 		})


### PR DESCRIPTION

fixing when the source of git repo of fork PR should take the branch so which was lately exposed in PaC v0.27.1


[KFLUXBUGS-1340](https://issues.redhat.com/browse/KFLUXBUGS-1340)

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
