### PR TITLE
feat(STONEINTG-1180): upgrade go version to 1.23

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.0"
+          go-version: "1.23.6"
       - name: Run tests
         run: make test
       - name: Codecov

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.0"
+          go-version: "1.23.6"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.0"
+          go-version: "1.23.6"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/.tekton/integration-service-push.yaml
+++ b/.tekton/integration-service-push.yaml
@@ -165,7 +165,7 @@ spec:
         - name: name
           value: sealights-go-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-sealights-go-oci-ta:0.1@sha256:b8e72ab0c7fa2d9005b768b50be4c13db2d77c486a623af5e59fa9d59593db65
+          value: quay.io/konflux-ci/tekton-catalog/task-sealights-go-oci-ta:0.1@sha256:96317fb573660541cc274c324bd3efc4a2198e4fb4a7d1070f3fd59538eb9eeb
         - name: kind
           value: task
         resolver: bundles

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:9.5-1745328278 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.23.6-1744294473 as builder
 
 USER 1001
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/konflux-ci/integration-service
 
-go 1.22.3
+go 1.23
 
 toolchain go1.23.6
 
@@ -96,7 +96,7 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.62.0 // indirect
-	github.com/prometheus/procfs v0.15.1 // indirect
+	github.com/prometheus/procfs v0.15.1 // indirect; indirecttoolchain go1.23.6
 	github.com/prometheus/statsd_exporter v0.26.1 // indirect
 	github.com/spf13/pflag v1.0.6-0.20210604193023-d5e0c0615ace // indirect
 	github.com/stoewer/go-strcase v1.3.0 // indirect


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
