### PR TITLE
feat(STONEINTG-1131): initialize pending intg status for group ITS

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -2278,8 +2278,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			ctrl := gomock.NewController(GinkgoT())
 			mockStatus := status.NewMockStatusInterface(ctrl)
-			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), hasComSnapshot2).Return(true, nil)
-			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), hasComSnapshot3).Return(true, nil)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot2, nil)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot3, nil)
 			// mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).Return(true, nil)
 			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -309,7 +309,7 @@ func (a *Adapter) iterateIntegrationTestStatusDetailsInStatusReport(reporter sta
 	// set componentName to component name of component snapshot or pr group name of group snapshot when reporting status to git provider
 	componentName := ""
 	if gitops.IsGroupSnapshot(testedSnapshot) {
-		componentName = "pr group"
+		componentName = gitops.ComponentNameForGroupSnapshot
 	} else if gitops.IsComponentSnapshot(testedSnapshot) {
 		componentName = testedSnapshot.Labels[gitops.SnapshotComponentLabel]
 	} else {

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -61,6 +61,7 @@ const (
 	GetComponentSnapshotsKey
 	GetPRSnapshotsKey
 	GetPipelineRunforSnapshotsKey
+	GetComponentsFromSnapshotForPRGroupKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -256,19 +257,27 @@ func (l *mockLoader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx
 }
 
 // GetMatchingComponentSnapshotsForPRGroupHash returns the resource and error passed as values of the context
-func (l *mockLoader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Context, c client.Client, nameSpace, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(GetPRSnapshotsKey) == nil {
-		return l.loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, c, snapshot, prGroupHash)
+		return l.loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPRSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 
-// GetMatchingComponentSnapshotsForPRGroupHash returns the resource and error passed as values of the context
+// GetAllIntegrationPipelineRunsForSnapshot returns the resource and error passed as values of the context
 func (l *mockLoader) GetAllIntegrationPipelineRunsForSnapshot(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot) ([]tektonv1.PipelineRun, error) {
 	if ctx.Value(GetPipelineRunforSnapshotsKey) == nil {
 		return l.loader.GetAllIntegrationPipelineRunsForSnapshot(ctx, adapterClient, snapshot)
 	}
 	pipelineRuns, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPipelineRunforSnapshotsKey, []tektonv1.PipelineRun{})
 	return pipelineRuns, err
+}
+
+func (l *mockLoader) GetComponentsFromSnapshotForPRGroup(ctx context.Context, c client.Client, namespace, prGroup, prGroupHash string) ([]string, error) {
+	if ctx.Value(GetComponentsFromSnapshotForPRGroupKey) == nil {
+		return l.loader.GetComponentsFromSnapshotForPRGroup(ctx, c, namespace, prGroup, prGroupHash)
+	}
+	components, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentsFromSnapshotForPRGroupKey, []string{})
+	return components, err
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -345,8 +345,23 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(mockContext, nil, nil, "")
+			resource, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(mockContext, nil, "", "")
 			Expect(resource).To(Equal(&snapshots))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("When calling GetComponentsFromSnapshotForPRGroup", func() {
+		It("return resource and error from the context", func() {
+			components := []string{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetComponentsFromSnapshotForPRGroupKey,
+					Resource:   components,
+				},
+			})
+			resource, err := loader.GetComponentsFromSnapshotForPRGroup(mockContext, nil, "", "", "")
+			Expect(resource).To(Equal(components))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -703,11 +703,18 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get matching snapshot for pr group hash", func() {
-			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, k8sClient, hasSnapshot, "featuresha")
+			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, k8sClient, "", "featuresha")
 			Expect(err).To(Succeed())
 			Expect((*fetchedSnapshots)[0].Name).To(Equal(hasSnapshot.Name))
 			Expect((*fetchedSnapshots)[0].Namespace).To(Equal(hasSnapshot.Namespace))
 			Expect((*fetchedSnapshots)[0].Spec).To(Equal(hasSnapshot.Spec))
+		})
+
+		It("Can get matching components from snapshots for pr group hash", func() {
+			components, err := loader.GetComponentsFromSnapshotForPRGroup(ctx, k8sClient, "", "", "featuresha")
+			Expect(err).To(Succeed())
+			Expect((components)[0]).To(Equal(hasComp.Name))
+
 		})
 	})
 })

