### PR TITLE
fix(STONEINTG-1125): fix gitlab commitStatus change from pending to pending

### DIFF
--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -184,9 +184,8 @@ func (r *GitLabReporter) setCommitStatus(report TestReport) error {
 		}
 		existingCommitStatus = r.GetExistingCommitStatus(allCommitStatuses, report.FullName)
 
-		// special case, we want to skip updating commit status if the status from running to running, from enque to pending
-		if existingCommitStatus != nil && (existingCommitStatus.Status == "enqueue" ||
-			existingCommitStatus.Status == string(gitlab.Running)) {
+		// special case, we want to skip updating commit status if the status from running to running, from pending to pending
+		if existingCommitStatus != nil && existingCommitStatus.Status == string(glState) {
 			r.logger.Info("Skipping commit status update",
 				"scenario.name", report.ScenarioName,
 				"commitStatus.ID", existingCommitStatus.ID,
@@ -201,7 +200,7 @@ func (r *GitLabReporter) setCommitStatus(report TestReport) error {
 
 	commitStatus, _, err := r.client.Commits.SetCommitStatus(r.sourceProjectID, r.sha, &opt)
 	if err != nil {
-		return fmt.Errorf("failed to set commit status: %w", err)
+		return fmt.Errorf("failed to set commit status to %s: %w", string(glState), err)
 	}
 
 	r.logger.Info("Created gitlab commit status", "scenario.name", report.ScenarioName, "commitStatus.ID", commitStatus.ID, "TargetURL", opt.TargetURL)


### PR DESCRIPTION
* fix for commitStatus status change from pending to pending

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
