### PR TITLE
fix(STONEINTG-1141): fix sortSnapshot for group snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -1120,10 +1120,15 @@ func SortSnapshots(snapshots []applicationapiv1alpha1.Snapshot) []applicationapi
 	sort.Slice(snapshots, func(i, j int) bool {
 		// sorting snapshots according to the annotation BuildPipelineRunStartTime which
 		// represents the start time of build PLR
-		// when BuildPipelineRunStartTime is not set, the value of Atoi is 0
-		time_i, _ := strconv.Atoi(snapshots[i].Annotations[BuildPipelineRunStartTime])
-		time_j, _ := strconv.Atoi(snapshots[j].Annotations[BuildPipelineRunStartTime])
-
+		// when BuildPipelineRunStartTime is not set, we use its creation time
+		var time_i, time_j int
+		if metadata.HasAnnotation(&snapshots[i], BuildPipelineRunStartTime) && metadata.HasAnnotation(&snapshots[j], BuildPipelineRunStartTime) {
+			time_i, _ = strconv.Atoi(snapshots[i].Annotations[BuildPipelineRunStartTime])
+			time_j, _ = strconv.Atoi(snapshots[j].Annotations[BuildPipelineRunStartTime])
+		} else {
+			time_i = int(snapshots[i].CreationTimestamp.Time.Unix())
+			time_j = int(snapshots[j].CreationTimestamp.Time.Unix())
+		}
 		return time_i > time_j
 	})
 	return snapshots

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -442,8 +442,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.PRGroupHashLabel:             prGroupSha,
 				},
 				Annotations: map[string]string{
-					gitops.BuildPipelineRunStartTime: strconv.Itoa(plrstarttime),
-					gitops.PRGroupAnnotation:         prGroup,
+					gitops.PRGroupAnnotation: prGroup,
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -462,8 +461,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.PRGroupHashLabel:             prGroupSha,
 				},
 				Annotations: map[string]string{
-					gitops.BuildPipelineRunStartTime: strconv.Itoa(plrstarttime + 100),
-					gitops.PRGroupAnnotation:         prGroup,
+					gitops.PRGroupAnnotation: prGroup,
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -2474,6 +2472,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 	When("old integration pipelinerun gets cancelled because newer pipelinerun gets triggered for group snapshot", func() {
 		It("ensures that old group snapshot together with integration pipelinerun can be canceled", func() {
 			integrationPipelineRunOld.Labels["appstudio.openshift.io/snapshot"] = integrationPipelineRunOld.Name
+			hasOldGroupSnapshot.CreationTimestamp = metav1.NewTime(time.Now())
+			hasNewGroupSnapshot.CreationTimestamp = metav1.NewTime(time.Now().Add(time.Hour * 1))
 			Expect(k8sClient.Update(ctx, integrationPipelineRunOld)).Should(Succeed())
 			integrationPipelineRunOld.Status = tektonv1.PipelineRunStatus{
 				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{


### PR DESCRIPTION
* fix sortSnapshot when snapshot has no annotation test.appstudio.openshift.io/pipelinerunstarttime and sort according to their creation time

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
