### PR TITLE
feat(): use always sealights images for testing purpose

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -147,7 +147,7 @@ spec:
         - name: ocp-login-command
           value: $(tasks.provision-rosa.results.ocp-login-command)
         - name: component-image
-          value: $(tasks.test-metadata.results.container-image)
+          value: $(tasks.sealights-refs.results.sealights-container-image)
         - name: sealights-bsid
           value: $(tasks.sealights-refs.results.sealights-bsid)
         - name: test-stage


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
