### PR TITLE
fix(stoneintg-1017): validate git resolver in integration test scenario

### DIFF
--- a/api/v1beta2/integrationtestscenario_types_test.go
+++ b/api/v1beta2/integrationtestscenario_types_test.go
@@ -58,7 +58,7 @@ var _ = Describe("IntegrationTestScenario type", func() {
 					Params: []ResolverParameter{
 						{
 							Name:  "url",
-							Value: "http://url",
+							Value: "https://url",
 						},
 						{
 							Name:  "revision",

--- a/api/v1beta2/integrationtestscenario_webhook_test.go
+++ b/api/v1beta2/integrationtestscenario_webhook_test.go
@@ -117,7 +117,7 @@ var _ = Describe("IntegrationTestScenario webhook", func() {
 					Params: []ResolverParameter{
 						{
 							Name:  "url",
-							Value: "http://url",
+							Value: "https://url",
 						},
 						{
 							Name:  "revision",
@@ -142,4 +142,57 @@ var _ = Describe("IntegrationTestScenario webhook", func() {
 		Expect(k8sClient.Create(ctx, integrationTestScenarioInvalidGitResolver)).ShouldNot(Succeed())
 	})
 
+	It("should return nil when string contains neither leading nor trailing whitespace", func() {
+		testString := "this is a test string"
+		err := validateNoWhitespace("testString", testString)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an error when string contains leading whitespace", func() {
+		testString := " this is a test string"
+		err := validateNoWhitespace("testString", testString)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when string contains trailing whitespace", func() {
+		testString := "this is a test string "
+		err := validateNoWhitespace("testString", testString)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return nil when provided with a valid url", func() {
+		url := "https://github.com/konflux-ci/integration-examples"
+		err := validateUrl("serverURL", url)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return an error when provided with an invalid url", func() {
+		url := "konflux-ci/integration-examples"
+		err := validateUrl("serverURL", url)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when provided with a url without 'https://'", func() {
+		url := "http://github.com/konflux-ci/integration-examples"
+		err := validateUrl("serverURL", url)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return an error when url contains whitespace", func() {
+		url := " https://github.com/konflux-ci/integration-examples "
+		err := validateUrl("serverURL", url)
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("should return nil when token is a valid k8s secret name", func() {
+		token := "my-secret"
+		err := validateToken(token)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should return nil when token is a valid k8s secret name", func() {
+		token := "My_Secret"
+		err := validateToken(token)
+		Expect(err).To(HaveOccurred())
+	})
 })


### PR DESCRIPTION
No validation is done on the git resolver in the ITS, which can lead to errors when users attempt to run the tests.  This change adds basic validation to the ITS admission controller to verify that no fields contain leading or trailing whitespace and that URLs and secret names, if provided, are syntactically valid.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
