### PR TITLE
chore(STONEINTG-949): migrate service image to konflux-ci

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
 #
 # For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
 # redhat.com/integration-service-bundle:$VERSION and my.domain/integration-service-catalog:$VERSION.
-IMAGE_TAG_BASE ?= quay.io/redhat-appstudio/integration-service
+IMAGE_TAG_BASE ?= quay.io/konflux-ci/integration-service
 
 # TAG_NAME defines the tag for the new image
 TAG_NAME ?= next

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,5 +13,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: quay.io/redhat-appstudio/integration-service
+  newName: quay.io/konflux-ci/integration-service
   newTag: latest

--- a/config/snapshotgc/snapshotgc.yaml
+++ b/config/snapshotgc/snapshotgc.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
             - name: test-gc
               image: >-
-                quay.io/redhat-appstudio/integration-service:latest
+                quay.io/konflux-ci/integration-service:latest
               command:
                 - /snapshotgc
                 - --zap-log-level=debug

--- a/docs/pull_request_template.md
+++ b/docs/pull_request_template.md
@@ -1,5 +1,5 @@
 ## Maintainers will complete the following section
 
 - [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
-- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
+- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
 - [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


### PR DESCRIPTION
Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/redhat-appstudio/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
