### PR TITLE
fix(STONEINTG-1136): garbage collector checks konflux user namespaces

### DIFF
--- a/cmd/snapshotgc/snapshotgc_test.go
+++ b/cmd/snapshotgc/snapshotgc_test.go
@@ -598,7 +598,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns3",
 					Labels: map[string]string{
-						"toolchain.dev.openshift.com/type": "tenant",
+						"konflux.ci/type": "user",
 					},
 				},
 			}
@@ -654,7 +654,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns4",
 					Labels: map[string]string{
-						"toolchain.dev.openshift.com/type": "tenant",
+						"konflux.ci/type": "user",
 					},
 				},
 			}


### PR DESCRIPTION
* Since the new Konflux clusters do not use toolchain to provision user tenant namespaces, we need to use a new way to identify them: via the `konflux.ci/type` label

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
