### PR TITLE
fix(STONEINTG-1174):apply application label when getting resources

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -343,7 +343,7 @@ func (a *Adapter) notifySnapshotsInGroupAboutFailedBuild(pipelineRun *tektonv1.P
 	// Annotate all latest component Snapshots that are part of the PR group
 	for _, applicationComponent := range *applicationComponents {
 		applicationComponent := applicationComponent // G601
-		allComponentSnapshotsInGroup, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, a.pipelineRun.Namespace, applicationComponent.Name, prGroupHash)
+		allComponentSnapshotsInGroup, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, a.pipelineRun.Namespace, applicationComponent.Name, prGroupHash, a.application.Name)
 		if err != nil {
 			a.logger.Error(err, "Failed to fetch Snapshots for component", "component.Name", applicationComponent.Name)
 			return err
@@ -742,7 +742,7 @@ func (a *Adapter) isGroupSnapshotExpectedForBuildPLR(pipelineRun *tektonv1.Pipel
 		return true, nil
 	}
 
-	componentsFromSnapshot, err := a.loader.GetComponentsFromSnapshotForPRGroup(a.context, a.client, pipelineRun.Namespace, prGroup, prGroupHash)
+	componentsFromSnapshot, err := a.loader.GetComponentsFromSnapshotForPRGroup(a.context, a.client, pipelineRun.Namespace, prGroup, prGroupHash, a.application.Name)
 	if err != nil {
 		a.logger.Error(err, fmt.Sprintf("failed to get component from component snapshot for pr group %s", prGroup))
 		return false, err
@@ -754,7 +754,7 @@ func (a *Adapter) isGroupSnapshotExpectedForBuildPLR(pipelineRun *tektonv1.Pipel
 			continue
 		}
 
-		snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, pipelineRun.Namespace, componentName, prGroupHash)
+		snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, pipelineRun.Namespace, componentName, prGroupHash, a.application.Name)
 		if err != nil {
 			a.logger.Error(err, "Failed to fetch Snapshots for component", "component.Name", componentName)
 			return false, err

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -873,7 +873,7 @@ func (a *Adapter) updateComponentLastPromotedImage(ctx context.Context, c client
 }
 
 func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Application, prGroup, prGroupHash string) (*applicationapiv1alpha1.Snapshot, []gitops.ComponentSnapshotInfo, error) {
-	componentsToCheck, err := a.loader.GetComponentsFromSnapshotForPRGroup(a.context, a.client, application.Namespace, prGroup, prGroupHash)
+	componentsToCheck, err := a.loader.GetComponentsFromSnapshotForPRGroup(a.context, a.client, application.Namespace, prGroup, prGroupHash, application.Name)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -894,7 +894,7 @@ func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Appli
 
 		var foundSnapshotWithOpenedPR *applicationapiv1alpha1.Snapshot
 		if slices.Contains(componentsToCheck, applicationComponent.Name) {
-			snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, application.Namespace, applicationComponent.Name, prGroupHash)
+			snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, application.Namespace, applicationComponent.Name, prGroupHash, application.Name)
 			if err != nil {
 				a.logger.Error(err, "Failed to fetch Snapshots for component", "component.Name", applicationComponent.Name)
 				return nil, nil, err
@@ -1030,7 +1030,7 @@ func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun(application *application
 			a.logger.Error(fmt.Errorf("pr group info can't be found in group snapshot"), "snapshot.Namespace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
 			return fmt.Errorf("pr group info can't be found in group snapshot %s/%s", snapshot.Namespace, snapshot.Name)
 		}
-		snapshots, err = a.loader.GetMatchingGroupSnapshotsForPRGroupHash(a.context, a.client, application.Namespace, prGroupHash)
+		snapshots, err = a.loader.GetMatchingGroupSnapshotsForPRGroupHash(a.context, a.client, application.Namespace, prGroupHash, application.Name)
 		if err != nil {
 			a.logger.Error(fmt.Errorf("failed to get group snapshot for pr group from group snapshot"), "snapshot.Namespace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
 			return err

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -573,6 +573,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					gitops.PipelineAsCodeSHALabel:                    "sha",
 					gitops.PipelineAsCodePullRequestAnnotation:       "1",
+					gitops.ApplicationNameLabel:                      hasApp.Name,
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
@@ -620,6 +621,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					gitops.PipelineAsCodeSHALabel:                    "sha",
 					gitops.PipelineAsCodePullRequestAnnotation:       "1",
+					gitops.ApplicationNameLabel:                      hasApp.Name,
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
@@ -657,6 +659,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					"pac.test.appstudio.openshift.io/url-repository": "testrepo",
 					gitops.PipelineAsCodeSHALabel:                    "sha",
 					gitops.PipelineAsCodePullRequestAnnotation:       "1",
+					gitops.ApplicationNameLabel:                      hasApp.Name,
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -249,26 +249,26 @@ func (l *mockLoader) GetPipelineRunsWithPRGroupHash(ctx context.Context, c clien
 }
 
 // GetMatchingComponentSnapshotsForComponentAndPRGroupHash returns the resource and error passed as values of the context
-func (l *mockLoader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx context.Context, c client.Client, namespace, componentName, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx context.Context, c client.Client, namespace, componentName, prGroupHash, applicationName string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(GetComponentSnapshotsKey) == nil {
-		return l.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, c, namespace, componentName, prGroupHash)
+		return l.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, c, namespace, componentName, prGroupHash, applicationName)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 
 // GetMatchingComponentSnapshotsForPRGroupHash returns the resource and error passed as values of the context
-func (l *mockLoader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Context, c client.Client, nameSpace, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Context, c client.Client, nameSpace, prGroupHash, applicationName string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(GetPRSnapshotsKey) == nil {
-		return l.loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash)
+		return l.loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash, applicationName)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPRSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 
-func (l *mockLoader) GetMatchingGroupSnapshotsForPRGroupHash(ctx context.Context, c client.Client, nameSpace, prGroupHash string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *mockLoader) GetMatchingGroupSnapshotsForPRGroupHash(ctx context.Context, c client.Client, nameSpace, prGroupHash, applicationName string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	if ctx.Value(GetGroupSnapshotsKey) == nil {
-		return l.loader.GetMatchingGroupSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash)
+		return l.loader.GetMatchingGroupSnapshotsForPRGroupHash(ctx, c, nameSpace, prGroupHash, applicationName)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetGroupSnapshotsKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
@@ -283,9 +283,9 @@ func (l *mockLoader) GetAllIntegrationPipelineRunsForSnapshot(ctx context.Contex
 	return pipelineRuns, err
 }
 
-func (l *mockLoader) GetComponentsFromSnapshotForPRGroup(ctx context.Context, c client.Client, namespace, prGroup, prGroupHash string) ([]string, error) {
+func (l *mockLoader) GetComponentsFromSnapshotForPRGroup(ctx context.Context, c client.Client, namespace, prGroup, prGroupHash, applicationName string) ([]string, error) {
 	if ctx.Value(GetComponentsFromSnapshotForPRGroupKey) == nil {
-		return l.loader.GetComponentsFromSnapshotForPRGroup(ctx, c, namespace, prGroup, prGroupHash)
+		return l.loader.GetComponentsFromSnapshotForPRGroup(ctx, c, namespace, prGroup, prGroupHash, applicationName)
 	}
 	components, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetComponentsFromSnapshotForPRGroupKey, []string{})
 	return components, err

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -330,7 +330,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(mockContext, nil, "", "", "")
+			resource, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(mockContext, nil, "", "", "", "")
 			Expect(resource).To(Equal(&snapshots))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -345,7 +345,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(mockContext, nil, "", "")
+			resource, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(mockContext, nil, "", "", "")
 			Expect(resource).To(Equal(&snapshots))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -360,7 +360,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   components,
 				},
 			})
-			resource, err := loader.GetComponentsFromSnapshotForPRGroup(mockContext, nil, "", "", "")
+			resource, err := loader.GetComponentsFromSnapshotForPRGroup(mockContext, nil, "", "", "", "")
 			Expect(resource).To(Equal(components))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -375,7 +375,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   snapshots,
 				},
 			})
