### PR TITLE
chore(stoneintg-1008): stop referenciing spec.containerImage

### DIFF
--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -43,7 +43,7 @@ flowchart TD
 
   %% Node definitions
   ensure2(Process further if: <br>Snapshot was not created by PAC Pull Request Event OR <br>an override snapshot was created <br>& Snapshot wasn't added to Global Candidate List)
-  update_container_image("<b>Get</b> all components of snapshot and <br><b>Update</b> the '.spec.containerImage' field of the <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].containerImage field")
+  update_container_image("<b>Get</b> all components of snapshot and <br><b>Update</b> the '.status.lastPromotedImage' field of the <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].containerImage field")
   update_last_built_commit("<b>Update</b> the '.status.lastBuiltCommit' field of the given <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].source.git.revision field")
   mark_snapshot_added_to_GCL(<b>Mark</b> the Snapshot as AddedToGlobalCandidateList)
   continue_processing2(Controller continues processing...)

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -756,9 +756,6 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, applicati
 	for _, applicationComponent := range *applicationComponents {
 		applicationComponent := applicationComponent // G601
 		containerImage := applicationComponent.Status.LastPromotedImage
-		if containerImage == "" {
-			containerImage = applicationComponent.Spec.ContainerImage
-		}
 
 		var componentSource *applicationapiv1alpha1.ComponentSource
 		if applicationComponent.Name == component.Name {

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -83,7 +83,7 @@ func IsInvalidImageDigestError(err error) bool {
 func NewMissingValidComponentError(componentName string) error {
 	return &IntegrationError{
 		Reason:  ReasonMissingValidComponentError,
-		Message: fmt.Sprintf("The only one component %s is invalid, valid .Spec.ContainerImage is missing", componentName),
+		Message: fmt.Sprintf("The only one component %s is invalid, valid .Status.LastPromotedImage is missing", componentName),
 	}
 }
 

--- a/helpers/errorhandlers_test.go
+++ b/helpers/errorhandlers_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Helpers for error handlers", Ordered, func() {
 		It("Can define MissingValidComponentError", func() {
 			err := helpers.NewMissingValidComponentError("componentName")
 			Expect(helpers.IsMissingValidComponentError(err)).To(BeTrue())
-			Expect(err.Error()).To(Equal("The only one component componentName is invalid, valid .Spec.ContainerImage is missing"))
+			Expect(err.Error()).To(Equal("The only one component componentName is invalid, valid .Status.LastPromotedImage is missing"))
 		})
 
 		It("Can handle non integration error", func() {

--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -90,9 +90,6 @@ func (a *Adapter) EnsureComponentIsCleanedUp() (controller.OperationResult, erro
 		component := individualComponent
 		if a.component.Name != component.Name {
 			containerImage := component.Status.LastPromotedImage
-			if containerImage == "" {
-				containerImage = component.Spec.ContainerImage
-			}
 			componentSource := gitops.GetComponentSourceFromComponent(&component)
 			snapshotComponents = append(snapshotComponents, applicationapiv1alpha1.SnapshotComponent{
 				Name:           component.Name,

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -760,7 +760,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				return !result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
 
-			Expect(hasComp.Spec.ContainerImage).To(Equal(""))
 			Expect(hasComp.Status.LastBuiltCommit).To(Equal(""))
 		})
 
@@ -776,9 +775,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			expectedLogEntry := "Updated .Spec.ContainerImage of Global Candidate for the Component"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			expectedLogEntry := "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 
@@ -797,9 +794,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
 
-			expectedLogEntry := "Updated .Spec.ContainerImage of Global Candidate for the Component"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
+			expectedLogEntry := "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Updated .Status.LastPromotedImage of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
@@ -842,8 +837,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err = adapter.EnsureGlobalCandidateImageUpdated()
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(result.CancelRequest).To(BeFalse())
-			expectedLogEntry = "Updated .Spec.ContainerImage of Global Candidate for the Component"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "Updated .Status.LastBuiltCommit of Global Candidate for the Component"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			// don't update Global Candidate List for the component included in a override snapshot but doesn't existw
@@ -2273,7 +2266,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(result.RequeueRequest).To(BeFalse())
 			Expect(buf.String()).Should(ContainSubstring("component cannot be added to snapshot for application due to invalid digest in containerImage"))
-			Expect(buf.String()).Should(ContainSubstring("component with containerImage from Global Candidate List will be added to group snapshot"))
 			Expect(err).NotTo(HaveOccurred())
 			Eventually(func() bool {
 				_ = k8sClient.Get(adapter.context, types.NamespacedName{


### PR DESCRIPTION
The integration service has begun using status.lastPromotedImage as the source of truth for the GCL. Initially the spec.containerImage field was used as a fallback until components could migrate to the new field.  Now that all elligible components have been manually migrated to the new field, we can remove references to the old field in our code.

This will end the errors caused by the integration and build services both attempting to write to spec.containerImage.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
