### PR TITLE
feat(STONEINTG-569): get pac secret and private key name from config

### DIFF
--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -19,6 +19,7 @@ package status
 import (
 	"context"
 	"fmt"
+	"os"
 	"strconv"
 
 	"github.com/go-logr/logr"
@@ -34,14 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-)
-
-// Used by statusReport to get pipelines-as-code-secret under NS integration-service
-const (
-	integrationNS       = "integration-service"
-	PACSecret           = "pipelines-as-code-secret"
-	gitHubApplicationID = "github-application-id"
-	gitHubPrivateKey    = "github-private-key"
 )
 
 // StatusUpdater is common interface used by status reporter to update PR status
@@ -91,6 +84,24 @@ func GetAppCredentials(ctx context.Context, k8sclient client.Client, object clie
 	var err, unRecoverableError error
 	var found bool
 	appInfo := appCredentials{}
+
+	//get pac secret and private key name from integration-config, use the default values if they cannot be not found
+	integrationNS := os.Getenv("INTEGRATION_NS")
+	if integrationNS == "" {
+		integrationNS = "integration-service"
+	}
+	PACSecret := os.Getenv("PAC_SECRET")
+	if PACSecret == "" {
+		PACSecret = "pipelines-as-code-secret"
+	}
+	gitHubApplicationID := os.Getenv("GITHUBAPPLICATION_ID")
+	if gitHubApplicationID == "" {
+		gitHubApplicationID = "github-application-id"
+	}
+	gitHubPrivateKey := os.Getenv("GITHUBPRIVATE_KEY")
+	if gitHubPrivateKey == "" {
+		gitHubPrivateKey = "github-private-key"
+	}
 
 	appInfo.InstallationID, err = strconv.ParseInt(object.GetAnnotations()[gitops.PipelineAsCodeInstallationIDAnnotation], 10, 64)
 	if err != nil {

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -19,6 +19,7 @@ package status_test
 import (
 	"bytes"
 	"context"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -269,6 +270,19 @@ var _ = Describe("GitHubReporter", func() {
 			reporter = status.NewGitHubReporter(log, mockK8sClient, status.WithGitHubClient(mockGitHubClient))
 			err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
+		})
+
+		It("failed to initialize when invalid pac secret and private names is not found", func() {
+			os.Setenv("INTEGRATION_NS", "invalid")
+			os.Setenv("PAC_SECRET", "invalid")
+			os.Setenv("GITHUBAPPLICATION_ID", "invalid")
+			os.Setenv("GITHUBPRIVATE_KEY", "invalid")
+			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			Expect(err).To(HaveOccurred())
+			os.Setenv("INTEGRATION_NS", "integration-service")
+			os.Setenv("PAC_SECRET", "pipelines-as-code-secret")
+			os.Setenv("GITHUBAPPLICATION_ID", "github-application-id")
+			os.Setenv("GITHUBPRIVATE_KEY", "github-private-key")
 		})
 
 		It("can detect if github reporter should be used", func() {


### PR DESCRIPTION
* get secret and private key name used pipelines as code from integration service config
* use default value if they can not be found

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
