### PR TITLE
chore(RELEASE-1227): remove owner and labels on created releases

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -657,18 +657,6 @@ func (a *Adapter) createMissingReleasesForReleasePlans(application *applicationa
 				"release.Name", existingRelease.Name)
 		} else {
 			newRelease := release.NewReleaseForReleasePlan(&releasePlan, snapshot)
-			// Propagate PAC annotations/labels from Snapshot to Release
-			_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &newRelease.ObjectMeta, gitops.PipelinesAsCodePrefix)
-			_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &newRelease.ObjectMeta, gitops.PipelinesAsCodePrefix)
-
-			// Propagate annotations/labels prefixed with 'appstudio.openshift.io' from Snapshot to Release
-			_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &newRelease.ObjectMeta, gitops.AppstudioLabelPrefix)
-			_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &newRelease.ObjectMeta, gitops.AppstudioLabelPrefix)
-
-			err := ctrl.SetControllerReference(application, newRelease, a.client.Scheme())
-			if err != nil {
-				return err
-			}
 			err = a.client.Create(a.context, newRelease)
 			if err != nil {
 				return err

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -905,32 +905,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
 		})
 
-		It("ensures Snapshot labels/annotations prefixed with 'appstudio.openshift.io' are propagated to the release", func() {
-			releasePlans := []releasev1alpha1.ReleasePlan{*testReleasePlan}
-			releaseList := &releasev1alpha1.ReleaseList{}
-			err := adapter.createMissingReleasesForReleasePlans(hasApp, &releasePlans, hasSnapshot)
-
-			Expect(err).To(BeNil())
-
-			opts := []client.ListOption{
-				client.InNamespace(hasApp.Namespace),
-				client.MatchingLabels{
-					"appstudio.openshift.io/component": hasComp.Name,
-					//"appstudio.openshift.io/application": hasApp.Name,
-				},
-			}
-
-			Eventually(func() error {
-				if err := k8sClient.List(adapter.context, releaseList, opts...); err != nil {
-					return err
-				}
-				if len(releaseList.Items) > 0 {
-					Expect(releaseList.Items[0].ObjectMeta.Labels["appstudio.openshift.io/component"]).To(Equal(hasComp.Name))
-				}
-				return nil
-			}, time.Second*10).Should(BeNil())
-		})
-
 		It("no action when EnsureAllReleasesExist function runs when AppStudio Tests failed and the snapshot is invalid", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 


### PR DESCRIPTION
This commit removes the part of the snapshot adapter that adds an owner reference and copies the PaC and openshift labels/annotations from the snapshot to the Release CR. This code is being moved to the release adapter instead so that manual and automatic releases are handled the same.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
