### PR TITLE
fix: group snapshot error causing panic

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -246,11 +246,14 @@ func (a *Adapter) notifySnapshotsInGroupAboutFailedBuild(pipelineRun *tektonv1.P
 			a.logger.Error(err, "Failed to fetch Snapshots for component", "component.Name", applicationComponent.Name)
 			return err
 		}
-		latestSnapshot := gitops.SortSnapshots(*allComponentSnapshotsInGroup)[0]
-		err = gitops.AnnotateSnapshot(a.context, &latestSnapshot, gitops.PRGroupCreationAnnotation,
-			buildPLRFailureMsg, a.client)
-		if err != nil {
-			return err
+
+		if len(*allComponentSnapshotsInGroup) > 0 {
+			latestSnapshot := gitops.SortSnapshots(*allComponentSnapshotsInGroup)[0]
+			err = gitops.AnnotateSnapshot(a.context, &latestSnapshot, gitops.PRGroupCreationAnnotation,
+				buildPLRFailureMsg, a.client)
+			if err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
If a build pipeline in a PR group fails before other PRs in the same group we attempt to notify snapshots that have already been created.

This change fixes a bug in which the service would panic and crash if not snapshots had been created for that PR group

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
