### PR TITLE
chore: remove Pat from integration-service's CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @dheerajodha @14rcole @jencull @chipspeak
-
+* @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @dheerajodha @14rcole @jencull


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