--- a/status/mock_status.go
+++ b/status/mock_status.go
@@ -99,6 +99,21 @@ func (mr *MockStatusInterfaceMockRecorder) IsPRMRInSnapshotOpened(arg0, arg1 any
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsPRMRInSnapshotOpened", reflect.TypeOf((*MockStatusInterface)(nil).IsPRMRInSnapshotOpened), arg0, arg1)
 }
 
+// FindSnapshotWithOpenedPR mocks base method.
+func (m *MockStatusInterface) FindSnapshotWithOpenedPR(arg0 context.Context, arg1 *[]v1alpha1.Snapshot) (*v1alpha1.Snapshot, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindSnapshotWithOpenedPR", arg0, arg1)
+	ret0, _ := ret[0].(*v1alpha1.Snapshot)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindSnapshotWithOpenedPR indicates an expected call of FindSnapshotWithOpenedPR.
+func (mr *MockStatusInterfaceMockRecorder) FindSnapshotWithOpenedPR(arg0, arg1 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSnapshotWithOpenedPR", reflect.TypeOf((*MockStatusInterface)(nil).FindSnapshotWithOpenedPR), arg0, arg1)
+}
+
 // // ReportSnapshotStatus mocks base method.
 // func (m *MockStatusInterface) ReportSnapshotStatus(arg0 context.Context, arg1 *v1alpha1.Snapshot) error {
 // 	m.ctrl.T.Helper()

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -449,44 +449,6 @@ var _ = Describe("Status Adapter", func() {
 			},
 		}
 
-		hasSnapshot = &applicationapiv1alpha1.Snapshot{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "snapshot-sample",
-				Namespace: "default",
-				Labels: map[string]string{
-					"test.appstudio.openshift.io/type":               "component",
-					"appstudio.openshift.io/component":               "component-sample",
-					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
-					"pac.test.appstudio.openshift.io/git-provider":   "github",
-					"pac.test.appstudio.openshift.io/url-org":        "devfile-sample",
-					"pac.test.appstudio.openshift.io/url-repository": "devfile-sample-go-basic",
-					"pac.test.appstudio.openshift.io/sha":            "12a4a35ccd08194595179815e4646c3a6c08bb77",
-					"pac.test.appstudio.openshift.io/event-type":     "pull_request",
-				},
-				Annotations: map[string]string{
-					"build.appstudio.redhat.com/commit_sha":         "6c65b2fcaea3e1a0a92476c8b5dc89e92a85f025",
-					"appstudio.redhat.com/updateComponentOnSuccess": "false",
-					"pac.test.appstudio.openshift.io/repo-url":      "https://github.com/devfile-sample/devfile-sample-go-basic",
-				},
-			},
-			Spec: applicationapiv1alpha1.SnapshotSpec{
-				Application: "application-sample",
-				Components: []applicationapiv1alpha1.SnapshotComponent{
-					{
-						Name:           "component-sample",
-						ContainerImage: "sample_image",
-						Source: applicationapiv1alpha1.ComponentSource{
-							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
-								GitSource: &applicationapiv1alpha1.GitSource{
-									Revision: "sample_revision",
-								},
-							},
-						},
-					},
-				},
-			},
-		}
-
 		githubSnapshot = &applicationapiv1alpha1.Snapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{


### PR DESCRIPTION
* set intg status to pending for group context ITS if group snapshot is expected
* get builds PLR and snapshots for the pr group in build PLR to check if multiple component is affected by the same pr group

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
