### PR TITLE
Revert "chore(stoneintg-1008): stop referencing/updating spec.containerImage"

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -696,6 +696,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				return !result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
 
+			Expect(hasComp.Spec.ContainerImage).To(Equal(""))
 			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
 		})
 
@@ -711,7 +712,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			expectedLogEntry := "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			expectedLogEntry := "Updated .Spec.ContainerImage of Global Candidate for the Component"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 
@@ -730,7 +733,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			expectedLogEntry := "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			expectedLogEntry := "Updated .Spec.ContainerImage of Global Candidate for the Component"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Updated .Status.LastPromotedImage of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
@@ -773,6 +778,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err = adapter.EnsureGlobalCandidateImageUpdated()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
+			expectedLogEntry = "Updated .Spec.ContainerImage of Global Candidate for the Component"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			// don't update Global Candidate List for the component included in a override snapshot but doesn't existw


### PR DESCRIPTION
Reverts konflux-ci/integration-service#901

There's a bug in our code from a previous commit that means `status.lastUpdatedImage` isn't being updated for all snapshots.  We can't remove `spec.containerImage` until that's fixed.