### PR TITLE
feat: store pipeline status in oci artifact

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -155,6 +155,25 @@ spec:
         - name: enable-sl-plugin
           value: $(params.enable-sl-plugin)
   finally:
+    - name: store-pipeline-status
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/store-pipeline-status/0.1/store-pipeline-status.yaml
+      params:
+        - name: oci-ref
+          value: "$(params.oci-container-repo):$(context.pipelineRun.name)"
+        - name: credentials-secret-name
+          value: "$(params.konflux-test-infra-secret)"
+        - name: pipelinerun-name
+          value: $(context.pipelineRun.name)
+        - name: pipeline-aggregate-status
+          value: $(tasks.status)
     - name: deprovision-rosa-collect-artifacts
       taskRef:
         resolver: git


### PR DESCRIPTION
## Description
Add a Task to the finally section that will wait for all other tasks to complete and then store their status in a json and uploads it to OCI artifact

## JIRA
[KFLUXDP-241](https://issues.redhat.com//browse/KFLUXDP-241)

## Verification
in [this PR](https://github.com/konflux-ci/e2e-tests/pull/1589/files)