### PR TITLE
KONFLUX-5971&STONEINTG-996: set intg test status in git according to build PLR and snapshot creation status

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -16,6 +16,7 @@ new_pipeline_run_without_prgroup{PR group is added to pipelineRun metadata?}
 get_pipeline_run{Pipeline updated?}
 failed_pipeline_run{Pipeline failed?}
 finalizer_exists{Does the finalizer already exist?}
+need_to_set_integration_test{Build pipelineRun is newly triggered?<br>Or Build pipelineRun failed?<br> Or Failing to create snapshot?}
 retrieve_associated_entity(Retrieve the entity <br> component/application)
 determine_snapshot{Does a snapshot exist?}
 prep_snapshot(Gather Application components<br> Add new component)
@@ -28,12 +29,15 @@ continue[Continue processing]
 update_metadata(add PR group info to build pipelineRun metadata)
 notify_pr_group_failure(annotate Snapshots and in-flight builds in PR group with failure message)
 failed_group_pipeline_run{Pipeline failed?}
+update_integrationTestStatus_in_git_provider(Create checkRun/commitStatus in<br>git provider)
+update_build_plr_annotation(Update build pipelineRun annotation<br>test.appstudio.openshift.io/snapshot-creation-report<br>with the status)
 
 %% Node connections
 predicate                        --> get_pipeline_run
 predicate                       -->  new_pipeline_run
 predicate                       -->  new_pipeline_run_without_prgroup
 predicate                       -->  failed_pipeline_run
+predicate                       -->  need_to_set_integration_test
 new_pipeline_run           --Yes-->  finalizer_exists
 finalizer_exists           --No-->   add_finalizer
 add_finalizer                    --> continue
@@ -55,6 +59,10 @@ prep_snapshot                    --> check_chains
 check_chains               --Yes --> annotate_pipelineRun
 annotate_pipelineRun       --Yes --> remove_finalizer
 remove_finalizer                 --> continue
+need_to_set_integration_test  --Yes --> update_integrationTestStatus_in_git_provider
+need_to_set_integration_test  --No  --> continue
+update_integrationTestStatus_in_git_provider --> update_build_plr_annotation
+update_build_plr_annotation --> continue
 
 %% Assigning styles to nodes
 class predicate Amber;

--- a/helpers/build.go
+++ b/helpers/build.go
@@ -1,3 +1,10 @@
 package helpers
 
-const CreateSnapshotAnnotationName = "test.appstudio.openshift.io/create-snapshot-status"
+const (
+	// CreateSnapshotAnnotationName contains medata of snapshot creation failure or success
+	CreateSnapshotAnnotationName = "test.appstudio.openshift.io/create-snapshot-status"
+
+	// SnapshotCreationReportAnnotation contains metadata of snapshot creation status reporting to git provider
+	// to initialize integration test
+	SnapshotCreationReportAnnotation = "test.appstudio.openshift.io/snapshot-creation-report"
+)

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -189,6 +189,20 @@ func (a *Adapter) EnsurePRGroupAnnotated() (controller.OperationResult, error) {
 	return controller.ContinueProcessing()
 }
 
+// EnsureIntegrationTestInitialized is an operation that will ensure that the integration test is initialized as pending
+// state when build PLR is triggered
+// or snapshot creation fail when failing to create snapshot
+func (a *Adapter) EnsureIntegrationTestInitialized() (controller.OperationResult, error) {
+	if metadata.HasAnnotation(a.pipelineRun, tekton.SnapshotNameLabel) {
+		a.logger.Info("snapshot has been created for build pipelineRun, no need to report integration status from build pipelinerun")
+		return controller.ContinueProcessing()
+	}
+
+	if h.InitializedIntegrationTestReport(a.pipelineRun) || !h.IsSnapshotCreationFailureReported(a.pipelineRun)
+
+
+}
+
 // getImagePullSpecFromPipelineRun gets the full image pullspec from the given build PipelineRun,
 // In case the Image pullspec can't be composed, an error will be returned.
 func (a *Adapter) getImagePullSpecFromPipelineRun(pipelineRun *tektonv1.PipelineRun) (string, error) {

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -26,14 +26,18 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
+	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/status"
 	"github.com/konflux-ci/integration-service/tekton"
 	"github.com/konflux-ci/operator-toolkit/metadata"
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
 
+	"go.uber.org/mock/gomock"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/strings/slices"
@@ -54,16 +58,20 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 	var (
 		adapter       *Adapter
 		createAdapter func() *Adapter
+		buf           bytes.Buffer
 		logger        helpers.IntegrationLogger
+		mockReporter  *status.MockReporterInterface
+		mockStatus    *status.MockStatusInterface
 
-		successfulTaskRun *tektonv1.TaskRun
-		failedTaskRun     *tektonv1.TaskRun
-		buildPipelineRun  *tektonv1.PipelineRun
-		buildPipelineRun2 *tektonv1.PipelineRun
-		hasComp           *applicationapiv1alpha1.Component
-		hasComp2          *applicationapiv1alpha1.Component
-		hasApp            *applicationapiv1alpha1.Application
-		hasSnapshot       *applicationapiv1alpha1.Snapshot
+		successfulTaskRun       *tektonv1.TaskRun
+		failedTaskRun           *tektonv1.TaskRun
+		buildPipelineRun        *tektonv1.PipelineRun
+		buildPipelineRun2       *tektonv1.PipelineRun
+		hasComp                 *applicationapiv1alpha1.Component
+		hasComp2                *applicationapiv1alpha1.Component
+		hasApp                  *applicationapiv1alpha1.Application
+		hasSnapshot             *applicationapiv1alpha1.Snapshot
+		integrationTestScenario *v1beta2.IntegrationTestScenario
 	)
 	const (
 		SampleRepoLink           = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
@@ -251,6 +259,39 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Status().Update(ctx, failedTaskRun)).Should(Succeed())
+
+		integrationTestScenario = &v1beta2.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "example-its",
+				Namespace: "default",
+
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1beta2.IntegrationTestScenarioSpec{
+				Application: hasApp.Name,
+				ResolverRef: v1beta2.ResolverRef{
+					Resolver: "git",
+					Params: []v1beta2.ResolverParameter{
+						{
+							Name:  "url",
+							Value: "https://github.com/redhat-appstudio/integration-examples.git",
+						},
+						{
+							Name:  "revision",
+							Value: "main",
+						},
+						{
+							Name:  "pathInRepo",
+							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
+						},
+					},
+				},
+			},
+		}
+
+		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
 	})
 
 	BeforeEach(func() {
@@ -357,6 +398,8 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		err = k8sClient.Delete(ctx, successfulTaskRun)
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, failedTaskRun)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, integrationTestScenario)
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 	})
 
@@ -1410,6 +1453,166 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			})
 		})
 
