### PR TITLE
fix: use same tekton task version to build pristine image and sealights images in push events

### DIFF
--- a/.tekton/integration-service-push.yaml
+++ b/.tekton/integration-service-push.yaml
@@ -280,7 +280,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.2@sha256:937f465189482f3279b9491161fff7720d4c443f27e6d9febbf2344268383011
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:63e57ac67f892a0e2990fc18db5c18ef5ad9de1db8df82c25d5813e2f84f5977
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Seems like if not using same tasks version to build pristine and sealights image is broking enterprise contract:

```
✕ [Violation] trusted_task.trusted
  ImageRef: quay.io/redhat-user-workloads/rhtap-integration-tenant/integration-service/integration-service@sha256:e1d230c8de65be3e5a8d0aac8390341fd71522d8a3ab8c7f7d66c79734e52209
  Reason: Code tampering detected, untrusted PipelineTask "build-sealights-container" (Task "buildah-oci-ta") was included in
  build chain comprised of: build-sealights-container, clone-repository, prefetch-dependencies, sealights-go-instrumentation
  Title: Tasks are trusted
  Description: Check the trust of the Tekton Tasks used in the build Pipeline. There are two modes in which trust is verified. The
  first mode is used if Trusted Artifacts are enabled. In this case, a chain of trust is established for all the Tasks involved in
  creating an artifact. If the chain contains an untrusted Task, then a violation is emitted. The second mode is used as a
  fallback when Trusted Artifacts are not enabled. In this case, **all** Tasks in the build Pipeline must be trusted. To exclude
  this rule add "trusted_task.trusted:buildah-oci-ta" to the `exclude` section of the policy configuration.
  Solution: If using Trusted Artifacts, be sure every Task in the build Pipeline responsible for producing a Trusted Artifact is
  trusted. Otherwise, ensure **all** Tasks in the build Pipeline are trusted. Note that trust is eventually revoked from Tasks
  when newer versions are made available.
```
