### PR TITLE
fix(STONEINTG-1050): annotation correction

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -379,13 +379,13 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
 					gitops.SnapshotComponentLabel:              "component-sample",
 					gitops.PipelineAsCodeEventTypeLabel:        "pull_request",
-					gitops.PipelineAsCodeRepoURLAnnotation:     "repo-url",
 					gitops.PipelineAsCodePullRequestAnnotation: "2",
 				},
 				Annotations: map[string]string{
 					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime),
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupHashLabel:                       prGroupSha,
+					gitops.PipelineAsCodeRepoURLAnnotation:        "repo-url",
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -403,13 +403,13 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.SnapshotComponentLabel:              "component-sample",
 					gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
 					gitops.PRGroupHashLabel:                    prGroupSha,
-					gitops.PipelineAsCodeRepoURLAnnotation:     "repo-url",
 					gitops.PipelineAsCodePullRequestAnnotation: "2",
 				},
 				Annotations: map[string]string{
 					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 100),
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupHashLabel:                       prGroupSha,
+					gitops.PipelineAsCodeRepoURLAnnotation:        "repo-url",
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -54,7 +54,7 @@ type ObjectLoader interface {
 	GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error)
 	GetScenario(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.IntegrationTestScenario, error)
 	GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error)
-	GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string, repoUrl string) (*[]applicationapiv1alpha1.Snapshot, error)
+	GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error)
 	GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error)
 	GetComponent(ctx context.Context, c client.Client, name, namespace string) (*applicationapiv1alpha1.Component, error)
@@ -351,16 +351,15 @@ func (l *loader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c clien
 	return &snapshots.Items, nil
 }
 
-// GetAllSnapshotsForPR returns all Snapshots for the associated Pull Request for the same repo url.
+// GetAllSnapshotsForPR returns all Snapshots for the associated Pull Request.
 // In the case the List operation fails, an error will be returned.
 // gitops.PipelineAsCodePullRequestAnnotation is also a label
-func (l *loader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string, repoUrl string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *loader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	snapshots := &applicationapiv1alpha1.SnapshotList{}
 	opts := []client.ListOption{
 		client.InNamespace(application.Namespace),
 		client.MatchingLabels{
 			gitops.PipelineAsCodePullRequestAnnotation: pullRequest,
-			gitops.PipelineAsCodeRepoURLAnnotation:     repoUrl,
 		},
 	}
 

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -205,9 +205,9 @@ func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c c
 	return &snapshots, err
 }
 
-func (l *mockLoader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string, repoUrl string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(AllSnapshotsForGivenPRContextKey) == nil {
-		return l.loader.GetAllSnapshotsForPR(ctx, c, application, pullRequest, repoUrl)
+		return l.loader.GetAllSnapshotsForPR(ctx, c, application, pullRequest)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsForGivenPRContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)

Made adjustemnt regarding how we filter the snapshots in question.
Since the repo_url PAC annotation is not duplicated in labels, we need to approach it individually.
Also added the case if we have only single snapshot and customer decides to run multiple integration tests. I think that it was not previously covered.