### PR TITLE
feat(STONEINTG-1068): add SHA value in Release CR name

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -1158,3 +1158,27 @@ func GetSourceRepoOwnerFromSnapshot(snapshot *applicationapiv1alpha1.Snapshot) s
 	}
 	return ""
 }
+
+// GetShaFromSnapshot returns the value of "pac.test.appstudio.openshift.io/sha"
+// annotation of length 7 for short SHA from the Snapshot, if it exists.
+// If the SHA is shorter than 7 characters, it returns it as is.
+// If the SHA is empty, it logs an info message and returns an empty string.
+func GetShaFromSnapshot(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) string {
+	log := log.FromContext(ctx)
+
+	sha, found := snapshot.GetAnnotations()[PipelineAsCodeSHAAnnotation]
+	if found {
+		if len(sha) == 0 {
+			log.Info(fmt.Sprintf("annotation '%s' in Snapshot '%s' is present but empty", PipelineAsCodeSHAAnnotation, snapshot.Name))
+			return ""
+		}
+		if len(sha) >= 7 {
+			return sha[:7]
+		}
+		return sha // Return as is if shorter than 7 characters
+	}
+
+	log.Info(fmt.Sprintf("annotation '%s' not found in Snapshot '%s', won't add SHA value to the Release name", PipelineAsCodeSHAAnnotation, snapshot.Name))
+
+	return ""
+}

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -656,7 +656,7 @@ func (a *Adapter) createMissingReleasesForReleasePlans(application *applicationa
 				"releasePlan.Name", releasePlan.Name,
 				"release.Name", existingRelease.Name)
 		} else {
-			newRelease := release.NewReleaseForReleasePlan(&releasePlan, snapshot)
+			newRelease := release.NewReleaseForReleasePlan(a.context, &releasePlan, snapshot)
 			err = a.client.Create(a.context, newRelease)
 			if err != nil {
 				return err

--- a/release/releaseplan.go
+++ b/release/releaseplan.go
@@ -17,17 +17,25 @@ limitations under the License.
 package release
 
 import (
+	"context"
+
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/gitops"
 	releasev1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	releasemetadata "github.com/konflux-ci/release-service/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // NewReleaseForReleasePlan creates the Release for a given ReleasePlan.
-func NewReleaseForReleasePlan(releasePlan *releasev1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) *releasev1alpha1.Release {
+func NewReleaseForReleasePlan(ctx context.Context, releasePlan *releasev1alpha1.ReleasePlan, snapshot *applicationapiv1alpha1.Snapshot) *releasev1alpha1.Release {
+	shaShort := gitops.GetShaFromSnapshot(ctx, snapshot)
+	if shaShort != "" {
+		shaShort = "-" + shaShort
+	}
+
 	newRelease := &releasev1alpha1.Release{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: snapshot.Name + "-",
+			GenerateName: snapshot.Name + shaShort + "-",
 			Namespace:    snapshot.Namespace,
 			Labels: map[string]string{
 				releasemetadata.AutomatedLabel: "true",


### PR DESCRIPTION
* This is useful for a developer who has enabled auto-releases for their Application.
* They will now have a deterministic way to find the Release related to a particular code change
* They can search Release CR with the short SHA value (first 7 chars) belonging to their commit
* This will make it easy for them to relate a Release with a code change.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
