### PR TITLE
fix(STONEINTG-1033): fix for format in status report

### DIFF
--- a/status/format.go
+++ b/status/format.go
@@ -50,7 +50,7 @@ const summaryTemplate = `
 {{ if .ComponentSnapshotInfos}}
 The group snapshot is generated for the component snasphots as below:
 | Component | Snapshot | BuildPipelineRun | PullRequest |
-| --- | --- | --- |
+| --- | --- | --- | --- |
 {{- range $cs := .ComponentSnapshotInfos }}
 | {{ $cs.Component }} | {{ $cs.Snapshot }} | <a href="{{ formatPipelineURL $cs.BuildPipelineRun $namespace $logger }}">{{ $cs.BuildPipelineRun }}</a> | <a href="{{ formatPullRequestURL $cs.RepoUrl $cs.PullRequestNumber }}">{{ formatRepoURL $cs.RepoUrl }}</a> |
 {{- end }}


### PR DESCRIPTION
* a fix for format in status report

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
