### PR TITLE
fix: canceled status of snapshot should be considered as finished

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -520,9 +520,9 @@ func IsSnapshotValid(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	return false
 }
 
-// IsSnapshotIntegrationStatusMarkedAsFinished returns true if snapshot is marked as finished
+// IsSnapshotIntegrationStatusMarkedAsFinished returns true if snapshot is marked as finished or canceled
 func IsSnapshotIntegrationStatusMarkedAsFinished(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return IsSnapshotStatusConditionSet(snapshot, AppStudioIntegrationStatusCondition, metav1.ConditionTrue, AppStudioIntegrationStatusFinished)
+	return IsSnapshotStatusConditionSet(snapshot, AppStudioIntegrationStatusCondition, metav1.ConditionTrue, AppStudioIntegrationStatusFinished) || IsSnapshotStatusConditionSet(snapshot, AppStudioIntegrationStatusCondition, metav1.ConditionTrue, AppStudioIntegrationStatusCanceled)
 }
 
 // IsSnapshotStatusConditionSet checks if the condition with the conditionType in the status of Snapshot has been marked as the conditionStatus and reason.

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -350,6 +350,17 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(gitops.IsSnapshotIntegrationStatusMarkedAsFinished(hasSnapshot)).To(BeTrue())
 	})
 
+	It("ensures the Snapshots status won't be marked as finished if it is canceled", func() {
+		err := gitops.MarkSnapshotAsCanceled(ctx, k8sClient, hasSnapshot, "canceled")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(hasSnapshot.Status.Conditions).NotTo(BeNil())
+		if !gitops.IsSnapshotIntegrationStatusMarkedAsFinished(hasSnapshot) {
+			err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
+			Expect(err).ToNot(HaveOccurred())
+		}
+		Expect(gitops.IsSnapshotMarkedAsCanceled(hasSnapshot)).To(BeTrue())
+	})
+
 	It("ensures the Snapshots status can be marked as in progress", func() {
 		err := gitops.MarkSnapshotIntegrationStatusAsInProgress(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
* Canceled status of snapshot should be considered as finished when it is being checked and marked as finished in EnsureSnapshotFinishedAllTests of statusreport adapter

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
