### PR TITLE
feat(STONEINTG-883): Set owner reference to application for ALL Snapshots

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -1925,7 +1925,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err := adapter.EnsureOverrideSnapshotValid()
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(result.RequeueRequest).To(BeFalse())
-			Expect(controllerutil.HasControllerReference(hasInvalidOverrideSnapshot)).To(BeTrue())
 			Expect(buf.String()).Should(ContainSubstring("Snapshot has been marked as invalid"))
 			Expect(err).ToNot(HaveOccurred())
 


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
