### PR TITLE
fix(STONEINTG-1087): retry longer to fetch App from ITS, and stop processing if not found

### DIFF
--- a/internal/controller/scenario/scenario_adapter.go
+++ b/internal/controller/scenario/scenario_adapter.go
@@ -69,8 +69,6 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 		return controller.ContinueProcessing()
 	}
 
-	// application exist, always log it
-	a.logger = a.logger.WithApp(*a.application)
 	// Checks if scenario has ownerReference assigned to it
 	if a.scenario.OwnerReferences == nil {
 		patch := client.MergeFrom(a.scenario.DeepCopy())

--- a/internal/controller/scenario/scenario_adapter.go
+++ b/internal/controller/scenario/scenario_adapter.go
@@ -69,20 +69,6 @@ func (a *Adapter) EnsureCreatedScenarioIsValid() (controller.OperationResult, er
 		return controller.ContinueProcessing()
 	}
 
-	// Check if application exists or not
-	if a.application == nil {
-		a.logger.Info("Application for Scenario was not found.")
-
-		patch := client.MergeFrom(a.scenario.DeepCopy())
-		h.SetScenarioIntegrationStatusAsInvalid(a.scenario, "Failed to get application for Scenario.")
-		err := a.client.Status().Patch(a.context, a.scenario, patch)
-		if err != nil {
-			a.logger.Error(err, "Failed to update Scenario")
-			return controller.RequeueWithError(err)
-		}
-		return controller.ContinueProcessing()
-	}
-
 	// application exist, always log it
 	a.logger = a.logger.WithApp(*a.application)
 	// Checks if scenario has ownerReference assigned to it

--- a/internal/controller/scenario/scenario_adapter_test.go
+++ b/internal/controller/scenario/scenario_adapter_test.go
@@ -149,16 +149,6 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 		Expect(reflect.TypeOf(NewAdapter(ctx, hasApp, invalidScenario, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
-	It("EnsureCreatedScenarioIsValid without app", func() {
-		a := NewAdapter(ctx, nil, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient)
-
-		Eventually(func() bool {
-			result, err := a.EnsureCreatedScenarioIsValid()
-			return !result.CancelRequest && err == nil
-		}, time.Second*10).Should(BeTrue())
-
-	})
-
 	It("ensures the integrationTestPipelines are created", func() {
 		Eventually(func() bool {
 			result, err := adapter.EnsureCreatedScenarioIsValid()

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -103,6 +103,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return ctrl.Result{}, nil
 	}
 
+	logger = logger.WithApp(*application)
+
 	adapter := NewAdapter(ctx, application, scenario, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -18,6 +18,7 @@ package scenario
 
 import (
 	"context"
+	"time"
 
 	"github.com/konflux-ci/integration-service/loader"
 
@@ -29,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -75,15 +77,30 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	var application *applicationapiv1alpha1.Application
-	err = retry.OnError(retry.DefaultRetry, func(_ error) bool { return true }, func() error {
+	var CustomRetry = wait.Backoff{
+		Steps:    5,
+		Duration: 10 * time.Second, // Default was 10 milliseconds
+		Factor:   1.0,
+		Jitter:   0.1,
+	}
+	err = retry.OnError(CustomRetry, func(_ error) bool { return true }, func() error {
 		application, err = r.getApplicationFromScenario(ctx, scenario)
 		if err != nil {
-			logger.Info("Failed to get Application from the IntegrationTestScenario, try again", "error:", err)
+			logger.Info("Failed to get Application from the IntegrationTestScenario, trying again", "error:", err)
 		}
 		return err
 	})
 	if err != nil {
-		logger.Error(err, "Failed to get Application from the IntegrationTestScenario after retry", "application", scenario.Spec.Application)
+		errString := "Failed to get Application from the IntegrationTestScenario even after retrying"
+		logger.Error(err, errString, "application", scenario.Spec.Application)
+		patch := client.MergeFrom(scenario.DeepCopy())
+		helpers.SetScenarioIntegrationStatusAsInvalid(scenario, errString)
+		err := r.Client.Status().Patch(ctx, scenario, patch)
+		if err != nil {
+			logger.Error(err, "Failed to update Scenario as Invalid")
+			return ctrl.Result{}, err
+		}
+		return ctrl.Result{}, nil
 	}
 
 	adapter := NewAdapter(ctx, application, scenario, logger, loader, r.Client)


### PR DESCRIPTION
* There are some cases where the App and ITS are created almost at the same time.
* This causes a problem when the App is not found while the controllers reconcile ITS.
* To fix this, we increased the retry time from 10 ms to 10 seconds. This should give enough time to fetch the App.
* And if we're still unable to find App, we stop reconciling, since there's no point in reconciling an ITS without any parent.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
