### PR TITLE
fix(STONEINTG-1096): remove pr name from integration test report title

### DIFF
--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -308,7 +308,7 @@ func (a *Adapter) iterateIntegrationTestStatusDetailsInStatusReport(reporter sta
 	// set componentName to component name of component snapshot or pr group name of group snapshot when reporting status to git provider
 	componentName := ""
 	if gitops.IsGroupSnapshot(testedSnapshot) {
-		componentName = "pr group " + testedSnapshot.Annotations[gitops.PRGroupAnnotation]
+		componentName = "pr group"
 	} else if gitops.IsComponentSnapshot(testedSnapshot) {
 		componentName = testedSnapshot.Labels[gitops.SnapshotComponentLabel]
 	} else {


### PR DESCRIPTION
* remove pr name from integration test report in checkRun and commitStatus


Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