-			resource, err := loader.GetMatchingGroupSnapshotsForPRGroupHash(mockContext, nil, "", "")
+			resource, err := loader.GetMatchingGroupSnapshotsForPRGroupHash(mockContext, nil, "", "", "")
 			Expect(resource).To(Equal(&snapshots))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -110,6 +110,7 @@ var _ = Describe("Loader", Ordered, func() {
 					gitops.PRGroupHashLabel:                    prGroupSha,
 					gitops.PipelineAsCodeEventTypeLabel:        "pull_request",
 					gitops.PipelineAsCodePullRequestAnnotation: "1",
+					gitops.ApplicationNameLabel:                hasApp.Name,
 				},
 				Annotations: map[string]string{
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -142,6 +143,7 @@ var _ = Describe("Loader", Ordered, func() {
 					gitops.SnapshotTypeLabel:            "group",
 					gitops.PRGroupHashLabel:             prGroupSha,
 					gitops.PipelineAsCodeEventTypeLabel: "pull_request",
+					gitops.ApplicationNameLabel:         hasApp.Name,
 				},
 				Annotations: map[string]string{
 					gitops.PRGroupAnnotation: prGroup,
@@ -731,7 +733,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get matching snapshot for component and pr group hash", func() {
-			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, k8sClient, hasSnapshot.Namespace, hasComp.Name, prGroupSha)
+			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx, k8sClient, hasSnapshot.Namespace, hasComp.Name, prGroupSha, hasApp.Name)
 			Expect(err).To(Succeed())
 			Expect((*fetchedSnapshots)[0].Name).To(Equal(hasSnapshot.Name))
 			Expect((*fetchedSnapshots)[0].Namespace).To(Equal(hasSnapshot.Namespace))
@@ -739,7 +741,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get matching snapshot for pr group hash", func() {
-			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, k8sClient, "", prGroupSha)
+			fetchedSnapshots, err := loader.GetMatchingComponentSnapshotsForPRGroupHash(ctx, k8sClient, "", prGroupSha, hasApp.Name)
 			Expect(err).To(Succeed())
 			Expect((*fetchedSnapshots)[0].Name).To(Equal(hasSnapshot.Name))
 			Expect((*fetchedSnapshots)[0].Namespace).To(Equal(hasSnapshot.Namespace))
@@ -747,7 +749,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get matching group snapshot for pr group hash", func() {
-			fetchedSnapshots, err := loader.GetMatchingGroupSnapshotsForPRGroupHash(ctx, k8sClient, "", prGroupSha)
+			fetchedSnapshots, err := loader.GetMatchingGroupSnapshotsForPRGroupHash(ctx, k8sClient, "", prGroupSha, hasApp.Name)
 			Expect(err).To(Succeed())
 			Expect((*fetchedSnapshots)[0].Name).To(Equal(hasGroupSnapshot.Name))
 			Expect((*fetchedSnapshots)[0].Namespace).To(Equal(hasGroupSnapshot.Namespace))
@@ -755,7 +757,7 @@ var _ = Describe("Loader", Ordered, func() {
 		})
 
 		It("Can get matching components from snapshots for pr group hash", func() {
-			components, err := loader.GetComponentsFromSnapshotForPRGroup(ctx, k8sClient, "", "", prGroupSha)
+			components, err := loader.GetComponentsFromSnapshotForPRGroup(ctx, k8sClient, "", "", prGroupSha, hasApp.Name)
 			Expect(err).To(Succeed())
 			Expect((components)[0]).To(Equal(hasComp.Name))
 


### PR DESCRIPTION
* Should have application label when getting resources in loader

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
