### PR TITLE
feat(STONEINTG-1003): notify PRs in group of build failure

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -26,6 +26,8 @@ remove_finalizer(Remove finalizer from build PLR)
 error[Return error]
 continue[Continue processing]
 update_metadata(add PR group info to build pipelineRun metadata)
+notify_pr_group_failure(annotate Snapshots and in-flight builds in PR group with failure message)
+failed_group_pipeline_run{Pipeline failed?}
 
 %% Node connections
 predicate                        --> get_pipeline_run
@@ -37,8 +39,11 @@ finalizer_exists           --No-->   add_finalizer
 add_finalizer                    --> continue
 failed_pipeline_run        --Yes --> remove_finalizer
 new_pipeline_run_without_prgroup --No  --> update_metadata
-new_pipeline_run_without_prgroup --Yes  --> continue
-update_metadata                    --> continue
+new_pipeline_run_without_prgroup --Yes  --> failed_group_pipeline_run
+failed_group_pipeline_run  --Yes --> notify_pr_group_failure
+failed_group_pipeline_run   --No --> continue
+notify_pr_group_failure          --> continue
+update_metadata                  --> continue
 get_pipeline_run           --Yes --> retrieve_associated_entity
 get_pipeline_run           --No  --> error
 retrieve_associated_entity --No  --> error

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -968,7 +968,7 @@ func isLatestBuildPipelineRunInComponent(pipelineRun *tektonv1.PipelineRun, pipe
 
 // haveAllPipelineRunProcessedForPrGroup checks if all build plr has been processed for the given pr group
 func (a *Adapter) haveAllPipelineRunProcessedForPrGroup(prGroup, prGroupHash string) (bool, error) {
-	pipelineRuns, err := a.loader.GetPipelineRunsWithPRGroupHash(a.context, a.client, a.snapshot, prGroupHash)
+	pipelineRuns, err := a.loader.GetPipelineRunsWithPRGroupHash(a.context, a.client, a.snapshot.Namespace, prGroupHash)
 	if err != nil {
 		a.logger.Error(err, fmt.Sprintf("Failed to get build pipelineRuns for given pr group hash %s", prGroupHash))
 		return false, err
@@ -1031,7 +1031,7 @@ func (a *Adapter) getComponentsForPRGroup(prGroup, prGroupHash string) ([]string
 }
 
 func (a *Adapter) findSnapshotWithOpenedPR(snapshot *applicationapiv1alpha1.Snapshot, applicationComponent *applicationapiv1alpha1.Component, prGroupHash string) (*applicationapiv1alpha1.Snapshot, error) {
-	snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, a.snapshot, applicationComponent.Name, prGroupHash)
+	snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, a.snapshot.Namespace, applicationComponent.Name, prGroupHash)
 	if err != nil {
 		a.logger.Error(err, "Failed to fetch Snapshots for component", "component.Name", applicationComponent.Name)
 		return nil, err

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -218,18 +218,18 @@ func (l *mockLoader) GetComponent(ctx context.Context, c client.Client, name, na
 }
 
 // GetPipelineRunsWithPRGroupHash returns the resource and error passed as values of the context.
-func (l *mockLoader) GetPipelineRunsWithPRGroupHash(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, prGroupHash string) (*[]tektonv1.PipelineRun, error) {
+func (l *mockLoader) GetPipelineRunsWithPRGroupHash(ctx context.Context, c client.Client, namespace, prGroupHash string) (*[]tektonv1.PipelineRun, error) {
 	if ctx.Value(GetBuildPLRContextKey) == nil {
-		return l.loader.GetPipelineRunsWithPRGroupHash(ctx, c, snapshot, prGroupHash)
+		return l.loader.GetPipelineRunsWithPRGroupHash(ctx, c, namespace, prGroupHash)
 	}
 	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetBuildPLRContextKey, []tektonv1.PipelineRun{})
 	return &pipelineRuns, err
 }
 
 // GetMatchingComponentSnapshotsForComponentAndPRGroupHash returns the resource and error passed as values of the context
-func (l *mockLoader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, componentName, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx context.Context, c client.Client, namespace, componentName, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(GetComponentSnapshotsKey) == nil {
-		return l.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, c, snapshot, componentName, prGroupHash)
+		return l.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, c, namespace, componentName, prGroupHash)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -300,7 +300,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   plrs,
 				},
 			})
-			resource, err := loader.GetPipelineRunsWithPRGroupHash(mockContext, nil, nil, "")
+			resource, err := loader.GetPipelineRunsWithPRGroupHash(mockContext, nil, "", "")
 			Expect(resource).To(Equal(&plrs))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -315,7 +315,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(mockContext, nil, nil, "", "")
+			resource, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(mockContext, nil, "", "", "")
 			Expect(resource).To(Equal(&snapshots))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -644,7 +644,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get build plr with pr group hash", func() {
-			fetchedBuildPLRs, err := loader.GetPipelineRunsWithPRGroupHash(ctx, k8sClient, hasSnapshot, "featuresha")
+			fetchedBuildPLRs, err := loader.GetPipelineRunsWithPRGroupHash(ctx, k8sClient, hasSnapshot.Namespace, "featuresha")
 			Expect(err).To(Succeed())
 			Expect((*fetchedBuildPLRs)[0].Name).To(Equal(buildPipelineRun.Name))
 			Expect((*fetchedBuildPLRs)[0].Namespace).To(Equal(buildPipelineRun.Namespace))
@@ -652,7 +652,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get matching snapshot for component and pr group hash", func() {
-			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, k8sClient, hasSnapshot, hasComp.Name, "featuresha")
+			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, k8sClient, hasSnapshot.Namespace, hasComp.Name, "featuresha")
 			Expect(err).To(Succeed())
 			Expect((*fetchedSnapshots)[0].Name).To(Equal(hasSnapshot.Name))
 			Expect((*fetchedSnapshots)[0].Namespace).To(Equal(hasSnapshot.Namespace))


### PR DESCRIPTION
* Failing of a group PR's build PLR should be notified to all PRs belonging to the same group.
* This is done by finding the group Snapshot and notifying each component Snapshot in the group.
* Additionally, any in-flight build PLRs are annotated with the failure message so the Snapshots that get created after the fact can also be notified.

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