+	})
+
+	When("a build PLR is triggered or retirggered, succeeded or failed", func() {
+		BeforeEach(func() {
+			ctrl := gomock.NewController(GinkgoT())
+			mockReporter = status.NewMockReporterInterface(ctrl)
+			mockStatus = status.NewMockStatusInterface(ctrl)
+			mockReporter.EXPECT().GetReporterName().Return("mocked-reporter").AnyTimes()
+			mockStatus.EXPECT().GetReporter(gomock.Any()).Return(mockReporter)
+			mockStatus.EXPECT().GetReporter(gomock.Any()).AnyTimes()
+			mockReporter.EXPECT().GetReporterName().AnyTimes()
+			mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Times(1)
+			mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).Times(1)
+		})
+		It("ensure integration test is initialized from build PLR", func() {
+			buildPipelineRun.Status = tektonv1.PipelineRunStatus{
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Running",
+							Status: "Unknown",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+
+			buf = bytes.Buffer{}
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.AllIntegrationTestScenariosContextKey,
+					Resource:   []v1beta2.IntegrationTestScenario{*integrationTestScenario},
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitHub()
+			fmt.Fprintf(GinkgoWriter, "-------test: %v\n", buf.String())
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			Expect(metadata.HasAnnotationWithValue(buildPipelineRun, helpers.SnapshotCreationReportAnnotation, intgteststat.BuildPLRInProgress.String())).To(BeTrue())
+
+			result, err = adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			expectedLogEntry := "integration test has been set correctly, no need to set integration test status from build pipelinerun"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
+
+		It("ensure integration test is set from build PLR when build PLR fails", func() {
+			buildPipelineRun.Status = tektonv1.PipelineRunStatus{
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Failed",
+							Status: "False",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+
+			buf = bytes.Buffer{}
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.AllIntegrationTestScenariosContextKey,
+					Resource:   []v1beta2.IntegrationTestScenario{*integrationTestScenario},
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			Expect(metadata.HasAnnotationWithValue(buildPipelineRun, helpers.SnapshotCreationReportAnnotation, intgteststat.BuildPLRFailed.String())).To(BeTrue())
+
+			result, err = adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			expectedLogEntry := "integration test has been set correctly, no need to set integration test status from build pipelinerun"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
+
+		It("ensure integration test is set from build PLR when build PLR succeeded but snapshot is not created", func() {
+			Expect(metadata.SetAnnotation(buildPipelineRun, helpers.CreateSnapshotAnnotationName, "failed to create snapshot due to error")).ShouldNot(HaveOccurred())
+			buf = bytes.Buffer{}
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+				{
+					ContextKey: loader.AllIntegrationTestScenariosContextKey,
+					Resource:   []v1beta2.IntegrationTestScenario{*integrationTestScenario},
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			Expect(metadata.HasAnnotationWithValue(buildPipelineRun, helpers.SnapshotCreationReportAnnotation, intgteststat.SnapshotCreationFailed.String())).To(BeTrue())
+
+			result, err = adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			expectedLogEntry := "integration test has been set correctly, no need to set integration test status from build pipelinerun"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
+	})
+
+	When("integration status should not be set from build PLR", func() {
+		It("integration test will not be set from build PLR when build PLR succeeded and snapshot is created", func() {
+			Expect(metadata.SetAnnotation(buildPipelineRun, tekton.SnapshotNameLabel, "snashot-sample")).ShouldNot(HaveOccurred())
+			buf = bytes.Buffer{}
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			Expect(metadata.HasAnnotationWithValue(buildPipelineRun, helpers.SnapshotCreationReportAnnotation, "SnapshotCreated")).To(BeTrue())
+			expectedLogEntry := "snapshot has been created for build pipelineRun, no need to report integration status from build pipelinerun status"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
+
+		It("integration test will not be set from build PLR when build PLR is not from pac pull request event", func() {
+			Expect(metadata.DeleteLabel(buildPipelineRun, tekton.PipelineAsCodePullRequestLabel)).ShouldNot(HaveOccurred())
+			buf = bytes.Buffer{}
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   hasApp,
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitHub()
+			Expect(!result.CancelRequest && err == nil).To(BeTrue())
+			expectedLogEntry := "build pipelineRun is not created by pull/merge request, no need to set integration test status in git provider"
+			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
+		})
 	})
 	createAdapter = func() *Adapter {
 		adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, logger, loader.NewMockLoader(), k8sClient)

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -119,7 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsurePipelineIsFinalized,
 		adapter.EnsurePRGroupAnnotated,
 		adapter.EnsureSnapshotExists,
-		adapter.EnsureIntegrationTestInitialized,
+		adapter.EnsureIntegrationTestReportedToGitHub,
 	})
 }
 
@@ -128,7 +128,7 @@ type AdapterInterface interface {
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureSnapshotExists() (controller.OperationResult, error)
-	EnsureIntegrationTestInitialized() (controller.OperationResult, error)
+	EnsureIntegrationTestReportedToGitHub() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -119,6 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsurePipelineIsFinalized,
 		adapter.EnsurePRGroupAnnotated,
 		adapter.EnsureSnapshotExists,
+		adapter.EnsureIntegrationTestInitialized,
 	})
 }
 
@@ -127,6 +128,7 @@ type AdapterInterface interface {
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureSnapshotExists() (controller.OperationResult, error)
+	EnsureIntegrationTestInitialized() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -2177,7 +2177,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			result, err := adapter.EnsureGroupSnapshotExist()
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(result.RequeueRequest).To(BeFalse())
-			Expect(buf.String()).Should(ContainSubstring("failed to get app credentials from Snapshot"))
+			Expect(buf.String()).Should(ContainSubstring("failed to get app credentials from Object"))
 			Expect(err).ToNot(HaveOccurred())
 		})
 

--- a/internal/controller/statusreport/statusreport_adapter_test.go
+++ b/internal/controller/statusreport/statusreport_adapter_test.go
@@ -790,7 +790,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			expectedTestReport := status.TestReport{
 				FullName:            "Konflux Staging / scenario1 / component-sample",
 				ScenarioName:        "scenario1",
-				SnapshotName:        "snapshot-pr-sample",
+				ObjectName:          "snapshot-pr-sample",
 				ComponentName:       "component-sample",
 				Text:                "Test in progress",
 				Summary:             "Integration test for snapshot snapshot-pr-sample and scenario scenario1 is in progress",

--- a/pkg/integrationteststatus/integration_test_status.go
+++ b/pkg/integrationteststatus/integration_test_status.go
@@ -45,6 +45,12 @@ const (
 	IntegrationTestStatusTestPassed // TestPassed
 	// Integration PLR is invalid
 	IntegrationTestStatusTestInvalid // TestInvalid
+	// Build PLR is in progress
+	BuildPLRInProgress // BuildPLRInProgress
+	// Snapshot is not created
+	SnapshotCreationFailed // SnapshotCreationFailed
+	// Build pipelinerun failed
+	BuildPLRFailed // BuildPLRFailed
 )
 
 const integrationTestStatusesSchema = `{
@@ -168,7 +174,7 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestStatusIfChanged(scenarioN
 			detail.StartTime = &timestamp
 			// null CompletionTime because testing started again
 			detail.CompletionTime = nil
-		case IntegrationTestStatusPending:
+		case IntegrationTestStatusPending, BuildPLRInProgress:
 			// null all timestamps as test is not inProgress neither in final state
 			detail.StartTime = nil
 			detail.CompletionTime = nil
@@ -177,7 +183,10 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestStatusIfChanged(scenarioN
 			IntegrationTestStatusDeleted,
 			IntegrationTestStatusTestFail,
 			IntegrationTestStatusTestPassed,
-			IntegrationTestStatusTestInvalid:
+			IntegrationTestStatusTestInvalid,
+			SnapshotCreationFailed,
+			BuildPLRFailed:
+
 			detail.CompletionTime = &timestamp
 		}
 	}

--- a/pkg/integrationteststatus/integrationteststatus_enumer.go
+++ b/pkg/integrationteststatus/integrationteststatus_enumer.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-const _IntegrationTestStatusName = "PendingInProgressDeletedEnvironmentProvisionErrorDeploymentErrorTestFailTestPassedTestInvalid"
+const _IntegrationTestStatusName = "PendingInProgressDeletedEnvironmentProvisionErrorDeploymentErrorTestFailTestPassedTestInvalidBuildPLRInProgressSnapshotCreationFailedBuildPLRFailed"
 
-var _IntegrationTestStatusIndex = [...]uint8{0, 7, 17, 24, 49, 64, 72, 82, 93}
+var _IntegrationTestStatusIndex = [...]uint8{0, 7, 17, 24, 49, 64, 72, 82, 93, 111, 133, 147}
 
 func (i IntegrationTestStatus) String() string {
 	i -= 1
@@ -22,14 +22,17 @@ func (i IntegrationTestStatus) String() string {
 var _IntegrationTestStatusValues = []IntegrationTestStatus{1, 2, 3, 4, 5, 6, 7, 8}
 
 var _IntegrationTestStatusNameToValueMap = map[string]IntegrationTestStatus{
-	_IntegrationTestStatusName[0:7]:   1,
-	_IntegrationTestStatusName[7:17]:  2,
-	_IntegrationTestStatusName[17:24]: 3,
-	_IntegrationTestStatusName[24:49]: 4,
-	_IntegrationTestStatusName[49:64]: 5,
-	_IntegrationTestStatusName[64:72]: 6,
-	_IntegrationTestStatusName[72:82]: 7,
-	_IntegrationTestStatusName[82:93]: 8,
+	_IntegrationTestStatusName[0:7]:     1,
+	_IntegrationTestStatusName[7:17]:    2,
+	_IntegrationTestStatusName[17:24]:   3,
+	_IntegrationTestStatusName[24:49]:   4,
+	_IntegrationTestStatusName[49:64]:   5,
+	_IntegrationTestStatusName[64:72]:   6,
+	_IntegrationTestStatusName[72:82]:   7,
+	_IntegrationTestStatusName[82:93]:   8,
+	_IntegrationTestStatusName[93:111]:  9,
+	_IntegrationTestStatusName[111:133]: 10,
+	_IntegrationTestStatusName[133:147]: 11,
 }
 
 // IntegrationTestStatusString retrieves an enum value from the enum constants string name.

--- a/status/format.go
+++ b/status/format.go
@@ -24,8 +24,11 @@ import (
 	"text/template"
 
 	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 )
 
@@ -294,4 +297,40 @@ func FormatTaskLogURL(taskRun *helpers.TaskRun, pipelinerun string, namespace st
 		logger.Error(err, "Error occured when executing task log template.")
 	}
 	return buf.String()
+}
+
+// GetEquivalentLabel gets the lable from snapshot or plr since they have Equivalent pac label
+func GetPACLabel(obj metav1.Object, labels map[string]string, labelSufix string) (string, bool) {
+	if _, ok := obj.(*applicationapiv1alpha1.Snapshot); ok {
+		label, ok := labels[gitops.PipelinesAsCodePrefix+labelSufix]
+		return label, ok
+	}
+	if _, ok := obj.(*tektonv1.PipelineRun); ok {
+		label, ok := labels[gitops.BuildPipelinesAsCodePrefix+labelSufix]
+		return label, ok
+	}
+	return "", false
+}
+
+// GetPACAnnotation gets the annotation from snapshot or plr since they have Equivalent pac label
+func GetPACAnnotation(obj metav1.Object, annotations map[string]string, annotationSuffix string) (string, bool) {
+	if _, ok := obj.(*applicationapiv1alpha1.Snapshot); ok {
+		annotation, ok := annotations[gitops.PipelinesAsCodePrefix+annotationSuffix]
+		return annotation, ok
+	}
+	if _, ok := obj.(*tektonv1.PipelineRun); ok {
+		annotation, ok := annotations[gitops.BuildPipelinesAsCodePrefix+annotationSuffix]
+		return annotation, ok
+	}
+	return "", false
+}
+
+func GetObjectKind(obj metav1.Object) string {
+	if _, ok := obj.(*applicationapiv1alpha1.Snapshot); ok {
+		return "Snapshot"
+	}
+	if _, ok := obj.(*tektonv1.PipelineRun); ok {
+		return "PipelineRun"
+	}
+	return ""
 }

--- a/status/mock_reporter.go
+++ b/status/mock_reporter.go
@@ -13,8 +13,8 @@ import (
 	context "context"
 	reflect "reflect"
 
-	v1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	gomock "go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockReporterInterface is a mock of ReporterInterface interface.
@@ -41,7 +41,7 @@ func (m *MockReporterInterface) EXPECT() *MockReporterInterfaceMockRecorder {
 }
 
 // Detect mocks base method.
-func (m *MockReporterInterface) Detect(arg0 *v1alpha1.Snapshot) bool {
+func (m *MockReporterInterface) Detect(arg0 metav1.Object) bool {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Detect", arg0)
 	ret0, _ := ret[0].(bool)
@@ -69,7 +69,7 @@ func (mr *MockReporterInterfaceMockRecorder) GetReporterName() *gomock.Call {
 }
 
 // Initialize mocks base method.
-func (m *MockReporterInterface) Initialize(arg0 context.Context, arg1 *v1alpha1.Snapshot) error {
+func (m *MockReporterInterface) Initialize(arg0 context.Context, arg1 metav1.Object) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", arg0, arg1)
 	ret0, _ := ret[0].(error)

--- a/status/mock_status.go
+++ b/status/mock_status.go
@@ -15,6 +15,7 @@ import (
 
 	v1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	gomock "go.uber.org/mock/gomock"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // MockStatusInterface is a mock of StatusInterface interface.
@@ -41,7 +42,7 @@ func (m *MockStatusInterface) EXPECT() *MockStatusInterfaceMockRecorder {
 }
 
 // GetReporter mocks base method.
-func (m *MockStatusInterface) GetReporter(arg0 *v1alpha1.Snapshot) ReporterInterface {
+func (m *MockStatusInterface) GetReporter(arg0 metav1.Object) ReporterInterface {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetReporter", arg0)
 	ret0, _ := ret[0].(ReporterInterface)

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -23,14 +23,15 @@ import (
 
 	"github.com/go-logr/logr"
 	ghapi "github.com/google/go-github/v45/github"
-	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/git/github"
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/tekton"
 
 	"github.com/konflux-ci/operator-toolkit/metadata"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -47,7 +48,7 @@ const (
 // StatusUpdater is common interface used by status reporter to update PR status
 type StatusUpdater interface {
 	// Authentication of client
-	Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error
+	Authenticate(ctx context.Context, obj metav1.Object) error
 	// Update status of PR
 	UpdateStatus(ctx context.Context, report TestReport) error
 }
@@ -60,7 +61,7 @@ type CheckRunStatusUpdater struct {
 	owner             string
 	repo              string
 	sha               string
-	snapshot          *applicationapiv1alpha1.Snapshot
+	object            metav1.Object
 	creds             *appCredentials
 	allCheckRunsCache []*ghapi.CheckRun
 }
@@ -73,7 +74,7 @@ func NewCheckRunStatusUpdater(
 	owner string,
 	repo string,
 	sha string,
-	snapshot *applicationapiv1alpha1.Snapshot,
+	object metav1.Object,
 ) *CheckRunStatusUpdater {
 	return &CheckRunStatusUpdater{
 		ghClient:  ghClient,
@@ -82,17 +83,18 @@ func NewCheckRunStatusUpdater(
 		owner:     owner,
 		repo:      repo,
 		sha:       sha,
-		snapshot:  snapshot,
+		object:    object,
 	}
 }
 
-func GetAppCredentials(ctx context.Context, k8sclient client.Client, object client.Object) (*appCredentials, error) {
+func GetAppCredentials(ctx context.Context, k8sclient client.Client, object metav1.Object) (*appCredentials, error) {
 	log := log.FromContext(ctx)
 	var err, unRecoverableError error
 	var found bool
 	appInfo := appCredentials{}
 
-	appInfo.InstallationID, err = strconv.ParseInt(object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation], 10, 64)
+	installationID, _ := GetPACAnnotation(object, object.GetAnnotations(), gitops.InstallationIDAnnotationSuffix)
+	appInfo.InstallationID, err = strconv.ParseInt(installationID, 10, 64)
 	if err != nil {
 		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("Error %s when parsing string annotation %s: %s", err.Error(), gitops.PipelineAsCodeInstallationIDAnnotation, object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation]))
 		log.Error(unRecoverableError, fmt.Sprintf("Error %s when parsing string annotation %s: %s", err.Error(), gitops.PipelineAsCodeInstallationIDAnnotation, object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation]))
@@ -133,13 +135,13 @@ func GetAppCredentials(ctx context.Context, k8sclient client.Client, object clie
 }
 
 // Authenticate Github Client with application credentials
-func (cru *CheckRunStatusUpdater) Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
-	creds, err := GetAppCredentials(ctx, cru.k8sClient, snapshot)
+func (cru *CheckRunStatusUpdater) Authenticate(ctx context.Context, object metav1.Object) error {
+	creds, err := GetAppCredentials(ctx, cru.k8sClient, object)
 	cru.creds = creds
 
 	if err != nil {
-		cru.logger.Error(err, "failed to get app credentials from Snapshot",
-			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		cru.logger.Error(err, "failed to get app credentials from Object", "object.Kind", GetObjectKind(object),
+			"object.NameSpace", object.GetNamespace(), "object.Name", object.GetName())
 		return err
 	}
 
@@ -168,22 +170,23 @@ func (cru *CheckRunStatusUpdater) getAllCheckRuns(ctx context.Context) ([]*ghapi
 	return cru.allCheckRunsCache, nil
 }
 
-// createCheckRunAdapterForSnapshot create a CheckRunAdapter for given snapshot, integrationTestStatusDetail, owner, repo and sha to create a checkRun
+// createCheckRunAdapterForObject create a CheckRunAdapter for given snapshot, integrationTestStatusDetail, owner, repo and sha to create a checkRun
 // https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run
-func (cru *CheckRunStatusUpdater) createCheckRunAdapterForSnapshot(report TestReport) (*github.CheckRunAdapter, error) {
-	snapshot := cru.snapshot
+func (cru *CheckRunStatusUpdater) createCheckRunAdapterForObject(report TestReport) (*github.CheckRunAdapter, error) {
+	object := cru.object
 	detailsURL := ""
+	objectKind := GetObjectKind(object)
 
 	conclusion, err := generateCheckRunConclusion(report.Status)
 	if err != nil {
-		cru.logger.Error(err, fmt.Sprintf("failed to generate conclusion for integrationTestScenario %s and snapshot %s/%s", report.ScenarioName, snapshot.Namespace, snapshot.Name))
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", report.Status, report.ScenarioName, snapshot.Namespace, snapshot.Name)
+		cru.logger.Error(err, fmt.Sprintf("failed to generate conclusion for integrationTestScenario %s and %s %s/%s", report.ScenarioName, objectKind, object.GetNamespace(), object.GetName()))
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and %s %s/%s", report.Status, report.ScenarioName, objectKind, object.GetNamespace(), object.GetName())
 	}
 
 	title, err := generateCheckRunTitle(report.Status)
 	if err != nil {
-		cru.logger.Error(err, fmt.Sprintf("failed to generate title for integrationTestScenario %s and snapshot %s/%s", report.ScenarioName, snapshot.Namespace, snapshot.Name))
-		return nil, fmt.Errorf("failed to generate title for integrationTestScenario %s and snapshot %s/%s", report.ScenarioName, snapshot.Namespace, snapshot.Name)
+		cru.logger.Error(err, fmt.Sprintf("failed to generate title for integrationTestScenario %s and %s %s/%s", report.ScenarioName, objectKind, object.GetNamespace(), object.GetName()))
+		return nil, fmt.Errorf("failed to generate title for integrationTestScenario %s and %s %s/%s", report.ScenarioName, objectKind, object.GetNamespace(), object.GetName())
 	}
 
 	externalID := report.ScenarioName
@@ -194,7 +197,7 @@ func (cru *CheckRunStatusUpdater) createCheckRunAdapterForSnapshot(report TestRe
 	if report.TestPipelineRunName == "" {
 		cru.logger.Info("TestPipelineRunName is not set for CheckRun", "ExternalID", externalID)
 	} else {
-		detailsURL = FormatPipelineURL(report.TestPipelineRunName, snapshot.Namespace, *cru.logger)
+		detailsURL = FormatPipelineURL(report.TestPipelineRunName, object.GetNamespace(), *cru.logger)
 	}
 
 	cra := &github.CheckRunAdapter{
@@ -227,16 +230,17 @@ func (cru *CheckRunStatusUpdater) UpdateStatus(ctx context.Context, report TestR
 		panic("authenticate first")
 	}
 	allCheckRuns, err := cru.getAllCheckRuns(ctx)
+	objectKind := GetObjectKind(cru.object)
 
 	if err != nil {
 		cru.logger.Error(err, "failed to get all checkruns")
 		return err
 	}
 
-	checkRunAdapter, err := cru.createCheckRunAdapterForSnapshot(report)
+	checkRunAdapter, err := cru.createCheckRunAdapterForObject(report)
 	if err != nil {
-		cru.logger.Error(err, "failed to create checkRunAdapter for scenario, skipping update",
-			"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name,
+		cru.logger.Error(err, "failed to create checkRunAdapter for scenario, skipping update", "object.Kind", objectKind,
+			"object.NameSpace", cru.object.GetNamespace(), "object.Name", cru.object.GetName(),
 			"scenario.Name", report.ScenarioName,
 		)
 		return nil
@@ -246,7 +250,7 @@ func (cru *CheckRunStatusUpdater) UpdateStatus(ctx context.Context, report TestR
 
 	if existingCheckrun == nil {
 		cru.logger.Info("creating checkrun for scenario test status of snapshot",
-			"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", report.ScenarioName, "externalID", checkRunAdapter.ExternalID)
+			"object.NameSpace", cru.object.GetNamespace(), "object.Kind", objectKind, "object.Name", cru.object.GetName(), "scenarioName", report.ScenarioName, "externalID", checkRunAdapter.ExternalID)
 		_, err = cru.ghClient.CreateCheckRun(ctx, checkRunAdapter)
 		if err != nil {
 			cru.logger.Error(err, "failed to create checkrun",
@@ -261,7 +265,7 @@ func (cru *CheckRunStatusUpdater) UpdateStatus(ctx context.Context, report TestR
 	// new checkrun with same external ID, rather than updating it
 	if existingCheckrun.GetStatus() == "completed" {
 		cru.logger.Info("The existing checkrun is already in completed state, re-creating a new checkrun for scenario test status of snapshot",
-			"snapshot.NameSpace", cru.snapshot.Namespace, "snapshot.Name", cru.snapshot.Name, "scenarioName", report.ScenarioName, "externalID", checkRunAdapter.ExternalID)
+			"object.NameSpace", cru.object.GetNamespace(), "object.Kind", objectKind, "object.Name", cru.object.GetName(), "scenarioName", report.ScenarioName, "externalID", checkRunAdapter.ExternalID)
 		_, err = cru.ghClient.CreateCheckRun(ctx, checkRunAdapter)
 		if err != nil {
 			cru.logger.Error(err, "failed to create checkrun",
@@ -287,7 +291,7 @@ type CommitStatusUpdater struct {
 	owner                  string
 	repo                   string
 	sha                    string
-	snapshot               *applicationapiv1alpha1.Snapshot
+	object                 metav1.Object
 	allCommitStatusesCache []*ghapi.RepoStatus
 }
 
@@ -299,7 +303,7 @@ func NewCommitStatusUpdater(
 	owner string,
 	repo string,
 	sha string,
-	snapshot *applicationapiv1alpha1.Snapshot,
+	object metav1.Object,
 ) *CommitStatusUpdater {
 	return &CommitStatusUpdater{
 		ghClient:  ghClient,
@@ -308,7 +312,7 @@ func NewCommitStatusUpdater(
 		owner:     owner,
 		repo:      repo,
 		sha:       sha,
-		snapshot:  snapshot,
+		object:    object,
 	}
 }
 
@@ -316,8 +320,8 @@ func (csu *CommitStatusUpdater) getAllCommitStatuses(ctx context.Context) ([]*gh
 	if len(csu.allCommitStatusesCache) == 0 {
 		allCommitStatuses, err := csu.ghClient.GetAllCommitStatusesForRef(ctx, csu.owner, csu.repo, csu.sha)
 		if err != nil {
-			csu.logger.Error(err, "failed to get all commitStatuses for snapshot",
-				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name)
+			csu.logger.Error(err, "failed to get all commitStatuses for object", "object.Kind", GetObjectKind(csu.object),
+				"object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName())
 			return nil, err
 		}
 		csu.allCommitStatusesCache = allCommitStatuses
@@ -325,12 +329,12 @@ func (csu *CommitStatusUpdater) getAllCommitStatuses(ctx context.Context) ([]*gh
 	return csu.allCommitStatusesCache, nil
 }
 
-// Authenticate Github Client with token secret ref defined in snapshot
-func (csu *CommitStatusUpdater) Authenticate(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
-	token, err := GetPACGitProviderToken(ctx, csu.k8sClient, snapshot)
+// Authenticate Github Client with token secret ref defined in snapshot/build plr
+func (csu *CommitStatusUpdater) Authenticate(ctx context.Context, object metav1.Object) error {
+	token, err := GetPACGitProviderToken(ctx, csu.k8sClient, object)
 	if err != nil {
-		csu.logger.Error(err, "failed to get token from snapshot",
-			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		csu.logger.Error(err, "failed to get token from object", "object.Kind", GetObjectKind(csu.object),
+			"object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName())
 		return err
 	}
 
@@ -341,19 +345,20 @@ func (csu *CommitStatusUpdater) Authenticate(ctx context.Context, snapshot *appl
 // createCommitStatusAdapterForSnapshot create a commitStatusAdapter used to create commitStatus on GitHub
 // https://docs.github.com/en/rest/commits/statuses?apiVersion=2022-11-28#create-a-commit-status
 func (csu *CommitStatusUpdater) createCommitStatusAdapterForSnapshot(report TestReport) (*github.CommitStatusAdapter, error) {
-	snapshot := csu.snapshot
+	object := csu.object
 	targetURL := ""
+	objectKind := GetObjectKind(csu.object)
 
 	state, err := generateGithubCommitState(report.Status)
 	if err != nil {
-		csu.logger.Error(err, fmt.Sprintf("failed to generate commitStatus for integrationTestScenario %s and snapshot %s/%s", report.ScenarioName, snapshot.Namespace, snapshot.Name))
-		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and snapshot %s/%s", report.Status, report.ScenarioName, snapshot.Namespace, snapshot.Name)
+		csu.logger.Error(err, fmt.Sprintf("failed to generate commitStatus for integrationTestScenario %s and %s %s/%s", report.ScenarioName, objectKind, object.GetNamespace(), object.GetName()))
+		return nil, fmt.Errorf("unknown status %s for integrationTestScenario %s and %s %s/%s", report.Status, report.ScenarioName, objectKind, object.GetNamespace(), object.GetName())
 	}
 
 	if report.TestPipelineRunName == "" {
 		csu.logger.Info("TestPipelineRunName is not set for CommitStatus")
 	} else {
-		targetURL = FormatPipelineURL(report.TestPipelineRunName, snapshot.Namespace, *csu.logger)
+		targetURL = FormatPipelineURL(report.TestPipelineRunName, object.GetNamespace(), *csu.logger)
 	}
 
 	return &github.CommitStatusAdapter{
@@ -370,24 +375,24 @@ func (csu *CommitStatusUpdater) createCommitStatusAdapterForSnapshot(report Test
 // updateStatusInComment will create/update a comment in PR which creates snapshot
 func (csu *CommitStatusUpdater) updateStatusInComment(ctx context.Context, report TestReport) error {
 	var unRecoverableError error
-	issueNumberStr, found := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
+	issueNumberStr, found := csu.object.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
 	if !found {
 		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("pull-request annotation not found %q", gitops.PipelineAsCodePullRequestAnnotation))
-		csu.logger.Error(unRecoverableError, "snapshot.Name", report.SnapshotName)
+		csu.logger.Error(unRecoverableError, "object.Name", report.ObjectName)
 		return unRecoverableError
 	}
 
 	issueNumber, err := strconv.Atoi(issueNumberStr)
 	if err != nil {
 		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("failed to convert string issueNumberStr %s to int：%s", issueNumberStr, err.Error()))
-		csu.logger.Error(unRecoverableError, "snapshot.Name", report.SnapshotName)
+		csu.logger.Error(unRecoverableError, "object.Name", report.ObjectName)
 		return unRecoverableError
 	}
 
 	comment, err := FormatComment(report.Summary, report.Text)
 	if err != nil {
 		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("failed to format comment for pull-request %d: %s", issueNumber, err.Error()))
-		csu.logger.Error(unRecoverableError, "snapshot.Name", report.SnapshotName)
+		csu.logger.Error(unRecoverableError, "object.Name", report.ObjectName)
 		return unRecoverableError
 	}
 
@@ -396,7 +401,7 @@ func (csu *CommitStatusUpdater) updateStatusInComment(ctx context.Context, repor
 		csu.logger.Error(err, fmt.Sprintf("error while getting all comments for pull-request %s", issueNumberStr))
 		return fmt.Errorf("error while getting all comments for pull-request %s: %w", issueNumberStr, err)
 	}
-	existingCommentId := csu.ghClient.GetExistingCommentID(allComments, csu.snapshot.Name, report.ScenarioName)
+	existingCommentId := csu.ghClient.GetExistingCommentID(allComments, csu.object.GetName(), report.ScenarioName)
 	if existingCommentId == nil {
 		_, err = csu.ghClient.CreateComment(ctx, csu.owner, csu.repo, issueNumber, comment)
 		if err != nil {
@@ -417,13 +422,14 @@ func (csu *CommitStatusUpdater) updateStatusInComment(ctx context.Context, repor
 // UpdateStatus updates commit status in PR
 func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestReport) error {
 
-	sourceRepoOwner := gitops.GetSourceRepoOwnerFromSnapshot(csu.snapshot)
+	sourceRepoOwner := gitops.GetSourceRepoOwnerFromObject(csu.object)
+	objectKind := GetObjectKind(csu.object)
 	// we create/update commitStatus only when the source and target repo owner are the same
 	if csu.owner == sourceRepoOwner {
 		allCommitStatuses, err := csu.getAllCommitStatuses(ctx)
 		if err != nil {
-			csu.logger.Error(err, "failed to get all CommitStatuses for scenario",
-				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
+			csu.logger.Error(err, "failed to get all CommitStatuses for scenario", "object.Kind", objectKind,
+				"object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(),
 				"scenario.Name", report.ScenarioName)
 			return err
 		}
@@ -431,7 +437,7 @@ func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestRep
 		commitStatusAdapter, err := csu.createCommitStatusAdapterForSnapshot(report)
 		if err != nil {
 			csu.logger.Error(err, "failed to create CommitStatusAdapter for scenario, skipping update",
-				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name,
+				"object.Kind", objectKind, "object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(),
 				"scenario.Name", report.ScenarioName,
 			)
 			return nil
@@ -444,27 +450,27 @@ func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestRep
 		}
 
 		if !commitStatusExist {
-			csu.logger.Info("creating commit status for scenario test status of snapshot",
-				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+			csu.logger.Info("creating commit status for scenario test status of snapshot", "object.Kind", objectKind,
+				"object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(), "scenarioName", report.ScenarioName)
 			_, err = csu.ghClient.CreateCommitStatus(ctx, commitStatusAdapter.Owner, commitStatusAdapter.Repository, commitStatusAdapter.SHA, commitStatusAdapter.State, commitStatusAdapter.Description, commitStatusAdapter.Context, commitStatusAdapter.TargetURL)
 			if err != nil {
-				csu.logger.Error(err, "failed to create commitStatus", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+				csu.logger.Error(err, "failed to create commitStatus", "object.Kind", objectKind, "object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(), "scenarioName", report.ScenarioName)
 				return err
 			}
 		} else {
 			csu.logger.Info("found existing commitStatus for scenario test status of snapshot, no need to create new commit status",
-				"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+				"object.Kind", objectKind, "object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(), "scenarioName", report.ScenarioName)
 		}
 	} else {
 		csu.logger.Info("Won't create/update commitStatus since there is access limitation for different source and target Repo Owner",
-			"snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "sourceRepoOwner", sourceRepoOwner, "targetRepoOwner", csu.owner)
+			"object.Kind", objectKind, "object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(), "sourceRepoOwner", sourceRepoOwner, "targetRepoOwner", csu.owner)
 	}
 	// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
-	_, isPullRequest := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
+	_, isPullRequest := csu.object.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
 	if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && isPullRequest {
 		err := csu.updateStatusInComment(ctx, report)
 		if err != nil {
-			csu.logger.Error(err, "failed to update comment", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)
+			csu.logger.Error(err, "failed to update comment", "object.Kind", objectKind, "object.NameSpace", csu.object.GetNamespace(), "object.Name", csu.object.GetName(), "scenarioName", report.ScenarioName)
 			return err
 		}
 	}
@@ -518,7 +524,7 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 	var title string
 
 	switch state {
-	case intgteststat.IntegrationTestStatusPending:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.BuildPLRInProgress:
 		title = "Pending"
 	case intgteststat.IntegrationTestStatusInProgress:
 		title = "In Progress"
@@ -530,7 +536,9 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 		title = "Deleted"
 	case intgteststat.IntegrationTestStatusTestPassed:
 		title = "Succeeded"
-	case intgteststat.IntegrationTestStatusTestFail:
+	case intgteststat.IntegrationTestStatusTestFail,
+		intgteststat.SnapshotCreationFailed,
+		intgteststat.BuildPLRFailed:
 		title = "Failed"
 	default:
 		return title, fmt.Errorf("unknown status")
@@ -552,8 +560,11 @@ func generateCheckRunConclusion(state intgteststat.IntegrationTestStatus) (strin
 		conclusion = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		conclusion = gitops.IntegrationTestStatusSuccessGithub
-	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress,
+		intgteststat.BuildPLRInProgress:
 		conclusion = ""
+	case intgteststat.SnapshotCreationFailed, intgteststat.BuildPLRFailed:
+		conclusion = gitops.IntegrationTestStatusCancelledGithub
 	default:
 		return conclusion, fmt.Errorf("unknown status")
 	}
@@ -571,11 +582,13 @@ func generateGithubCommitState(state intgteststat.IntegrationTestStatus) (string
 	case intgteststat.IntegrationTestStatusTestFail:
 		commitState = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusEnvironmentProvisionError_Deprecated, intgteststat.IntegrationTestStatusDeploymentError_Deprecated,
-		intgteststat.IntegrationTestStatusDeleted, intgteststat.IntegrationTestStatusTestInvalid:
+		intgteststat.IntegrationTestStatusDeleted, intgteststat.IntegrationTestStatusTestInvalid,
+		intgteststat.SnapshotCreationFailed, intgteststat.BuildPLRFailed:
 		commitState = gitops.IntegrationTestStatusErrorGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		commitState = gitops.IntegrationTestStatusSuccessGithub
-	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress,
+		intgteststat.BuildPLRInProgress:
 		commitState = gitops.IntegrationTestStatusPendingGithub
 	default:
 		return commitState, fmt.Errorf("unknown status")
@@ -584,47 +597,50 @@ func generateGithubCommitState(state intgteststat.IntegrationTestStatus) (string
 	return commitState, nil
 }
 
-// Detect if GitHubReporter can be used
-func (r *GitHubReporter) Detect(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return metadata.HasAnnotationWithValue(snapshot, gitops.PipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeGitHubProviderType) ||
-		metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType)
+// Detect if GitHubReporter can be used in snapshot or build pipelinerun
+func (r *GitHubReporter) Detect(object metav1.Object) bool {
+	return metadata.HasAnnotationWithValue(object, gitops.PipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeGitHubProviderType) ||
+		metadata.HasLabelWithValue(object, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType) ||
+		metadata.HasAnnotationWithValue(object, gitops.BuildPipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeGitHubProviderType) ||
+		metadata.HasLabelWithValue(object, gitops.BuildPipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGitHubProviderType)
 }
 
 // Initialize github reporter. Must be called before updating status
-func (r *GitHubReporter) Initialize(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) error {
+func (r *GitHubReporter) Initialize(ctx context.Context, object metav1.Object) error {
 	var unRecoverableError error
-	labels := snapshot.GetLabels()
-	owner, found := labels[gitops.PipelineAsCodeURLOrgLabel]
+	labels := object.GetLabels()
+	objectKind := GetObjectKind(object)
+	owner, found := GetPACLabel(object, labels, gitops.URLOrgLabel)
 	if !found {
 		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("org label not found %q", gitops.PipelineAsCodeURLOrgLabel))
-		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		r.logger.Error(unRecoverableError, "object.Kind", objectKind, "object.NameSpace", object.GetNamespace(), "object.Name", object.GetName())
 		return unRecoverableError
 	}
 
-	repo, found := labels[gitops.PipelineAsCodeURLRepositoryLabel]
+	repo, found := GetPACLabel(object, labels, gitops.URLRepositoryLabelSuffix)
 	if !found {
-		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("repository label not found %q", gitops.PipelineAsCodeURLRepositoryLabel))
-		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("repository label not found %q", gitops.URLRepositoryLabelSuffix))
+		r.logger.Error(unRecoverableError, "object.Kind", objectKind, "object.NameSpace", object.GetNamespace(), "object.Name", object.GetName())
 		return unRecoverableError
 	}
 
-	sha, found := labels[gitops.PipelineAsCodeSHALabel]
+	sha, found := GetPACLabel(object, labels, gitops.SHALabelSuffix)
 	if !found {
 		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("sha label not found %q", gitops.PipelineAsCodeSHALabel))
-		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		r.logger.Error(unRecoverableError, "object.Kind", objectKind, "object.NameSpace", object.GetNamespace(), "object.Name", object.GetName())
 		return unRecoverableError
 	}
 
 	// Existence of the Pipelines as Code installation ID annotation signals configuration using GitHub App integration.
 	// If it doesn't exist, GitHub webhook integration is configured.
-	if metadata.HasAnnotation(snapshot, gitops.PipelineAsCodeInstallationIDAnnotation) {
-		r.updater = NewCheckRunStatusUpdater(r.client, r.k8sClient, r.logger, owner, repo, sha, snapshot)
+	if metadata.HasAnnotation(object, gitops.PipelineAsCodeInstallationIDAnnotation) || metadata.HasAnnotation(object, tekton.PipelineAsCodeInstallationIDAnnotation) {
+		r.updater = NewCheckRunStatusUpdater(r.client, r.k8sClient, r.logger, owner, repo, sha, object)
 	} else {
-		r.updater = NewCommitStatusUpdater(r.client, r.k8sClient, r.logger, owner, repo, sha, snapshot)
+		r.updater = NewCommitStatusUpdater(r.client, r.k8sClient, r.logger, owner, repo, sha, object)
 	}
 
-	if err := r.updater.Authenticate(ctx, snapshot); err != nil {
-		r.logger.Error(err, fmt.Sprintf("failed to authenticate for snapshot %s/%s", snapshot.Namespace, snapshot.Name))
+	if err := r.updater.Authenticate(ctx, object); err != nil {
+		r.logger.Error(err, fmt.Sprintf("failed to authenticate for %s %s/%s", objectKind, object.GetNamespace(), object.GetName()))
 		return err
 	}
 	return nil
@@ -638,12 +654,12 @@ func (r *GitHubReporter) GetReporterName() string {
 // Update status in Github
 func (r *GitHubReporter) ReportStatus(ctx context.Context, report TestReport) error {
 	if r.updater == nil {
-		r.logger.Error(nil, fmt.Sprintf("reporter is not initialized for snapshot %s", report.SnapshotName))
+		r.logger.Error(nil, fmt.Sprintf("reporter is not initialized for object %s", report.ObjectName))
 		return fmt.Errorf("reporter is not initialized")
 	}
 
 	if err := r.updater.UpdateStatus(ctx, report); err != nil {
-		r.logger.Error(err, fmt.Sprintf("failed to update status for snapshot %s", report.SnapshotName))
+		r.logger.Error(err, fmt.Sprintf("failed to update status for object %s", report.ObjectName))
 		return err
 	}
 	return nil

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -150,7 +150,7 @@ func (c *MockGitHubClient) GetAllCommentsForPR(ctx context.Context, owner string
 	return comments, nil
 }
 
-func (c *MockGitHubClient) GetExistingCommentID(comments []*ghapi.IssueComment, snapshotName, scenarioName string) *int64 {
+func (c *MockGitHubClient) GetExistingCommentID(comments []*ghapi.IssueComment, ObjectName, scenarioName string) *int64 {
 	return nil
 }
 
@@ -354,7 +354,7 @@ var _ = Describe("GitHubReporter", func() {
 				status.TestReport{
 					FullName:       "test-name",
 					ScenarioName:   "scenario1",
-					SnapshotName:   "snapshot-sample",
+					ObjectName:     "snapshot-sample",
 					ComponentName:  "component-sample",
 					Status:         integrationteststatus.IntegrationTestStatusTestFail,
 					Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment",
@@ -381,7 +381,7 @@ var _ = Describe("GitHubReporter", func() {
 				status.TestReport{
 					FullName:       "test-name",
 					ScenarioName:   "scenario1",
-					SnapshotName:   "snapshot-sample",
+					ObjectName:     "snapshot-sample",
 					Status:         integrationteststatus.IntegrationTestStatusTestFail,
 					Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment",
 					StartTime:      &now,
@@ -413,7 +413,7 @@ var _ = Describe("GitHubReporter", func() {
 				status.TestReport{
 					FullName:       "test-name",
 					ScenarioName:   "scenario1",
-					SnapshotName:   "snapshot-sample",
+					ObjectName:     "snapshot-sample",
 					ComponentName:  "component-sample",
 					Status:         integrationteststatus.IntegrationTestStatusTestFail,
 					Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment",
@@ -446,7 +446,7 @@ var _ = Describe("GitHubReporter", func() {
 				status.TestReport{
 					FullName:      "test-name",
 					ScenarioName:  "scenario1",
-					SnapshotName:  "snapshot-sample",
+					ObjectName:    "snapshot-sample",
 					ComponentName: "component-sample",
 					Status:        integrationteststatus.IntegrationTestStatusInProgress,
 					Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 is in progress",
@@ -520,7 +520,7 @@ var _ = Describe("GitHubReporter", func() {
 				status.TestReport{
 					FullName:      "fullname/scenario1",
 					ScenarioName:  "scenario1",
-					SnapshotName:  "snapshot-sample",
+					ObjectName:    "snapshot-sample",
 					ComponentName: "component-sample",
 					Status:        integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
 					Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 failed",
@@ -540,7 +540,7 @@ var _ = Describe("GitHubReporter", func() {
 				status.TestReport{
 					FullName:      "fullname/scenario1",
 					ScenarioName:  "scenario1",
-					SnapshotName:  "snapshot-sample",
+					ObjectName:    "snapshot-sample",
 					ComponentName: "component-sample",
 					Status:        integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
 					Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 failed",

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -315,7 +315,7 @@ var _ = Describe("GitLabReporter", func() {
 			report := status.TestReport{
 				FullName:     "fullname/scenario1",
 				ScenarioName: "scenario1",
-				SnapshotName: "snapshot-sample",
+				ObjectName:   "snapshot-sample",
 				Status:       integrationteststatus.IntegrationTestStatusTestPassed,
 				Summary:      summary,
 				Text:         "detailed text here",
@@ -330,7 +330,7 @@ var _ = Describe("GitLabReporter", func() {
 			notes := []*gitlab.Note{
 				&note,
 			}
-			existingNoteID := reporter.GetExistingNoteID(notes, report.ScenarioName, report.SnapshotName)
+			existingNoteID := reporter.GetExistingNoteID(notes, report.ScenarioName, report.ObjectName)
 
 			Expect(*existingNoteID).To(Equal(note.ID))
 		})

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -44,6 +44,10 @@ const (
 
 	// PipelineAsCodePullRequestLabel is the type of event which triggered the pipelinerun in build service
 	PipelineAsCodePullRequestLabel = "pipelinesascode.tekton.dev/pull-request"
+
+	// SnapshotCreationReportAnnotation contains metadata of snapshot creation status reporting to git provider
+	// to initialize integration test
+	SnapshotCreationReportAnnotation = "test.appstudio.openshift.io/snapshot-creation-report"
 )
 
 // AnnotateBuildPipelineRun sets annotation for a build pipelineRun in defined context and returns that pipeline
@@ -121,4 +125,12 @@ func GenerateSHA(str string) string {
 // IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
 func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
 	return !metadata.HasLabel(plr, PipelineAsCodePullRequestLabel)
+}
+
+func IsIntegrationTestReportInitialized(plr *tektonv1.PipelineRun) bool {
+	return metadata.HasAnnotation(plr, SnapshotCreationReportAnnotation) && !h.HasPipelineRunFinished(plr)
+}
+
+func IsSnapshotCreationFailureReported(plr *tektonv1.PipelineRun) bool {
+	return metadata.HasAnnotationWithValue(plr, SnapshotCreationReportAnnotation, "") && h.HasPipelineRunSucceeded(plr)
 }

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -36,6 +36,8 @@ const (
 	// main branch in github/gitlab
 	MainBranch = "main"
 
+	PipelineAsCodeInstallationIDAnnotation = "pipelinesascode.tekton.dev/installation-id"
+
 	// PipelineAsCodeSourceBranchAnnotation is the branch name of the the pull request is created from
 	PipelineAsCodeSourceBranchAnnotation = "pipelinesascode.tekton.dev/source-branch"
 
@@ -44,10 +46,6 @@ const (
 
 	// PipelineAsCodePullRequestLabel is the type of event which triggered the pipelinerun in build service
 	PipelineAsCodePullRequestLabel = "pipelinesascode.tekton.dev/pull-request"
-
-	// SnapshotCreationReportAnnotation contains metadata of snapshot creation status reporting to git provider
-	// to initialize integration test
-	SnapshotCreationReportAnnotation = "test.appstudio.openshift.io/snapshot-creation-report"
 )
 
 // AnnotateBuildPipelineRun sets annotation for a build pipelineRun in defined context and returns that pipeline
@@ -125,12 +123,4 @@ func GenerateSHA(str string) string {
 // IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
 func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
 	return !metadata.HasLabel(plr, PipelineAsCodePullRequestLabel)
-}
-
-func IsIntegrationTestReportInitialized(plr *tektonv1.PipelineRun) bool {
-	return metadata.HasAnnotation(plr, SnapshotCreationReportAnnotation) && !h.HasPipelineRunFinished(plr)
-}
-
-func IsSnapshotCreationFailureReported(plr *tektonv1.PipelineRun) bool {
-	return metadata.HasAnnotationWithValue(plr, SnapshotCreationReportAnnotation, "") && h.HasPipelineRunSucceeded(plr)
 }


### PR DESCRIPTION
* set integration tests status to pending when pr build plr is triggered or
   retriggered
* set integration test status to failed/cancelled when pr build plr fails
* set integration test status to failed/cancelled with failure reason when pr snapshot is not
   created to shown to users on git provider
    
Signed-off-by: Hongwei Liu<hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
