### PR TITLE
fix: do not store SL token

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -189,6 +189,8 @@ spec:
           value: '{{ target_branch }}'
         - name: oci-storage
           value: $(params.output-image).sealights.git
+        - name: disable-token-save
+          value: "true"
     - name: prefetch-dependencies
       params:
       - name: input

--- a/.tekton/integration-service-push.yaml
+++ b/.tekton/integration-service-push.yaml
@@ -180,6 +180,8 @@ spec:
           value: '{{ revision }}'
         - name: oci-storage
           value: $(params.output-image).sealights.git
+        - name: disable-token-save
+          value: "true"
     - name: prefetch-dependencies
       params:
       - name: input


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/KFLUXDP-180

### Changes
* adding a new parameter to the Sealights instrumentation task to skip saving the token in TA - that way it is safe to push the image to public repository