### PR TITLE
feat(STONEINTG-1065): let users rerun ALL tests

### DIFF
--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -47,6 +47,7 @@ const (
 	PipelineRunsContextKey
 	AllIntegrationTestScenariosContextKey
 	RequiredIntegrationTestScenariosContextKey
+	AllIntegrationTestScenariosForSnapshotContextKey
 	AllSnapshotsContextKey
 	AutoReleasePlansContextKey
 	GetScenarioContextKey
@@ -147,6 +148,15 @@ func (l *mockLoader) GetRequiredIntegrationTestScenariosForSnapshot(ctx context.
 		return l.loader.GetRequiredIntegrationTestScenariosForSnapshot(ctx, c, application, snapshot)
 	}
 	integrationTestScenarios, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, RequiredIntegrationTestScenariosContextKey, []v1beta2.IntegrationTestScenario{})
+	return &integrationTestScenarios, err
+}
+
+// GetAllIntegrationTestScenariosForSnapshot returns the resource and error passed as values of the context.
+func (l *mockLoader) GetAllIntegrationTestScenariosForSnapshot(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot) (*[]v1beta2.IntegrationTestScenario, error) {
+	if ctx.Value(AllIntegrationTestScenariosForSnapshotContextKey) == nil {
+		return l.loader.GetAllIntegrationTestScenariosForSnapshot(ctx, c, application, snapshot)
+	}
+	integrationTestScenarios, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllIntegrationTestScenariosForSnapshotContextKey, []v1beta2.IntegrationTestScenario{})
 	return &integrationTestScenarios, err
 }
 

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -201,6 +201,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
+	Context("When calling GetAllIntegrationTestScenariosForSnapshot", func() {
+		It("returns all integrationTestScenario and error from the context", func() {
+			scenarios := []v1beta2.IntegrationTestScenario{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: AllIntegrationTestScenariosForSnapshotContextKey,
+					Resource:   scenarios,
+				},
+			})
+			resource, err := loader.GetAllIntegrationTestScenariosForSnapshot(mockContext, nil, nil, nil)
+			Expect(resource).To(Equal(&scenarios))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("When calling GetAllPipelineRunsForSnapshotAndScenario", func() {
 		It("returns pipelineRuns and error from the context", func() {
 			prs := []tektonv1.PipelineRun{}


### PR DESCRIPTION
* Before this commit, a user can only rerun one test at a time by adding the "run" label on snapshot with the name of ITS they want to rerun.
* After this commit, a user can add the value of "all" in the "run" label of snapshot to automatically rerun ALL the tests easily.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
