### PR TITLE
feat(KFLUXDP-109): enable test-results-analyzer

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -48,7 +48,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -58,7 +58,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -68,35 +68,19 @@ spec:
           value: $(params.SNAPSHOT)
         - name: test-name
           value: $(context.pipelineRun.name)
-    - name: create-oci-container
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/create-oci-artifact/0.1/create-oci-artifact.yaml
-      params:
-        - name: oci-container-repo
-          value: $(params.oci-container-repo)
-        - name: oci-container-tag
-          value: $(context.pipelineRun.name)
     - name: provision-rosa
       runAfter:
         - rosa-hcp-metadata
         - test-metadata
-        - create-oci-container
       taskRef:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-provision/rosa-hcp-provision.yaml
+            value: tasks/rosa/hosted-cp/rosa-hcp-provision/0.2/rosa-hcp-provision.yaml
       params:
         - name: cluster-name
           value: $(tasks.rosa-hcp-metadata.results.cluster-name)
@@ -110,6 +94,8 @@ spec:
           value: $(params.konflux-test-infra-secret)
         - name: cloud-credential-key
           value: $(params.cloud-credential-key)
+        - name: oci-container
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
     - name: konflux-e2e-tests
       timeout: 2h
       runAfter:
@@ -133,7 +119,7 @@ spec:
         - name: git-revision
           value: $(tasks.test-metadata.results.git-revision)
         - name: oras-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: job-spec
           value: $(tasks.test-metadata.results.job-spec)
         - name: ocp-login-command
@@ -146,18 +132,18 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/rosa/hosted-cp/rosa-hcp-deprovision/rosa-hcp-deprovision.yaml
+            value: tasks/rosa/hosted-cp/rosa-hcp-deprovision/0.2/rosa-hcp-deprovision.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)
         - name: ocp-login-command
           value: $(tasks.provision-rosa.results.ocp-login-command)
         - name: oci-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: pull-request-author
           value: $(tasks.test-metadata.results.pull-request-author)
         - name: git-revision
@@ -181,14 +167,14 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
             value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
       params:
         - name: oci-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: quality-dashboard-api
           value: $(params.quality-dashboard-api)
         - name: pipeline-aggregate-status
@@ -202,7 +188,7 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/konflux-qe-definitions.git
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
           - name: revision
             value: main
           - name: pathInRepo
@@ -211,7 +197,7 @@ spec:
         - name: test-name
           value: $(context.pipelineRun.name)
         - name: oci-container
-          value: $(tasks.create-oci-container.results.oci-container)
+          value: $(params.oci-container-repo):$(context.pipelineRun.name)
         - name: pipeline-aggregate-status
           value: $(tasks.status)
         - name: pull-request-author
@@ -224,3 +210,11 @@ spec:
           value: $(tasks.test-metadata.results.git-org)
         - name: git-revision
           value: $(tasks.test-metadata.results.git-revision)
+        - name: junit-report-name
+          value: e2e-report.xml
+        - name: e2e-log-name
+          value: e2e-tests.log
+        - name: cluster-provision-log-name
+          value: cluster-provision.log
+        - name: enable-test-results-analysis
+          value: "true"


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


### Description
Update integration-test pipeline to enable test-results-analyzer
https://issues.redhat.com/browse/KFLUXDP-109

![Screenshot 2025-01-20 at 14 33 37](https://github.com/user-attachments/assets/0f859506-79ff-4d9c-be4e-4008734c4563)

