### PR TITLE
feat(STONEINTG-1144): report group snapshot creation failure to git provider

### DIFF
--- a/docs/statusreport-controller.md
+++ b/docs/statusreport-controller.md
@@ -109,6 +109,21 @@ flowchart TD
   is_test_final                  --No --> test_iterate
   remove_finalizer_from_plr      -->      continue_processing
 
+%%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGroupSnapshotCreationStatusReportedToGitProvider() function
+
+%% Node definitions
+  
+  check_snapshot_annotation(Process further if: <br>Group snapshot creation failure is annotated to snapshot)
+  report_groupsnapshotcreation_failure(Report group snapshot creation failure<br>back to git provider)
+  continue_processing(Controller continues processing)
+
+
+%% Node connections
+  predicate                    ---->    |"EnsureGroupSnapshotCreationStatusReportedToGitProvider()"|check_snapshot_annotation
+  check_snapshot_annotation        --Yes-->    report_groupsnapshotcreation_failure
+  check_snapshot_annotation        --No-->     continue_processing
+  report_groupsnapshotcreation_failure     ---->    continue_processing
+
   %% Assigning styles to nodes
   class predicate Amber;
 ```

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -1027,6 +1027,11 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 					return gitops.IsSnapshotMarkedAsCanceled(hasSnapshot)
 				}, time.Second*15).Should(BeTrue())
 			})
+
+			It("can prepare temp group snapshot", func() {
+				tempGroupSnapshot := gitops.PrepareTempGroupSnapshot(hasApp, hasSnapshot)
+				Expect(metadata.HasLabelWithValue(tempGroupSnapshot, gitops.SnapshotTypeLabel, gitops.SnapshotGroupType)).To(BeTrue())
+			})
 		})
 	})
 })

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -632,7 +632,7 @@ func (a *Adapter) EnsureGroupSnapshotExist() (controller.OperationResult, error)
 		a.logger.Error(err, "Failed to create group snapshot")
 		if clienterrors.IsForbidden(err) {
 			// notify all component snapshots that group snapshot is not created for them due to
-			err = gitops.NotifyComponentSnapshotsInGroupSnapshot(a.context, a.client, componentSnapshotInfos, fmt.Sprintf("Failed to create group snapshot for pr group %s due to error %s", prGroup, err.Error()))
+			err = gitops.NotifyComponentSnapshotsInGroupSnapshot(a.context, a.client, componentSnapshotInfos, fmt.Sprintf(gitops.FailedToCreateGroupSnapshotMsg+" %s due to error %s", prGroup, err.Error()))
 			if err != nil {
 				a.logger.Error(err, fmt.Sprintf("Failed to annotate the component snapshots of pr group %s", prGroup))
 				return controller.RequeueWithError(err)

--- a/internal/controller/statusreport/statusreport_controller.go
+++ b/internal/controller/statusreport/statusreport_controller.go
@@ -90,12 +90,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsureSnapshotFinishedAllTests,
 		adapter.EnsureSnapshotTestStatusReportedToGitProvider,
+		adapter.EnsureGroupSnapshotCreationStatusReportedToGitProvider,
 	})
 }
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
 	EnsureSnapshotTestStatusReportedToGitHub() (controller.OperationResult, error)
+	EnsureGroupSnapshotCreationStatusReportedToGitProvider(controller.OperationResult, error)
 	EnsureSnapshotFinishedAllTests() (controller.OperationResult, error)
 }
 

--- a/internal/controller/statusreport/statusreport_controller_test.go
+++ b/internal/controller/statusreport/statusreport_controller_test.go
@@ -76,6 +76,9 @@ var _ = Describe("StatusReportController", func() {
 					gitops.SnapshotTypeLabel:      "component",
 					gitops.SnapshotComponentLabel: "component-sample",
 				},
+				Annotations: map[string]string{
+					gitops.PRGroupCreationAnnotation: "failed to create group snapshot due to error",
+				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
 				Application: hasApp.Name,

--- a/pkg/integrationteststatus/integration_test_status.go
+++ b/pkg/integrationteststatus/integration_test_status.go
@@ -51,6 +51,8 @@ const (
 	SnapshotCreationFailed // SnapshotCreationFailed
 	// Build pipelinerun failed
 	BuildPLRFailed // BuildPLRFailed
+	// Group snapshot creation failed
+	GroupSnapshotCreationFailed //GroupSnapshotCreationFailed
 )
 
 const integrationTestStatusesSchema = `{
@@ -185,6 +187,7 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestStatusIfChanged(scenarioN
 			IntegrationTestStatusTestPassed,
 			IntegrationTestStatusTestInvalid,
 			SnapshotCreationFailed,
+			GroupSnapshotCreationFailed,
 			BuildPLRFailed:
 
 			detail.CompletionTime = &timestamp

--- a/pkg/integrationteststatus/integrationteststatus_enumer.go
+++ b/pkg/integrationteststatus/integrationteststatus_enumer.go
@@ -7,9 +7,9 @@ import (
 	"fmt"
 )
 
-const _IntegrationTestStatusName = "PendingInProgressDeletedEnvironmentProvisionErrorDeploymentErrorTestFailTestPassedTestInvalidBuildPLRInProgressSnapshotCreationFailedBuildPLRFailed"
+const _IntegrationTestStatusName = "PendingInProgressDeletedEnvironmentProvisionErrorDeploymentErrorTestFailTestPassedTestInvalidBuildPLRInProgressSnapshotCreationFailedBuildPLRFailedGroupSnapshotCreationFailed"
 
-var _IntegrationTestStatusIndex = [...]uint8{0, 7, 17, 24, 49, 64, 72, 82, 93, 111, 133, 147}
+var _IntegrationTestStatusIndex = [...]uint8{0, 7, 17, 24, 49, 64, 72, 82, 93, 111, 133, 147, 174}
 
 func (i IntegrationTestStatus) String() string {
 	i -= 1
@@ -19,7 +19,7 @@ func (i IntegrationTestStatus) String() string {
 	return _IntegrationTestStatusName[_IntegrationTestStatusIndex[i]:_IntegrationTestStatusIndex[i+1]]
 }
 
-var _IntegrationTestStatusValues = []IntegrationTestStatus{1, 2, 3, 4, 5, 6, 7, 8}
+var _IntegrationTestStatusValues = []IntegrationTestStatus{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12}
 
 var _IntegrationTestStatusNameToValueMap = map[string]IntegrationTestStatus{
 	_IntegrationTestStatusName[0:7]:     1,
@@ -33,6 +33,7 @@ var _IntegrationTestStatusNameToValueMap = map[string]IntegrationTestStatus{
 	_IntegrationTestStatusName[93:111]:  9,
 	_IntegrationTestStatusName[111:133]: 10,
 	_IntegrationTestStatusName[133:147]: 11,
+	_IntegrationTestStatusName[148:174]: 12,
 }
 
 // IntegrationTestStatusString retrieves an enum value from the enum constants string name.

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -543,7 +543,8 @@ func generateCheckRunTitle(state intgteststat.IntegrationTestStatus) (string, er
 		title = "Succeeded"
 	case intgteststat.IntegrationTestStatusTestFail,
 		intgteststat.SnapshotCreationFailed,
-		intgteststat.BuildPLRFailed:
+		intgteststat.BuildPLRFailed,
+		intgteststat.GroupSnapshotCreationFailed:
 		title = "Failed"
 	default:
 		return title, fmt.Errorf("unknown status")
@@ -568,7 +569,7 @@ func generateCheckRunConclusion(state intgteststat.IntegrationTestStatus) (strin
 	case intgteststat.IntegrationTestStatusPending, intgteststat.IntegrationTestStatusInProgress,
 		intgteststat.BuildPLRInProgress:
 		conclusion = ""
-	case intgteststat.SnapshotCreationFailed, intgteststat.BuildPLRFailed:
+	case intgteststat.SnapshotCreationFailed, intgteststat.BuildPLRFailed, intgteststat.GroupSnapshotCreationFailed:
 		conclusion = gitops.IntegrationTestStatusCancelledGithub
 	default:
 		return conclusion, fmt.Errorf("unknown status")
@@ -585,7 +586,7 @@ func generateGithubCommitState(state intgteststat.IntegrationTestStatus) (string
 
 	switch state {
 	case intgteststat.IntegrationTestStatusTestFail, intgteststat.SnapshotCreationFailed,
-		intgteststat.BuildPLRFailed:
+		intgteststat.BuildPLRFailed, intgteststat.GroupSnapshotCreationFailed:
 		commitState = gitops.IntegrationTestStatusFailureGithub
 	case intgteststat.IntegrationTestStatusEnvironmentProvisionError_Deprecated, intgteststat.IntegrationTestStatusDeploymentError_Deprecated,
 		intgteststat.IntegrationTestStatusDeleted, intgteststat.IntegrationTestStatusTestInvalid:

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -347,6 +347,10 @@ var _ = Describe("GitHubReporter", func() {
 			Entry("In progress", integrationteststatus.IntegrationTestStatusInProgress, "In Progress", ""),
 			Entry("Pending", integrationteststatus.IntegrationTestStatusPending, "Pending", ""),
 			Entry("Invalid", integrationteststatus.IntegrationTestStatusTestInvalid, "Errored", gitops.IntegrationTestStatusFailureGithub),
+			Entry("BuildPLRInProgress", integrationteststatus.IntegrationTestStatusPending, "Pending", ""),
+			Entry("BuildPLRFailed", integrationteststatus.IntegrationTestStatusTestFail, "Failed", gitops.IntegrationTestStatusFailureGithub),
+			Entry("SnapshotCreationFailed", integrationteststatus.IntegrationTestStatusTestFail, "Failed", gitops.IntegrationTestStatusFailureGithub),
+			Entry("GroupSnapshotCreationFailed", integrationteststatus.IntegrationTestStatusTestFail, "Failed", gitops.IntegrationTestStatusFailureGithub),
 		)
 
 		It("check if all integration tests statuses are supported", func() {
@@ -587,6 +591,10 @@ var _ = Describe("GitHubReporter", func() {
 			Entry("In progress", integrationteststatus.IntegrationTestStatusInProgress, gitops.IntegrationTestStatusPendingGithub),
 			Entry("Pending", integrationteststatus.IntegrationTestStatusPending, gitops.IntegrationTestStatusPendingGithub),
 			Entry("Invalid", integrationteststatus.IntegrationTestStatusTestInvalid, gitops.IntegrationTestStatusErrorGithub),
+			Entry("BuildPLRInProgress", integrationteststatus.BuildPLRInProgress, gitops.IntegrationTestStatusPendingGithub),
+			Entry("BuildPLRFailed", integrationteststatus.BuildPLRFailed, gitops.IntegrationTestStatusFailureGithub),
+			Entry("SnapshotCreationFailed", integrationteststatus.SnapshotCreationFailed, gitops.IntegrationTestStatusFailureGithub),
+			Entry("GroupSnapshotCreationFailed", integrationteststatus.GroupSnapshotCreationFailed, gitops.IntegrationTestStatusFailureGithub),
 		)
 
 		It("check if all integration tests statuses are supported", func() {

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -312,7 +312,7 @@ func GenerateGitlabCommitState(state intgteststat.IntegrationTestStatus) (gitlab
 		intgteststat.IntegrationTestStatusTestInvalid:
 		glState = gitlab.Failed
 	case intgteststat.IntegrationTestStatusDeleted,
-		intgteststat.BuildPLRFailed, intgteststat.SnapshotCreationFailed:
+		intgteststat.BuildPLRFailed, intgteststat.SnapshotCreationFailed, intgteststat.GroupSnapshotCreationFailed:
 		glState = gitlab.Canceled
 	case intgteststat.IntegrationTestStatusTestPassed:
 		glState = gitlab.Success

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -380,6 +380,10 @@ var _ = Describe("GitLabReporter", func() {
 			Entry("In progress", integrationteststatus.IntegrationTestStatusInProgress, gitlab.Running),
 			Entry("Pending", integrationteststatus.IntegrationTestStatusPending, gitlab.Pending),
 			Entry("Invalid", integrationteststatus.IntegrationTestStatusTestInvalid, gitlab.Failed),
+			Entry("BuildPLRInProgress", integrationteststatus.BuildPLRInProgress, gitlab.Pending),
+			Entry("BuildPLRFailed", integrationteststatus.BuildPLRFailed, gitlab.Canceled),
+			Entry("SnapshotCreationFailed", integrationteststatus.SnapshotCreationFailed, gitlab.Canceled),
+			Entry("GroupSnapshotCreationFailed", integrationteststatus.GroupSnapshotCreationFailed, gitlab.Canceled),
 		)
 
 		It("check if all integration tests statuses are supported", func() {


### PR DESCRIPTION
* report group snapshot creation failure back to PRs/MRs expected to be included in group snapshot

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
