### PR TITLE
fix(STONEINTG-1110): fix for IsSnapshotCreatedByPACPushEvent

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -678,7 +678,7 @@ func IsSnapshotCreatedByPACPushEvent(snapshot *applicationapiv1alpha1.Snapshot) 
 	return metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodePushType) ||
 		metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodeGLPushType) ||
 		!metadata.HasLabel(snapshot, PipelineAsCodeEventTypeLabel) ||
-		!metadata.HasLabel(snapshot, PipelineAsCodePullRequestAnnotation)
+		!metadata.HasLabel(snapshot, PipelineAsCodePullRequestAnnotation) && !IsGroupSnapshot(snapshot)
 }
 
 // IsSnapshotCreatedBySamePACEvent checks if the two snapshot are created by the same PAC event

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -844,6 +844,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			})
 
 			It("Testing annotating snapshot", func() {
+				hasSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePullRequestType
 				componentSnapshotInfos := []gitops.ComponentSnapshotInfo{
 					{
 						Component:        "com1",
@@ -862,6 +863,8 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(componentSnapshotInfos).To(HaveLen(2))
 				Expect(snapshot.Labels[gitops.SnapshotTypeLabel]).To(Equal("group"))
+				Expect(gitops.IsSnapshotCreatedByPACPushEvent(snapshot)).To(BeFalse())
+
 			})
 
 			It("Testing UnmarshalJSON", func() {


### PR DESCRIPTION
 fix func IsSnapshotCreatedByPACPushEvent for group snapshot

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
