### PR TITLE
fix(STONEINTG-1168): don't report test status for cancelled snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -204,7 +204,7 @@ const (
 	// AppStudioTestSucceededConditionFailed is the reason that's set when the AppStudio tests fail.
 	AppStudioTestSucceededConditionFailed = "Failed"
 
-	// AppStudioIntegrationStatusCanceled is the reason that's set when the AppStudio tests cancel.
+	// AppStudioIntegrationStatusCanceled is the reason that's set when the AppStudio tests cancel because of being superseded by newer Snapshot.
 	AppStudioIntegrationStatusCanceled = "Canceled"
 
 	// AppStudioIntegrationStatusInvalid is the reason that's set when the AppStudio integration gets into an invalid state.

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -77,6 +77,12 @@ func (a *Adapter) EnsureSnapshotTestStatusReportedToGitProvider() (controller.Op
 	if !gitops.IsGroupSnapshot(a.snapshot) && !gitops.IsComponentSnapshot(a.snapshot) {
 		return controller.ContinueProcessing()
 	}
+
+	// Don't report status for superseded/canceled Snapshots
+	if gitops.IsSnapshotMarkedAsCanceled(a.snapshot) {
+		return controller.ContinueProcessing()
+	}
+
 	err := a.ReportSnapshotStatus(a.snapshot)
 	if err != nil {
 		a.logger.Error(err, "failed to report test status to git provider for snapshot",


### PR DESCRIPTION
* Skip reporting integration test status to git provider if the Snapshot is cancelled/superseded
* Clarify that the `AppStudioIntegrationStatusCanceled` is meant for superseded Snapshots

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
