### PR TITLE
chore(stoneintg-1079): separate build and test pipeline failures

### DIFF
--- a/config/grafana/dashboards/integration-service-health.json
+++ b/config/grafana/dashboards/integration-service-health.json
@@ -244,7 +244,16 @@
         {
           "datasource": "$datasource",
           "editorMode": "builder",
-          "expr": "controller_runtime_reconcile_errors_total{namespace=\"integration-service\", controller=\"pipelinerun\"}",
+          "expr": "controller_runtime_reconcile_errors_total{namespace=\"integration-service\", controller=\"buildpipelinerun\"}",
+          "interval": "",
+          "legendFormat": "{{controller}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": "$datasource",
+          "editorMode": "builder",
+          "expr": "controller_runtime_reconcile_errors_total{namespace=\"integration-service\", controller=\"integrationpipelinerun\"}",
           "interval": "",
           "legendFormat": "{{controller}}",
           "range": true,

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -150,6 +150,7 @@ func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) er
 
 	return ctrl.NewControllerManagedBy(manager).
 		For(&tektonv1.PipelineRun{}).
+		Named("buildpipelinerun").
 		WithEventFilter(predicate.Or(
 			tekton.BuildPipelineRunSignedAndSucceededPredicate(),
 			tekton.BuildPipelineRunFailedPredicate(),

--- a/internal/controller/integrationpipeline/integrationpipeline_controller.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_controller.go
@@ -146,6 +146,7 @@ func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) er
 
 	return ctrl.NewControllerManagedBy(manager).
 		For(&tektonv1.PipelineRun{}).
+		Named("integrationpipelinerun").
 		WithEventFilter(predicate.Or(
 			tekton.IntegrationPipelineRunPredicate())).
 		Complete(controller)


### PR DESCRIPTION
Prior to this change the grafana dashboard for integration service errors showed the errors for both the build and integration pipeline controllers together.  This change separates them for clearer debugging

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
