### PR TITLE
fix(STONEINTG-996): adjust bld PLR ensure fucntions sequence in ctrl

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -118,8 +118,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsurePipelineIsFinalized,
 		adapter.EnsurePRGroupAnnotated,
-		adapter.EnsureSnapshotExists,
 		adapter.EnsureIntegrationTestReportedToGitProvider,
+		adapter.EnsureSnapshotExists,
 	})
 }
 
@@ -127,8 +127,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 type AdapterInterface interface {
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
-	EnsureSnapshotExists() (controller.OperationResult, error)
 	EnsureIntegrationTestReportedToGitProvider() (controller.OperationResult, error)
+	EnsureSnapshotExists() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.


### PR DESCRIPTION
* Run EnsureIntegrationTestReportedToGitProvider before EnsureSnapshotExists since snapshot creation faliure will stop processing

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
