### PR TITLE
fix: add rpms-signature-scan task to pipelines

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -233,6 +233,23 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-source-image
       params:
       - name: BINARY_IMAGE

--- a/.tekton/integration-service-push.yaml
+++ b/.tekton/integration-service-push.yaml
@@ -230,6 +230,23 @@ spec:
       workspaces:
       - name: source
         workspace: workspace
+    - name: rpms-signature-scan
+      params:
+      - name: image-digest
+        value: $(tasks.build-container.results.IMAGE_DIGEST)
+      - name: image-url
+        value: $(tasks.build-container.results.IMAGE_URL)
+      runAfter:
+      - build-container
+      taskRef:
+        params:
+        - name: name
+          value: rpms-signature-scan
+        - name: bundle
+          value: quay.io/konflux-ci/tekton-catalog/task-rpms-signature-scan:0.2@sha256:7aa4d3c95e2b963e82fdda392f7cb3d61e3dab035416cf4a3a34e43cf3c9c9b8
+        - name: kind
+          value: task
+        resolver: bundles
     - name: build-source-image
       params:
       - name: BINARY_IMAGE


### PR DESCRIPTION
* adding rpms-signature-scan task to build pipeline to pass EC check, refer to the failure in EC check https://github.com/konflux-ci/integration-service/pull/910 and push pipelinerun in PR https://github.com/konflux-ci/integration-service/pull/915 https://console.redhat.com/application-pipeline/workspaces/rhtap-integration/applications/integration-service/pipelineruns/integration-service-enterprise-contract-6dhmc/logs

```
            "violations": [
                {
                    "msg": "Required task \"rpms-signature-scan\" is missing",
                    "metadata": {
                        "code": "tasks.required_tasks_found",
                        "collections": [
                            "redhat"
                        ],
                        "depends_on": [
                            "tasks.pipeline_has_tasks"
                        ],
                        "description": "Ensure that the set of required tasks are included in the PipelineRun attestation. To exclude this rule add \"tasks.required_tasks_found:rpms-signature-scan\" to the `exclude` section of the policy configuration.",
                        "solution": "Make sure all required tasks are in the build pipeline. The required task list is contained as xref:ec-cli:ROOT:configuration.adoc#_data_sources[data] under the key 'required-tasks'.",
                        "term": "rpms-signature-scan",
                        "title": "All required tasks were included in the pipeline"
                    }
                }
            ],
```
Refer to mail `[Konflux Announce] Adding rpms-signature-scan task to build pipeline` 

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
