### PR TITLE
fix(STONEINTG-1048): stop reconciliation for unrecoverable error during group snapshot creation

### DIFF
--- a/git/github/github.go
+++ b/git/github/github.go
@@ -529,7 +529,8 @@ func (c *Client) CreateCommitStatus(ctx context.Context, owner string, repo stri
 func (c *Client) GetPullRequest(ctx context.Context, owner string, repo string, prID int) (*ghapi.PullRequest, error) {
 	pr, _, err := c.GetPullRequestsService().Get(ctx, owner, repo, prID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get pull request for owner/repo/pull %s/%s/%d: %w", owner, repo, prID, err)
+		c.logger.Error(err, "failed to get pull request for owner/repo/pull %s/%s/%d", owner, repo, prID)
+		return nil, err
 	}
 
 	return pr, err

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -27,6 +27,7 @@ const (
 	ReasonInvalidImageDigestError       = "InvalidImageDigest"
 	ReasonMissingValidComponentError    = "MissingValidComponentError"
 	ReasonUnknownError                  = "UnknownError"
+	ReasonUnrecoverableMetadataError    = "UnrecoverableMetadataError"
 )
 
 type IntegrationError struct {
@@ -98,4 +99,15 @@ func HandleLoaderError(logger IntegrationLogger, err error, resource, from strin
 
 	logger.Error(err, fmt.Sprintf("Failed to get %s from the %s", resource, from))
 	return ctrl.Result{}, err
+}
+
+func NewUnrecoverableMetadataError(msg string) error {
+	return &IntegrationError{
+		Reason:  ReasonUnrecoverableMetadataError,
+		Message: fmt.Sprintf("Meeting metadata data error: %s", msg),
+	}
+}
+
+func IsUnrecoverableMetadataError(err error) bool {
+	return getReason(err) == ReasonUnrecoverableMetadataError
 }

--- a/helpers/errorhandlers_test.go
+++ b/helpers/errorhandlers_test.go
@@ -106,5 +106,10 @@ var _ = Describe("Helpers for error handlers", Ordered, func() {
 			Expect(helpers.IsMissingInfoInPipelineRunError(err)).To(BeFalse())
 		})
 
+		It("Can define UnrecoverableMetadataError", func() {
+			err := helpers.NewUnrecoverableMetadataError("undefined annotation")
+			Expect(helpers.IsUnrecoverableMetadataError(err)).To(BeTrue())
+			Expect(err.Error()).To(Equal("Meeting metadata data error: undefined annotation"))
+		})
 	})
 })

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -573,6 +573,5 @@ var _ = Describe("GitHubReporter", func() {
 			expectedLogEntry := "found existing commitStatus for scenario test status of snapshot, no need to create new commit status"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
-
 	})
 })


### PR DESCRIPTION
* stop reconciliation for unrecoverable error when getting PR/MR status during group snapshot preparation

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
