### PR TITLE
 feat(KONFLUX-5971): set intg test status in git according to PR bld PLR

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -16,6 +16,7 @@ new_pipeline_run_without_prgroup{PR group is added to pipelineRun metadata?}
 get_pipeline_run{Pipeline updated?}
 failed_pipeline_run{Pipeline failed?}
 finalizer_exists{Does the finalizer already exist?}
+need_to_set_integration_test{Build pipelineRun is newly triggered?<br>Or Build pipelineRun failed?<br> Or Failing to create snapshot?}
 retrieve_associated_entity(Retrieve the entity <br> component/application)
 determine_snapshot{Does a snapshot exist?}
 prep_snapshot(Gather Application components<br> Add new component)
@@ -28,12 +29,15 @@ continue[Continue processing]
 update_metadata(add PR group info to build pipelineRun metadata)
 notify_pr_group_failure(annotate Snapshots and in-flight builds in PR group with failure message)
 failed_group_pipeline_run{Pipeline failed?}
+update_integrationTestStatus_in_git_provider(Create checkRun/commitStatus in<br>git provider)
+update_build_plr_annotation(Update build pipelineRun annotation<br>test.appstudio.openshift.io/snapshot-creation-report<br>with the status)
 
 %% Node connections
 predicate                        --> get_pipeline_run
 predicate                       -->  new_pipeline_run
 predicate                       -->  new_pipeline_run_without_prgroup
 predicate                       -->  failed_pipeline_run
+predicate                       -->  need_to_set_integration_test
 new_pipeline_run           --Yes-->  finalizer_exists
 finalizer_exists           --No-->   add_finalizer
 add_finalizer                    --> continue
@@ -55,6 +59,10 @@ prep_snapshot                    --> check_chains
 check_chains               --Yes --> annotate_pipelineRun
 annotate_pipelineRun       --Yes --> remove_finalizer
 remove_finalizer                 --> continue
+need_to_set_integration_test  --Yes --> update_integrationTestStatus_in_git_provider
+need_to_set_integration_test  --No  --> continue
+update_integrationTestStatus_in_git_provider --> update_build_plr_annotation
+update_build_plr_annotation --> continue
 
 %% Assigning styles to nodes
 class predicate Amber;

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -233,6 +233,9 @@ const (
 
 	//IntegrationTestStatusInProgressGithub is the status reported to github when integration test is in progress
 	IntegrationTestStatusInProgressGithub = "in_progress"
+
+	//IntegrationTestStatusCancelledGithub is the status reported to github when integration test is cancelled
+	IntegrationTestStatusCancelledGithub = "cancelled"
 )
 
 var (

--- a/helpers/build.go
+++ b/helpers/build.go
@@ -1,3 +1,10 @@
 package helpers
 
-const CreateSnapshotAnnotationName = "test.appstudio.openshift.io/create-snapshot-status"
+const (
+	// CreateSnapshotAnnotationName contains metadata of snapshot creation failure or success
+	CreateSnapshotAnnotationName = "test.appstudio.openshift.io/create-snapshot-status"
+
+	// SnapshotCreationReportAnnotation contains metadata of snapshot creation status reporting to git provider
+	// to initialize integration test or set it to cancelled or failed
+	SnapshotCreationReportAnnotation = "test.appstudio.openshift.io/snapshot-creation-report"
+)

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -119,6 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsurePipelineIsFinalized,
 		adapter.EnsurePRGroupAnnotated,
 		adapter.EnsureSnapshotExists,
+		adapter.EnsureIntegrationTestReportedToGitProvider,
 	})
 }
 
@@ -127,6 +128,7 @@ type AdapterInterface interface {
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureSnapshotExists() (controller.OperationResult, error)
+	EnsureIntegrationTestReportedToGitProvider() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -221,7 +221,7 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 
 	allIntegrationTestScenarios, err := a.loader.GetAllIntegrationTestScenariosForApplication(a.context, a.client, a.application)
 	if err != nil {
-		a.logger.Error(err, "Failed to get Integration test scenarios for the following application",
+		a.logger.Error(err, "Failed to get integration test scenarios for the following application",
 			"Application.Namespace", a.application.Namespace)
 	}
 

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -1076,7 +1076,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 			})
 			result, err := adapter.EnsureIntegrationPipelineRunsExist()
