### PR TITLE
feat(KFLUXBUGS-1889): set ITS timeouts from annotations

### DIFF
--- a/api/v1beta2/integrationtestscenario_types.go
+++ b/api/v1beta2/integrationtestscenario_types.go
@@ -20,6 +20,20 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// TestLabelPrefix contains the prefix applied to labels and annotations related to testing.
+	TestLabelPrefix = "test.appstudio.openshift.io"
+
+	// PipelineTimeoutAnnotation contains the name of the application
+	PipelineTimeoutAnnotation = TestLabelPrefix + "/pipeline_timeout"
+
+	// TasksTimeoutAnnotation contains the name of the application
+	TasksTimeoutAnnotation = TestLabelPrefix + "/tasks_timeout"
+
+	// FinallyTimeoutAnnotation contains the name of the application
+	FinallyTimeoutAnnotation = TestLabelPrefix + "/finally_timeout"
+)
+
 // IntegrationTestScenarioSpec defines the desired state of IntegrationScenario
 type IntegrationTestScenarioSpec struct {
 	// Application that's associated with the IntegrationTestScenario

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -788,7 +788,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 		WithApplication(a.application).
 		WithExtraParams(integrationTestScenario.Spec.Params).
 		WithFinalizer(h.IntegrationPipelineRunFinalizer).
-		WithDefaultIntegrationTimeouts(a.logger.Logger)
+		WithIntegrationTimeouts(integrationTestScenario, a.logger.Logger)
 
 	if shouldUpdateIntegrationTestGitResolver(integrationTestScenario, snapshot) {
 		pipelineRunBuilder.WithUpdatedTestsGitResolver(getGitResolverUpdateMap(snapshot))


### PR DESCRIPTION
* If the ITS has any of the following annotations: 
  * test.appstudio.openshift.io/pipeline_timeout 
  * test.appstudio.openshift.io/tasks_timeout 
  * test.appstudio.openshift.io/finally_timeout
* Use them to overwrite the default timeouts that are set in configmaps

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
