### PR TITLE
chore(stoneintg-1008): stop referencing/updating spec.containerImage

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -323,11 +323,6 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 				if err != nil {
 					return controller.RequeueWithError(err)
 				}
-				//update .Spec.ContainerImage for the component included in component snapshot
-				err = a.updateComponentContainerImage(a.context, a.client, componentToUpdate, &snapshotComponent)
-				if err != nil {
-					return controller.RequeueWithError(err)
-				}
 
 				// update .Status.LastBuiltCommit for the component included in component snapshot
 				err = a.updateComponentSource(a.context, a.client, componentToUpdate, &snapshotComponent)
@@ -365,11 +360,6 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 			}
 			// update .Status.LastPromotedImage for the component included in override snapshot
 			err = a.updateComponentLastPromotedImage(a.context, a.client, componentToUpdate, &snapshotComponent)
-			if err != nil {
-				return controller.RequeueWithError(err)
-			}
-			//update component.Spec.ContainerImage for each snapshotComponent in override snapshot
-			err = a.updateComponentContainerImage(a.context, a.client, componentToUpdate, &snapshotComponent)
 			if err != nil {
 				return controller.RequeueWithError(err)
 			}
@@ -845,21 +835,6 @@ func (a *Adapter) HandlePipelineCreationError(err error, integrationTestScenario
 		return controller.StopProcessing()
 	}
 	return controller.RequeueWithError(err)
-}
-
-func (a *Adapter) updateComponentContainerImage(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component, snapshotComponent *applicationapiv1alpha1.SnapshotComponent) error {
-	patch := client.MergeFrom(component.DeepCopy())
-	component.Spec.ContainerImage = snapshotComponent.ContainerImage
-	err := a.client.Patch(a.context, component, patch)
-	if err != nil {
-		a.logger.Error(err, "Failed to update .Spec.ContainerImage of Global Candidate for the Component",
-			"component.Name", component.Name)
-		return err
-	}
-	a.logger.LogAuditEvent("Updated .Spec.ContainerImage of Global Candidate for the Component",
-		component, h.LogActionUpdate,
-		"containerImage", snapshotComponent.ContainerImage)
-	return nil
 }
 
 func (a *Adapter) updateComponentSource(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component, snapshotComponent *applicationapiv1alpha1.SnapshotComponent) error {

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -696,7 +696,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				return !result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
 
-			Expect(hasComp.Spec.ContainerImage).To(Equal(""))
 			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
 		})
 
@@ -712,9 +711,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			expectedLogEntry := "Updated .Spec.ContainerImage of Global Candidate for the Component"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			expectedLogEntry := "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 
@@ -733,9 +730,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			expectedLogEntry := "Updated .Spec.ContainerImage of Global Candidate for the Component"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			expectedLogEntry := "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Updated .Status.LastPromotedImage of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
@@ -778,8 +773,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err = adapter.EnsureGlobalCandidateImageUpdated()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
-			expectedLogEntry = "Updated .Spec.ContainerImage of Global Candidate for the Component"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			// don't update Global Candidate List for the component included in a override snapshot but doesn't existw


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
