### PR TITLE
feat(STONEINTG-851): allow status reports on push events

### DIFF
--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -99,9 +99,8 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		return controller.RequeueWithError(fmt.Errorf("failed to update test status in snapshot: %w", err))
 	}
 
-	// Remove the finalizer from Integration PLRs only if they are related to Snapshots created by Push event
-	// If they are related, then the statusreport controller removes the finalizers from these PLRs
-	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) && (h.HasPipelineRunFinished(a.pipelineRun) || pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
+	// Remove the finalizer from Integration PLRs if the snapshot is the override and its PLR has finished
+	if gitops.IsOverrideSnapshot(a.snapshot) && (h.HasPipelineRunFinished(a.pipelineRun) || pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
 		err = h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
 		if err != nil {
 			return controller.RequeueWithError(fmt.Errorf("failed to remove the finalizer: %w", err))

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -71,10 +71,9 @@ func NewAdapter(context context.Context, snapshot *applicationapiv1alpha1.Snapsh
 // The status is reported to git provider if it is a component snapshot
 // Or reported to git providers which trigger component snapshots included in group snapshot if it is a group snapshot
 func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.OperationResult, error) {
-	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) && !gitops.IsGroupSnapshot(a.snapshot) {
+	if gitops.IsOverrideSnapshot(a.snapshot) {
 		return controller.ContinueProcessing()
 	}
-
 	err := a.ReportSnapshotStatus(a.snapshot)
 	if err != nil {
 		a.logger.Error(err, "failed to report test status to git provider for snapshot",

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -449,7 +449,8 @@ func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestRep
 			return err
 		}
 		// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
-		if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress {
+		_, isPullRequest := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
+		if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && isPullRequest {
 			err = csu.updateStatusInComment(ctx, report)
 			if err != nil {
 				csu.logger.Error(err, "failed to update comment", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -218,6 +218,33 @@ var _ = Describe("GitLabReporter", func() {
 				})).To(Succeed())
 		})
 
+		It("creates a commit status for push snapshot with correct textual data without comments", func() {
+
+			pushSnapshot := hasSnapshot.DeepCopy()
+			// Removing the pull request annotation and adding the push label
+			delete(pushSnapshot.Annotations, gitops.PipelineAsCodePullRequestAnnotation)
+			pushSnapshot.Annotations[gitops.PipelineAsCodeEventTypeLabel] = "Push"
+
+			pushEventReporter := status.NewGitLabReporter(log, mockK8sClient)
+
+			err := pushEventReporter.Initialize(context.TODO(), pushSnapshot)
+			Expect(err).To(Succeed())
+
+			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
+
+			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
+
+			Expect(pushEventReporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:     "fullname/scenario1",
+					ScenarioName: "scenario1",
+					Status:       integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
+					Summary:      summary,
+					Text:         "detailed text here",
+				})).To(Succeed())
+		})
+
 		It("creates a commit status for snapshot with TargetURL in CommitStatus", func() {
 
 			PipelineRunName := "TestPipeline"


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)