### PR TITLE
fix(STONEINTG-1091): don't set commitStatus for PR/MR from forked repo

### DIFF
--- a/docs/statusreport-controller.md
+++ b/docs/statusreport-controller.md
@@ -54,13 +54,13 @@ flowchart TD
   get_all_commitStatuses_from_gh(Get all commitStatuses from github <br>according to commit owner, repo and SHA)
   create_commitStatusAdapter(Create commitStatusAdapter according to <br>commit owner, repo, SHA <br>and integration test status)
   does_commitStatus_exist{Does commitStatus exist <br>on github already?}
-  create_new_commitStatus_on_gh(Create new commitStatus on github)
+  create_new_commitStatus_on_gh(Create new commitStatus on github<br>if PR is not from forked repo)
   does_comment_exist(Does a comment exist for snapshot and scenario?)
-  update_existing_comment(Update the existing comment for <br>snapshot and scenario</br>)
+  update_existing_comment(Update the existing comment for <br>snapshot and scenario</br><br>if PR is not from forked repo)
   create_new_comment(Create a new comment for <br>snapshot and scenario</br>)
 
   collect_commit_info_gl(Collect commit projectID, repo-url and SHA from Snapshot)
-  report_commit_status_gl(Create/update commitStatus on Gitlab)
+  report_commit_status_gl(Create/update commitStatus on Gitlab<br>if MR is not from forked repo)
 
   test_iterate(Iterate across all existing related testStatuses)
   is_test_final{Is <br> the test in it's <br>final state?}

--- a/docs/statusreport-controller.md
+++ b/docs/statusreport-controller.md
@@ -56,7 +56,7 @@ flowchart TD
   does_commitStatus_exist{Does commitStatus exist <br>on github already?}
   create_new_commitStatus_on_gh(Create new commitStatus on github<br>if PR is not from forked repo)
   does_comment_exist(Does a comment exist for snapshot and scenario?)
-  update_existing_comment(Update the existing comment for <br>snapshot and scenario</br><br>if PR is not from forked repo)
+  update_existing_comment(Update the existing comment for <br>snapshot and scenario</br>)
   create_new_comment(Create a new comment for <br>snapshot and scenario</br>)
 
   collect_commit_info_gl(Collect commit projectID, repo-url and SHA from Snapshot)

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -1146,3 +1146,12 @@ func UnmarshalJSON(b []byte) ([]*ComponentSnapshotInfo, error) {
 
 	return componentSnapshotInfos, nil
 }
+
+func GetSourceRepoOwnerFromSnapshot(snapshot *applicationapiv1alpha1.Snapshot) string {
+	sourceRepoUrlAnnotation, found := snapshot.GetAnnotations()[PipelineAsCodeGitSourceURLAnnotation]
+	if found {
+		arr := strings.Split(sourceRepoUrlAnnotation, "/")
+		return arr[len(arr)-2]
+	}
+	return ""
+}

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -944,6 +944,14 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				}, time.Second*10).Should(BeTrue())
 				Expect(err).ShouldNot(HaveOccurred())
 			})