-			Expect(buf.String()).Should(ContainSubstring("Failed to get Integration test scenarios for the following application"))
+			Expect(buf.String()).Should(ContainSubstring("Failed to get integration test scenarios for the following application"))
 			Expect(buf.String()).Should(ContainSubstring("Failed to get all required IntegrationTestScenarios"))
 			Expect(result.CancelRequest).To(BeTrue())
 			Expect(result.RequeueRequest).To(BeFalse())

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -291,7 +291,7 @@ func (a *Adapter) ReportSnapshotStatus(testedSnapshot *applicationapiv1alpha1.Sn
 	}
 
 	if err != nil {
-		return fmt.Errorf("issue occured during generating or updating report status: %w", err)
+		return fmt.Errorf("issue occurred during generating or updating report status: %w", err)
 	}
 
 	a.logger.Info(fmt.Sprintf("Successfully updated the %s annotation", gitops.SnapshotStatusReportAnnotation), "snapshot.Name", testedSnapshot.Name)

--- a/pkg/integrationteststatus/integration_test_status.go
+++ b/pkg/integrationteststatus/integration_test_status.go
@@ -45,6 +45,12 @@ const (
 	IntegrationTestStatusTestPassed // TestPassed
 	// Integration PLR is invalid
 	IntegrationTestStatusTestInvalid // TestInvalid
+	// Build PLR is in progress
+	BuildPLRInProgress // BuildPLRInProgress
+	// Snapshot is not created
+	SnapshotCreationFailed // SnapshotCreationFailed
+	// Build pipelinerun failed
+	BuildPLRFailed // BuildPLRFailed
 )
 
 const integrationTestStatusesSchema = `{
@@ -168,7 +174,7 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestStatusIfChanged(scenarioN
 			detail.StartTime = &timestamp
 			// null CompletionTime because testing started again
 			detail.CompletionTime = nil
-		case IntegrationTestStatusPending:
+		case IntegrationTestStatusPending, BuildPLRInProgress:
 			// null all timestamps as test is not inProgress neither in final state
 			detail.StartTime = nil
 			detail.CompletionTime = nil
@@ -177,7 +183,10 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestStatusIfChanged(scenarioN
 			IntegrationTestStatusDeleted,
 			IntegrationTestStatusTestFail,
 			IntegrationTestStatusTestPassed,
-			IntegrationTestStatusTestInvalid:
+			IntegrationTestStatusTestInvalid,
+			SnapshotCreationFailed,
+			BuildPLRFailed:
+
 			detail.CompletionTime = &timestamp
 		}
 	}

--- a/pkg/integrationteststatus/integrationteststatus_enumer.go
+++ b/pkg/integrationteststatus/integrationteststatus_enumer.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-const _IntegrationTestStatusName = "PendingInProgressDeletedEnvironmentProvisionErrorDeploymentErrorTestFailTestPassedTestInvalid"
+const _IntegrationTestStatusName = "PendingInProgressDeletedEnvironmentProvisionErrorDeploymentErrorTestFailTestPassedTestInvalidBuildPLRInProgressSnapshotCreationFailedBuildPLRFailed"
 
-var _IntegrationTestStatusIndex = [...]uint8{0, 7, 17, 24, 49, 64, 72, 82, 93}
+var _IntegrationTestStatusIndex = [...]uint8{0, 7, 17, 24, 49, 64, 72, 82, 93, 111, 133, 147}
 
 func (i IntegrationTestStatus) String() string {
 	i -= 1
@@ -22,14 +22,17 @@ func (i IntegrationTestStatus) String() string {
 var _IntegrationTestStatusValues = []IntegrationTestStatus{1, 2, 3, 4, 5, 6, 7, 8}
 
 var _IntegrationTestStatusNameToValueMap = map[string]IntegrationTestStatus{
-	_IntegrationTestStatusName[0:7]:   1,
-	_IntegrationTestStatusName[7:17]:  2,
-	_IntegrationTestStatusName[17:24]: 3,
-	_IntegrationTestStatusName[24:49]: 4,
-	_IntegrationTestStatusName[49:64]: 5,
-	_IntegrationTestStatusName[64:72]: 6,
-	_IntegrationTestStatusName[72:82]: 7,
-	_IntegrationTestStatusName[82:93]: 8,
+	_IntegrationTestStatusName[0:7]:     1,
+	_IntegrationTestStatusName[7:17]:    2,
+	_IntegrationTestStatusName[17:24]:   3,
+	_IntegrationTestStatusName[24:49]:   4,
+	_IntegrationTestStatusName[49:64]:   5,
+	_IntegrationTestStatusName[64:72]:   6,
+	_IntegrationTestStatusName[72:82]:   7,
+	_IntegrationTestStatusName[82:93]:   8,
+	_IntegrationTestStatusName[93:111]:  9,
+	_IntegrationTestStatusName[111:133]: 10,
+	_IntegrationTestStatusName[133:147]: 11,
 }
 
 // IntegrationTestStatusString retrieves an enum value from the enum constants string name.

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -518,7 +518,7 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 	var title string
 
 	switch state {
-	case intgteststat.IntegrationTestStatusPending:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.BuildPLRInProgress:
 		title = "Pending"
 	case intgteststat.IntegrationTestStatusInProgress:
 		title = "In Progress"
@@ -530,7 +530,9 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 		title = "Deleted"
 	case intgteststat.IntegrationTestStatusTestPassed:
 		title = "Succeeded"
-	case intgteststat.IntegrationTestStatusTestFail:
+	case intgteststat.IntegrationTestStatusTestFail,
+		intgteststat.SnapshotCreationFailed,
+		intgteststat.BuildPLRFailed:
 		title = "Failed"
 	default:
 		return title, fmt.Errorf("unknown status")
@@ -552,8 +554,11 @@ func generateCheckRunConclusion(state intgteststat.IntegrationTestStatus) (strin
 		conclusion = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		conclusion = gitops.IntegrationTestStatusSuccessGithub
-	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress,
+		intgteststat.BuildPLRInProgress:
 		conclusion = ""
+	case intgteststat.SnapshotCreationFailed, intgteststat.BuildPLRFailed:
+		conclusion = gitops.IntegrationTestStatusCancelledGithub
 	default:
 		return conclusion, fmt.Errorf("unknown status")
 	}
@@ -568,14 +573,16 @@ func generateGithubCommitState(state intgteststat.IntegrationTestStatus) (string
 	var commitState string
 
 	switch state {
-	case intgteststat.IntegrationTestStatusTestFail:
+	case intgteststat.IntegrationTestStatusTestFail, intgteststat.SnapshotCreationFailed,
+		intgteststat.BuildPLRFailed:
 		commitState = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusEnvironmentProvisionError_Deprecated, intgteststat.IntegrationTestStatusDeploymentError_Deprecated,
 		intgteststat.IntegrationTestStatusDeleted, intgteststat.IntegrationTestStatusTestInvalid:
 		commitState = gitops.IntegrationTestStatusErrorGithub
 	case intgteststat.IntegrationTestStatusTestPassed:
 		commitState = gitops.IntegrationTestStatusSuccessGithub
-	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress,
+		intgteststat.BuildPLRInProgress:
 		commitState = gitops.IntegrationTestStatusPendingGithub
 	default:
 		return commitState, fmt.Errorf("unknown status")

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -284,7 +284,7 @@ func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) er
 
 	// Create a note when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful
 	_, isMergeRequest := r.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
-	if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && isMergeRequest {
+	if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && report.Status != intgteststat.SnapshotCreationFailed && isMergeRequest {
 		err := r.updateStatusInComment(report)
 		if err != nil {
 			return err
@@ -299,7 +299,7 @@ func GenerateGitlabCommitState(state intgteststat.IntegrationTestStatus) (gitlab
 	glState := gitlab.Failed
 
 	switch state {
-	case intgteststat.IntegrationTestStatusPending:
+	case intgteststat.IntegrationTestStatusPending, intgteststat.BuildPLRInProgress:
 		glState = gitlab.Pending
 	case intgteststat.IntegrationTestStatusInProgress:
 		glState = gitlab.Running
@@ -307,7 +307,8 @@ func GenerateGitlabCommitState(state intgteststat.IntegrationTestStatus) (gitlab
 		intgteststat.IntegrationTestStatusDeploymentError_Deprecated,
 		intgteststat.IntegrationTestStatusTestInvalid:
 		glState = gitlab.Failed
-	case intgteststat.IntegrationTestStatusDeleted:
+	case intgteststat.IntegrationTestStatusDeleted,
+		intgteststat.BuildPLRFailed, intgteststat.SnapshotCreationFailed:
 		glState = gitlab.Canceled
 	case intgteststat.IntegrationTestStatusTestPassed:
 		glState = gitlab.Success

--- a/status/status.go
+++ b/status/status.go
@@ -328,11 +328,21 @@ func GenerateSummary(state intgteststat.IntegrationTestStatus, snapshotName, sce
 		statusDesc = "has failed"
 	case intgteststat.IntegrationTestStatusTestInvalid:
 		statusDesc = "is invalid"
+	case intgteststat.BuildPLRInProgress:
+		statusDesc = "is pending because build pipelinerun is still running and snapshot has not been created"
+	case intgteststat.SnapshotCreationFailed:
+		statusDesc = "has not run and is considered as failed because the snapshot was not created"
+	case intgteststat.BuildPLRFailed:
+		statusDesc = "has not run and is considered as failed because the build pipelinerun failed and snapshot was not created"
 	default:
 		return summary, fmt.Errorf("unknown status")
 	}
 
-	summary = fmt.Sprintf("Integration test for snapshot %s and scenario %s %s", snapshotName, scenarioName, statusDesc)
+	if state == intgteststat.BuildPLRInProgress || state == intgteststat.SnapshotCreationFailed || state == intgteststat.BuildPLRFailed {
+		summary = fmt.Sprintf("Integration test for scenario %s %s", scenarioName, statusDesc)
+	} else {
+		summary = fmt.Sprintf("Integration test for snapshot %s and scenario %s %s", snapshotName, scenarioName, statusDesc)
+	}
 
 	return summary, nil
 }

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -583,6 +583,22 @@ var _ = Describe("Status Adapter", func() {
 		Entry("Invalid", integrationteststatus.IntegrationTestStatusTestInvalid, "is invalid"),
 	)
 
+	DescribeTable(
+		"report right summary per status",
+		func(expectedScenarioStatus integrationteststatus.IntegrationTestStatus, expectedTextEnding string) {
+
+			integrationTestStatusDetail := newIntegrationTestStatusDetail(expectedScenarioStatus)
+
+			expectedSummary := fmt.Sprintf("Integration test for scenario scenario1 %s", expectedTextEnding)
+			testReport, err := status.GenerateTestReport(context.Background(), mockK8sClient, integrationTestStatusDetail, hasSnapshot, "component-sample")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(testReport.Summary).To(Equal(expectedSummary))
+		},
+		Entry("BuildPLRInProgress", integrationteststatus.BuildPLRInProgress, "is pending because build pipelinerun is still running and snapshot has not been created"),
+		Entry("SnapshotCreationFailed", integrationteststatus.SnapshotCreationFailed, "has not run and is considered as failed because the snapshot was not created"),
+		Entry("BuildPLRFailed", integrationteststatus.BuildPLRFailed, "has not run and is considered as failed because the build pipelinerun failed and snapshot was not created"),
+	)
+
 	It("check if GenerateSummary supports all integration test statuses", func() {
 		for _, teststatus := range integrationteststatus.IntegrationTestStatusValues() {
 			_, err := status.GenerateSummary(teststatus, "yolo", "yolo")


### PR DESCRIPTION
* set integration tests status to pending when build plr is triggered or retriggered
* set integration test status to failed/cancelled when build plr fails
* set integration test status to failed/cancelled with failure reason when snapshot is not created to show to users on git provider

Signed-off-by: Hongwei Liu<hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
