### PR TITLE
fix: change ResolverType field to ResouceKind

### DIFF
--- a/api/v1beta2/integrationtestscenario_types.go
+++ b/api/v1beta2/integrationtestscenario_types.go
@@ -103,10 +103,11 @@ type ResolverRef struct {
 	// the chosen resolver.
 	// +required
 	Params []ResolverParameter `json:"params"`
-	// ResolverType defines the type of resolver. It can either be "pipeline" or "pipelinerun"
-	// but defaults to "pipeline" if no value is set
+	// ResourceKind defines the kind of resource being resolved. It can either
+	// be "pipeline" or "pipelinerun" but defaults to "pipeline" if no value is
+	// set
 	// +optional
-	ResolverType string `json:"resolverType"`
+	ResourceKind string `json:"resourceKind"`
 }
 
 // ResolverParameter contains the name and values used to identify the referenced Tekton resource

--- a/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
+++ b/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
@@ -546,10 +546,11 @@ spec:
                       perform resolution of the referenced Tekton resource, such as
                       "git" or "bundle"..
                     type: string
-                  resolverType:
+                  resourceKind:
                     description: |-
-                      ResolverType defines the type of resolver. It can either be "pipeline" or "pipelinerun"
-                      but defaults to "pipeline" if no value is set
+                      ResourceKind defines the kind of resource being resolved. It can either
+                      be "pipeline" or "pipelinerun" but defaults to "pipeline" if no value is
+                      set
                     type: string
                 required:
                 - params


### PR DESCRIPTION
Change Scenario.Spec.ResolverRef.ResolverType field name to ResourceKind in order to improve user clarity

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
