### PR TITLE
chore: use red hat rebuild of kube-rbac-proxy

### DIFF
--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -10,7 +10,7 @@ spec:
     spec:
       containers:
       - name: kube-rbac-proxy
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
+        image: registry.redhat.io/rhacm2/kube-rbac-proxy-rhel9:v2.11.6
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"


### PR DESCRIPTION
We need to stop using the kube-rbac-proxy image in gcr.io immediately while we migrate away from the kube-rbac-proxy image entirely.  This commit updates the image to the Red Hat rebuild of kube-rbac-proxy as a stopgap measure.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
