### PR TITLE
feat(STONEINTG-852): integration service reports on push events

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -567,12 +567,8 @@ func (a *Adapter) EnsureOverrideSnapshotValid() (controller.OperationResult, err
 }
 
 // EnsureGroupSnapshotExist is an operation that ensure the group snapshot is created for component snapshots
-// once a new component snapshot is created for an pull request and there are multiple existing PRs belonging to the same PR group
+// once a new component snapshot is created for an pull or push request and there are multiple existing PRs belonging to the same PR group
 func (a *Adapter) EnsureGroupSnapshotExist() (controller.OperationResult, error) {
-	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
-		a.logger.Info("The snapshot is not created by PAC pull request, no need to create group snapshot")
-		return controller.ContinueProcessing()
-	}
 
 	if !metadata.HasLabelWithValue(a.snapshot, gitops.SnapshotTypeLabel, gitops.SnapshotComponentType) {
 		a.logger.Info("The snapshot is not a component snapshot, no need to create group snapshot for it")


### PR DESCRIPTION
  - test integration results will show in commits also on push event
Signed-off-by: Kasem Alem <kalem@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
