### PR TITLE
feat: begin referencing status.lastPromotedImage

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -755,7 +755,10 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, applicati
 	var snapshotComponents []applicationapiv1alpha1.SnapshotComponent
 	for _, applicationComponent := range *applicationComponents {
 		applicationComponent := applicationComponent // G601
-		containerImage := applicationComponent.Spec.ContainerImage
+		containerImage := applicationComponent.Status.LastPromotedImage
+		if containerImage == "" {
+			containerImage = applicationComponent.Spec.ContainerImage
+		}
 
 		var componentSource *applicationapiv1alpha1.ComponentSource
 		if applicationComponent.Name == component.Name {

--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -89,7 +89,10 @@ func (a *Adapter) EnsureComponentIsCleanedUp() (controller.OperationResult, erro
 	for _, individualComponent := range *applicationComponents {
 		component := individualComponent
 		if a.component.Name != component.Name {
-			containerImage := component.Spec.ContainerImage
+			containerImage := component.Status.LastPromotedImage
+			if containerImage == "" {
+				containerImage = component.Spec.ContainerImage
+			}
 			componentSource := gitops.GetComponentSourceFromComponent(&component)
 			snapshotComponents = append(snapshotComponents, applicationapiv1alpha1.SnapshotComponent{
 				Name:           component.Name,

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -951,7 +951,10 @@ func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Appli
 		a.logger.Info("can't find snapshot with open pull/merge request for component, try to find snapshotComponent from Global Candidate List", "component", applicationComponent.Name)
 		// if there is no component snapshot found for open PR/MR, we get snapshotComponent from gcl
 		componentSource := gitops.GetComponentSourceFromComponent(&applicationComponent)
-		containerImage := applicationComponent.Spec.ContainerImage
+		containerImage := applicationComponent.Status.LastPromotedImage
+		if containerImage == "" {
+			containerImage = applicationComponent.Spec.ContainerImage
+		}
 		if containerImage == "" {
 			a.logger.Info("component cannot be added to snapshot for application due to missing containerImage", "component.Name", applicationComponent.Name)
 			continue


### PR DESCRIPTION
Attempt to use status.lastPrommotedImage as the source of truth for the gcl.  Fall back on the spec.containerImage field, despite the fact that it may have been changed by imageRepository

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
