### PR TITLE
fix(STONEINTG-1033): fix git provider pull/merge request url

### DIFF
--- a/status/format.go
+++ b/status/format.go
@@ -262,9 +262,9 @@ func FormatPipelineURL(pipelinerun string, namespace string, logger logr.Logger)
 func FormatPullRequestURL(repoUrl string, pullRequestNumber string) string {
 	pullRequestUrl := "https://PULLREQUEST_URL_NOT_AVAILABLE"
 
-	if strings.Contains(repoUrl, "https://gitlab") {
+	if strings.Contains(repoUrl, "https://github") {
 		pullRequestUrl = repoUrl + "/pull/" + pullRequestNumber
-	} else if strings.Contains(repoUrl, "https://github") {
+	} else if strings.Contains(repoUrl, "https://gitlab") {
 		pullRequestUrl = repoUrl + "/-/merge_requests/" + pullRequestNumber
 	}
 	return pullRequestUrl

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -356,7 +356,7 @@ var _ = Describe("Formatters", func() {
 		}
 		It("component snapshot info is generated", func() {
 			text, err := status.FormatTestsSummary([]*helpers.TaskRun{taskRun}, pipelineRun.Name, pipelineRun.Namespace, componentSnapshotInfos, logr.Discard())
-			Expect(text).To(ContainSubstring("| com3 | snapshot3 | <a href=\"https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/buildPLR3\">buildPLR3</a> | <a href=\"https://github.com/example/-/merge_requests/1\">example</a> |"))
+			Expect(text).To(ContainSubstring("| com3 | snapshot3 | <a href=\"https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/buildPLR3\">buildPLR3</a> | <a href=\"https://github.com/example/pull/1\">example</a> |"))
 			Expect(err).To(Succeed())
 		})
 	})


### PR DESCRIPTION
* fix git provider pull/merge request url

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