+
+			It("Can return correct source repo owner for snapshot", func() {
+				sourceRepoOwner := gitops.GetSourceRepoOwnerFromSnapshot(hasSnapshot)
+				Expect(sourceRepoOwner).To(Equal(""))
+				Expect(metadata.SetAnnotation(hasSnapshot, gitops.PipelineAsCodeGitSourceURLAnnotation, "https://github.com/devfile-sample/devfile-sample-go-basic")).To(Succeed())
+				sourceRepoOwner = gitops.GetSourceRepoOwnerFromSnapshot(hasSnapshot)
+				Expect(sourceRepoOwner).To(Equal("devfile-sample"))
+			})
 		})
 	})
 })

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -1033,11 +1033,14 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			})
 			It("add pr group to the build pipelineRun annotations and labels", func() {
 				existingBuildPLR := new(tektonv1.PipelineRun)
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Namespace: buildPipelineRun.Namespace,
-					Name:      buildPipelineRun.Name,
-				}, existingBuildPLR)
-				Expect(err).NotTo(HaveOccurred())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, types.NamespacedName{
+						Namespace: buildPipelineRun.Namespace,
+						Name:      buildPipelineRun.Name,
+					}, existingBuildPLR)
+					return err == nil
+				}, time.Second*10).Should(BeTrue())
+
 				Expect(metadata.HasAnnotation(existingBuildPLR, gitops.PRGroupAnnotation)).To(BeFalse())
 				Expect(metadata.HasLabel(existingBuildPLR, gitops.PRGroupHashLabel)).To(BeFalse())
 

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -417,49 +417,56 @@ func (csu *CommitStatusUpdater) updateStatusInComment(ctx context.Context, repor
 // UpdateStatus updates commit status in PR
 func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestReport) error {
 
-	allCommitStatuses, err := csu.getAllCommitStatuses(ctx)
-	if err != nil {
-		csu.logger.Error(err, "failed to get all CommitStatuses for scenario",
-			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
-			"scenario.Name", report.ScenarioName)
-		return err
-	}
-
-	commitStatusAdapter, err := csu.createCommitStatusAdapterForSnapshot(report)
-	if err != nil {
-		csu.logger.Error(err, "failed to create CommitStatusAdapter for scenario, skipping update",
-			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
-			"scenario.Name", report.ScenarioName,
-		)
-		return nil
-	}
-
-	commitStatusExist, err := csu.ghClient.CommitStatusExists(allCommitStatuses, commitStatusAdapter)
-	if err != nil {
-		csu.logger.Error(err, "failed to check existing commitStatus")
-		return err
-	}
-
-	if !commitStatusExist {
-		csu.logger.Info("creating commit status for scenario test status of snapshot",
-			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
-		_, err = csu.ghClient.CreateCommitStatus(ctx, commitStatusAdapter.Owner, commitStatusAdapter.Repository, commitStatusAdapter.SHA, commitStatusAdapter.State, commitStatusAdapter.Description, commitStatusAdapter.Context, commitStatusAdapter.TargetURL)
+	sourceRepoOwner := gitops.GetSourceRepoOwnerFromSnapshot(csu.snapshot)
+	// we create/update commitStatus only when the source and target repo owner are the same
+	if csu.owner == sourceRepoOwner {
+		allCommitStatuses, err := csu.getAllCommitStatuses(ctx)
 		if err != nil {
-			csu.logger.Error(err, "failed to create commitStatus", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+			csu.logger.Error(err, "failed to get all CommitStatuses for scenario",
+				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
+				"scenario.Name", report.ScenarioName)
 			return err
 		}
-		// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
-		_, isPullRequest := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
-		if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && isPullRequest {
-			err = csu.updateStatusInComment(ctx, report)
+
+		commitStatusAdapter, err := csu.createCommitStatusAdapterForSnapshot(report)
+		if err != nil {
+			csu.logger.Error(err, "failed to create CommitStatusAdapter for scenario, skipping update",
+				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
+				"scenario.Name", report.ScenarioName,
+			)
+			return nil
+		}
+
+		commitStatusExist, err := csu.ghClient.CommitStatusExists(allCommitStatuses, commitStatusAdapter)
+		if err != nil {
+			csu.logger.Error(err, "failed to check existing commitStatus")
+			return err
+		}
+
+		if !commitStatusExist {
+			csu.logger.Info("creating commit status for scenario test status of snapshot",
+				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+			_, err = csu.ghClient.CreateCommitStatus(ctx, commitStatusAdapter.Owner, commitStatusAdapter.Repository, commitStatusAdapter.SHA, commitStatusAdapter.State, commitStatusAdapter.Description, commitStatusAdapter.Context, commitStatusAdapter.TargetURL)
 			if err != nil {
-				csu.logger.Error(err, "failed to update comment", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+				csu.logger.Error(err, "failed to create commitStatus", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
 				return err
 			}
+		} else {
+			csu.logger.Info("found existing commitStatus for scenario test status of snapshot, no need to create new commit status",
+				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
 		}
 	} else {
-		csu.logger.Info("found existing commitStatus for scenario test status of snapshot, no need to create new commit status",
-			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+		csu.logger.Info("Won't create/update commitStatus since there is access limimation for different source and target Repo Owner",
+			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "sourceRepoOwner", sourceRepoOwner, "targetRepoOwner", csu.owner)
+	}
+	// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
+	_, isPullRequest := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
+	if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && isPullRequest {
+		err := csu.updateStatusInComment(ctx, report)
+		if err != nil {
+			csu.logger.Error(err, "failed to update comment", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+			return err
+		}
 	}
 
 	return nil

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -456,7 +456,7 @@ func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestRep
 				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
 		}
 	} else {
-		csu.logger.Info("Won't create/update commitStatus since there is access limimation for different source and target Repo Owner",
+		csu.logger.Info("Won't create/update commitStatus since there is access limitation for different source and target Repo Owner",
 			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "sourceRepoOwner", sourceRepoOwner, "targetRepoOwner", csu.owner)
 	}
 	// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	ghapi "github.com/google/go-github/v45/github"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -211,10 +212,11 @@ var _ = Describe("GitHubReporter", func() {
 					"pac.test.appstudio.openshift.io/event-type":     "pull_request",
 				},
 				Annotations: map[string]string{
-					"build.appstudio.redhat.com/commit_sha":         "6c65b2fcaea3e1a0a92476c8b5dc89e92a85f025",
-					"appstudio.redhat.com/updateComponentOnSuccess": "false",
-					"pac.test.appstudio.openshift.io/git-provider":  "github",
-					"pac.test.appstudio.openshift.io/repo-url":      "https://github.com/devfile-sample/devfile-sample-go-basic",
+					"build.appstudio.redhat.com/commit_sha":           "6c65b2fcaea3e1a0a92476c8b5dc89e92a85f025",
+					"appstudio.redhat.com/updateComponentOnSuccess":   "false",
+					"pac.test.appstudio.openshift.io/git-provider":    "github",
+					"pac.test.appstudio.openshift.io/repo-url":        "https://github.com/devfile-sample/devfile-sample-go-basic",
+					"pac.test.appstudio.openshift.io/source-repo-url": "https://github.com/devfile-sample/devfile-sample-go-basic",
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -593,6 +595,19 @@ var _ = Describe("GitHubReporter", func() {
 			}
 			Expect(reporter.ReportStatus(context.TODO(), testReport)).To(Succeed())
 			expectedLogEntry := "found existing commitStatus for scenario test status of snapshot, no need to create new commit status"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
+
+		It("don't create commit status when source and target repo owner are different", func() {
+			Expect(metadata.DeleteAnnotation(hasSnapshot, gitops.PipelineAsCodeGitSourceURLAnnotation)).To(Succeed())
+			testReport := status.TestReport{
+				ScenarioName: "scenario2",
+				FullName:     "test/scenario2",
+				Status:       integrationteststatus.IntegrationTestStatusPending,
+				Summary:      "Integration test for snapshot snapshot-sample and scenario scenario2 is pending",
+			}
+			Expect(reporter.ReportStatus(context.TODO(), testReport)).To(Succeed())
+			expectedLogEntry := "Won't create/update commitStatus since there is access limimation for different source and target Repo Owner"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 	})

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -607,7 +607,7 @@ var _ = Describe("GitHubReporter", func() {
 				Summary:      "Integration test for snapshot snapshot-sample and scenario scenario2 is pending",
 			}
 			Expect(reporter.ReportStatus(context.TODO(), testReport)).To(Succeed())
-			expectedLogEntry := "Won't create/update commitStatus since there is access limimation for different source and target Repo Owner"
+			expectedLogEntry := "Won't create/update commitStatus since there is access limitation for different source and target Repo Owner"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 	})

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/go-logr/logr"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit/metadata"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
@@ -334,6 +335,31 @@ var _ = Describe("GitLabReporter", func() {
 			Expect(*existingNoteID).To(Equal(note.ID))
 		})
 
+		It("don't create commit status when source and target project ID are different", func() {
+			Expect(metadata.SetAnnotation(hasSnapshot, gitops.PipelineAsCodeSourceProjectIDAnnotation, "0")).To(Succeed())
+			Expect(reporter.Initialize(context.TODO(), hasSnapshot)).To(Succeed())
+
+			PipelineRunName := "TestPipeline"
+			expectedURL := status.FormatPipelineURL(PipelineRunName, hasSnapshot.Namespace, logr.Discard())
+
+			muxCommitStatusPost(mux, sourceProjectID, digest, expectedURL)
+			muxMergeNotes(mux, sourceProjectID, mergeRequest, "")
+			muxCommitStatusesGet(mux, sourceProjectID, digest, nil)
+
+			Expect(reporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:            "fullname/scenario1",
+					ScenarioName:        "scenario1",
+					TestPipelineRunName: PipelineRunName,
+					Status:              integrationteststatus.IntegrationTestStatusInProgress,
+					Summary:             "summary",
+					Text:                "detailed text here",
+				})).To(Succeed())
+
+			expectedLogEntry := "Won't create/update commitStatus due to the access limitation for forked repo"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
 	})
 
 	Describe("Test helper functions", func() {


### PR DESCRIPTION
* Don't set commitStatus if the PR/MR is from forked repo since the limitation access

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
