### PR TITLE
feat(): add pac.test.appstudio.openshift.io/cancelled annotation to 

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -222,6 +222,9 @@ const (
 	//AppStudioIntegrationStatusCancelled is the reason that's set when the AppStudio tests pipelinerun gets cancelled.
 	AppStudioIntegrationStatusCancelled = "CancelledRunFinally"
 
+	// This annotation helps track PipelineRuns that were stopped before completion, enabling better auditability and observability.
+	PRGroupCancelledAnnotation = PipelinesAsCodePrefix + "/cancelled"
+
 	// the statuses needed to report to GiHub when creating check run or commit status, see doc
 	// https://docs.github.com/en/rest/guides/using-the-rest-api-to-interact-with-checks?apiVersion=2022-11-28
 	// https://docs.github.com/en/free-pro-team@latest/rest/checks/runs?apiVersion=2022-11-28#create-a-check-run


### PR DESCRIPTION
## Maintainers will complete the following section

the annotation helps track PipelineRuns that were stopped before completion, enabling better auditability and observability.

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
