### PR TITLE
chore(stoneintg-1134): update github workflows to ubuntu-24.04

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -5,7 +5,7 @@ on:
       - main
 jobs:
   build-and-deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -18,7 +18,7 @@ jobs:
           dockerfile: Dockerfile
   go-linters:
     name: Go linters
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
@@ -46,7 +46,7 @@ jobs:
           skip-cache: true
   go:
     name: Check sources
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       OPERATOR_SDK_VERSION: v1.18.0
     steps:
@@ -134,7 +134,7 @@ jobs:
         uses: codecov/codecov-action@v5
   gitlint:
     name: Run gitlint checks
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4


### PR DESCRIPTION
The ubuntu-20.04 image for github actions is being deprecated. Workflows that still rely on the image after April 1, 2025 willl no longer work. We need to update to ubuntu-24.04 to avoid this.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
