### PR TITLE
fix(ASC-783): support new label for konflux tenant namespaces

### DIFF
--- a/cmd/snapshotgc/snapshotgc.go
+++ b/cmd/snapshotgc/snapshotgc.go
@@ -120,10 +120,10 @@ func getTenantNamespaces(
 		"konflux.ci/type", selection.In, []string{"user"},
 	)
 	selector = labels.NewSelector().Add(*req)
-	konfluxNamespaceList := &core.NamespaceList{}
+	konfluxUserNamespaceList := &core.NamespaceList{}
 	err = cl.List(
 		context.Background(),
-		konfluxNamespaceList,
+		konfluxUserNamespaceList,
 		&client.ListOptions{LabelSelector: selector},
 	)
 	if err != nil {
@@ -131,7 +131,25 @@ func getTenantNamespaces(
 		return nil, err
 	}
 
-	namespaces := append(toolChainNamespaceList.Items, konfluxNamespaceList.Items...)
+	namespaces := append(toolChainNamespaceList.Items, konfluxUserNamespaceList.Items...)
+
+	// Finally get the new format Konflux tenant namespaces
+	req, _ = labels.NewRequirement(
+		"konflux-ci.dev/type", selection.In, []string{"tenant"},
+	)
+	selector = labels.NewSelector().Add(*req)
+	konfluxTenantNamespaceList := &core.NamespaceList{}
+	err = cl.List(
+		context.Background(),
+		konfluxTenantNamespaceList,
+		&client.ListOptions{LabelSelector: selector},
+	)
+	if err != nil {
+		logger.Error(err, "Failed listing namespaces")
+		return nil, err
+	}
+
+	namespaces = append(namespaces, konfluxTenantNamespaceList.Items...)
 
 	return namespaces, nil
 }

--- a/cmd/snapshotgc/snapshotgc_test.go
+++ b/cmd/snapshotgc/snapshotgc_test.go
@@ -590,7 +590,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns2",
 					Labels: map[string]string{
-						"toolchain.dev.openshift.com/type": "tenant",
+						"konflux-ci.dev/type": "tenant",
 					},
 				},
 			}
@@ -654,7 +654,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "ns4",
 					Labels: map[string]string{
-						"konflux.ci/type": "user",
+						"konflux-ci.dev/type": "tenant",
 					},
 				},
 			}


### PR DESCRIPTION
* The `konflux.ci/type` label was replaced with `konflux-ci.dev/type` on the newest Konflux clusters, so we need to update our garbage collector logic to take it into account
* We'll keep support for old labels to keep backwards-compatibility

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
