### PR TITLE
fix(STONEINTG-1100): don't report status for manual Snapshots

### DIFF
--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -99,8 +99,9 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		return controller.RequeueWithError(fmt.Errorf("failed to update test status in snapshot: %w", err))
 	}
 
-	// Remove the finalizer from Integration PLRs if the snapshot is the override and its PLR has finished
-	if gitops.IsOverrideSnapshot(a.snapshot) && (h.HasPipelineRunFinished(a.pipelineRun) || pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
+	// Remove the finalizer from Integration PLRs if the snapshot is not group or component type and its PLR has finished
+	if (!gitops.IsGroupSnapshot(a.snapshot) && !gitops.IsComponentSnapshot(a.snapshot)) && (h.HasPipelineRunFinished(a.pipelineRun) ||
+		pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
 		err = h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
 		if err != nil {
 			return controller.RequeueWithError(fmt.Errorf("failed to remove the finalizer: %w", err))

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -71,7 +71,8 @@ func NewAdapter(context context.Context, snapshot *applicationapiv1alpha1.Snapsh
 // The status is reported to git provider if it is a component snapshot
 // Or reported to git providers which trigger component snapshots included in group snapshot if it is a group snapshot
 func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.OperationResult, error) {
-	if gitops.IsOverrideSnapshot(a.snapshot) {
+	// Only report status for component or group Snapshots
+	if !gitops.IsGroupSnapshot(a.snapshot) && !gitops.IsComponentSnapshot(a.snapshot) {
 		return controller.ContinueProcessing()
 	}
 	err := a.ReportSnapshotStatus(a.snapshot)


### PR DESCRIPTION
* update the initial condition in the EnsureSnapshotTestStatusReportedToGitProvider function to only process component and group snapshots
* Remove the finalizer from Integration PLRs if the snapshot is not group or component type and its PLR has finished or has been deleted

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
