### PR TITLE
fix(KFLUXSPRT-2829): show latest integration plr in github UI

### DIFF
--- a/git/github/github.go
+++ b/git/github/github.go
@@ -58,7 +58,7 @@ type CommitStatusAdapter struct {
 
 // GetStatus returns the appropriate status based on conclusion and start time.
 func (s *CheckRunAdapter) GetStatus() string {
-	if s.Conclusion == "success" || s.Conclusion == "failure" {
+	if s.Conclusion == "success" || s.Conclusion == "failure" || s.Conclusion == "cancelled" {
 		return "completed"
 	} else if s.StartTime.IsZero() {
 		return "queued"

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1048,15 +1048,15 @@ func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun(application *application
 			a.logger.Info("Snapshot has been marked as cancelled previously, skipping marking it", "snapshot.Name", &sortedSnapshots[i].Name)
 			continue
 		}
-		err = a.cancelAllPipelineRunsForSnapshot(&sortedSnapshots[i])
-		if err != nil {
-			a.logger.Error(err, "failed to cancel all integration pipelinerun for older snapshot", "snapshot.Name", &sortedSnapshots[i].Name)
-			return err
-		}
 		a.logger.Info("integration test pipelineruns have been cancelled for older snapshot")
 		err = gitops.MarkSnapshotAsCanceled(a.context, a.client, &sortedSnapshots[i], "Snapshot canceled/superseded")
 		if err != nil {
 			a.logger.Error(err, "Failed to mark snapshot as canceled", "snapshot.Name", &sortedSnapshots[i].Name)
+			return err
+		}
+		err = a.cancelAllPipelineRunsForSnapshot(&sortedSnapshots[i])
+		if err != nil {
+			a.logger.Error(err, "failed to cancel all integration pipelinerun for older snapshot", "snapshot.Name", &sortedSnapshots[i].Name)
 			return err
 		}
 		a.logger.Info(fmt.Sprintf("older snapshot %s and its integration pipelinerun have been marked as cancelled", sortedSnapshots[i].Name))


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)