### PR TITLE
feat(): enable Sealights plugin for integration service

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -47,7 +47,7 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
-    - name: enable-sealights
+    - name: enable-sl-plugin
       description: "A flag to enable or disable the Sealights integration feature. When set to 'true', test results are sent to Sealights for analysis; otherwise, this feature is skipped."
       default: "true"
   tasks:
@@ -152,8 +152,8 @@ spec:
           value: $(tasks.sealights-refs.results.sealights-bsid)
         - name: test-stage
           value: $(params.test-stage)
-        - name: enable-sealights
-          value: $(params.enable-sealights)
+        - name: enable-sl-plugin
+          value: $(params.enable-sl-plugin)
   finally:
     - name: deprovision-rosa-collect-artifacts
       taskRef:


### PR DESCRIPTION
## Maintainers will complete the following section

The pull Request activate the ginkgo plugin that will upload e2e tests to Sealights dashboard and get coverage + in the future will allow to enable test selections to only run tests based on code changes

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
