### PR TITLE
fix(KONFLUX-5832): resync missed integration PLRs

### DIFF
--- a/tekton/predicates.go
+++ b/tekton/predicates.go
@@ -27,8 +27,11 @@ import (
 // integration PipelineRuns that have just started or finished.
 func IntegrationPipelineRunPredicate() predicate.Predicate {
 	return predicate.Funcs{
+		// Create events are triggered upon service re-sync (either every 10hrs or every restart)
+		// This allows for recovery if an event is missed during those times
 		CreateFunc: func(createEvent event.CreateEvent) bool {
-			return false
+			return IsIntegrationPipelineRun(createEvent.Object) &&
+				helpers.HasPipelineRunFinished(createEvent.Object)
 		},
 		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
 			return false

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -166,11 +166,22 @@ var _ = Describe("Predicates", func() {
 			newPipelineRun = pipelineRun.DeepCopy()
 		})
 
-		It("should ignore create events", func() {
+		It("should return ignore create events for unfinished pipelineRuns", func() {
 			contextEvent := event.CreateEvent{
 				Object: pipelineRun,
 			}
 			Expect(instance.Create(contextEvent)).To(BeFalse())
+		})
+
+		It("should return true for create events for finished pipelineRuns", func() {
+			pipelineRun.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: "True",
+			})
+			contextEvent := event.CreateEvent{
+				Object: pipelineRun,
+			}
+			Expect(instance.Create(contextEvent)).To(BeTrue())
 		})
 
 		It("should ignore delete events", func() {

--- a/tekton/predicates_test.go
+++ b/tekton/predicates_test.go
@@ -166,7 +166,7 @@ var _ = Describe("Predicates", func() {
 			newPipelineRun = pipelineRun.DeepCopy()
 		})
 
-		It("should return ignore create events for unfinished pipelineRuns", func() {
+		It("should ignore create events for unfinished pipelineRuns", func() {
 			contextEvent := event.CreateEvent{
 				Object: pipelineRun,
 			}


### PR DESCRIPTION
* Modify the integrationpipeline controller to react to 'create' events in order to handle finished integration PLRs in case their events were missed.
* Modify statusreport controller to react to 'create' events in order to handle Snapshots with updated status annotation in case their events were missed
* Create events are triggered upon service re-sync, either every 10hrs or every restart
* This allows us to record/report the status in the Snapshot and remove the PLR finalizers, as well as to report the missed events

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
