### PR TITLE
feat(STONEINTG-1141): cancel older group snapshot and its intg plr

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -372,6 +372,11 @@ func MarkSnapshotAsCanceled(ctx context.Context, adapterClient client.Client, sn
 	return nil
 }
 
+// IsSnapshotMarkedAsCanceled returns true if snapshot is marked as AppStudioIntegrationStatusCanceled
+func IsSnapshotMarkedAsCanceled(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return IsSnapshotStatusConditionSet(snapshot, AppStudioIntegrationStatusCondition, metav1.ConditionTrue, AppStudioIntegrationStatusCanceled)
+}
+
 // MarkSnapshotAsInvalid updates the AppStudio integration status condition for the Snapshot to invalid.
 // If the patch command fails, an error will be returned.
 func MarkSnapshotAsInvalid(ctx context.Context, adapterClient client.Client, snapshot *applicationapiv1alpha1.Snapshot, message string) error {
@@ -1170,6 +1175,7 @@ func SetAnnotationAndLabelForGroupSnapshot(groupSnapshot *applicationapiv1alpha1
 		return nil, err
 	}
 	groupSnapshot.Annotations[GroupSnapshotInfoAnnotation] = string(annotationJson)
+	groupSnapshot.Annotations[PRGroupAnnotation] = componentSnapshot.Annotations[PRGroupAnnotation]
 
 	err = metadata.SetLabel(groupSnapshot, PipelineAsCodeEventTypeLabel, componentSnapshot.Labels[PipelineAsCodeEventTypeLabel])
 	if err != nil {

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -994,6 +994,17 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Expect(metadata.HasLabel(tempGroupSnapshot, "pac.test.appstudio.openshift.io/event-type")).To(BeTrue())
 				Expect(metadata.HasLabel(tempGroupSnapshot, "appstudio.openshift.io/component")).To(BeFalse())
 			})
+
+			It("can mark snapshot as cancelled", func() {
+				Expect(gitops.MarkSnapshotAsCanceled(ctx, k8sClient, hasSnapshot, "Canceled")).Should(Succeed())
+				Eventually(func() bool {
+					_ = k8sClient.Get(ctx, types.NamespacedName{
+						Name:      hasSnapshot.Name,
+						Namespace: namespace,
+					}, hasSnapshot)
+					return gitops.IsSnapshotMarkedAsCanceled(hasSnapshot)
+				}, time.Second*15).Should(BeTrue())
+			})
 		})
 	})
 })

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -62,6 +62,7 @@ const (
 	GetPRSnapshotsKey
 	GetPipelineRunforSnapshotsKey
 	GetComponentsFromSnapshotForPRGroupKey
+	GetGroupSnapshotsKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -206,9 +207,9 @@ func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c c
 	return &snapshots, err
 }
 
-func (l *mockLoader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(AllSnapshotsForGivenPRContextKey) == nil {
-		return l.loader.GetAllSnapshotsForPR(ctx, c, application, pullRequest)
+		return l.loader.GetAllSnapshotsForPR(ctx, c, application, componentName, pullRequest)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsForGivenPRContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
@@ -262,6 +263,14 @@ func (l *mockLoader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Con
 		return l.loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPRSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
+	return &snapshots, err
+}
+
+func (l *mockLoader) GetMatchingGroupSnapshotsForPRGroupHash(ctx context.Context, c client.Client, nameSpace, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+	if ctx.Value(GetGroupSnapshotsKey) == nil {
+		return l.loader.GetMatchingGroupSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash)
+	}
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetGroupSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -365,4 +365,34 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("When calling GetMatchingGroupSnapshotsForPRGroupHash", func() {
+		It("return resource and error from the context", func() {
+			snapshots := []applicationapiv1alpha1.Snapshot{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetGroupSnapshotsKey,
+					Resource:   snapshots,
+				},
+			})
+			resource, err := loader.GetMatchingGroupSnapshotsForPRGroupHash(mockContext, nil, "", "")
+			Expect(resource).To(Equal(&snapshots))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("When calling GetAllIntegrationPipelineRunsForSnapshot", func() {
+		It("return resource and error from the context", func() {
+			plrs := []tektonv1.PipelineRun{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetPipelineRunforSnapshotsKey,
+					Resource:   plrs,
+				},
+			})
+			resource, err := loader.GetAllIntegrationPipelineRunsForSnapshot(mockContext, nil, nil)
+			Expect(resource).To(Equal(plrs))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })


### PR DESCRIPTION
* Cancel older group snapshot and its integration test plr when integration test plr is triggered for new group snapshot

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
