### PR TITLE
fix(KONFLUX-5949): prevent pipelineRun timeout validation failures

### DIFF
--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -306,5 +306,14 @@ func (r *IntegrationPipelineRun) WithIntegrationTimeouts(integrationTestScenario
 		}
 	}
 
+	// If the sum of tasks and finally timeout durations is greater than the pipeline timeout duration,
+	// increase the pipeline timeout to prevent a pipelineRun validation failure
+	if r.Spec.Timeouts.Tasks != nil && r.Spec.Timeouts.Finally != nil && r.Spec.Timeouts.Pipeline != nil &&
+		r.Spec.Timeouts.Tasks.Duration+r.Spec.Timeouts.Finally.Duration > r.Spec.Timeouts.Pipeline.Duration {
+		r.Spec.Timeouts.Pipeline = &metav1.Duration{Duration: r.Spec.Timeouts.Tasks.Duration + r.Spec.Timeouts.Finally.Duration}
+		logger.Info(fmt.Sprintf("Setting the pipeline timeout for %s to be the sum of tasks + finally: %.1f hours", r.Name,
+			r.Spec.Timeouts.Pipeline.Duration.Hours()))
+	}
+
 	return r
 }


### PR DESCRIPTION
* If the sum of tasks and finally timeout durations is greater than the pipeline timeout duration, set the pipeline timeout to that sum in order to prevent a pipelineRun validation failure

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
