### PR TITLE
fix: prevent nil-pointer error when ITS status isn't set

### DIFF
--- a/helpers/scenario.go
+++ b/helpers/scenario.go
@@ -58,5 +58,5 @@ func SetScenarioIntegrationStatusAsValid(scenario *v1beta2.IntegrationTestScenar
 // IsScenarioValid sets the IntegrationTestScenarioValid integration status condition for the Scenario to valid.
 func IsScenarioValid(scenario *v1beta2.IntegrationTestScenario) bool {
 	statusCondition := meta.FindStatusCondition(scenario.Status.Conditions, IntegrationTestScenarioValid)
-	return statusCondition.Status != metav1.ConditionFalse
+	return statusCondition != nil && statusCondition.Status != metav1.ConditionFalse
 }

--- a/helpers/scenario_test.go
+++ b/helpers/scenario_test.go
@@ -86,5 +86,12 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			Expect(helpers.IsScenarioValid(integrationTestScenario)).To(BeTrue())
 			Expect(meta.IsStatusConditionTrue(integrationTestScenario.Status.Conditions, helpers.IntegrationTestScenarioValid)).To(BeTrue())
 		})
+
+		It("ensures the Scenario is considered invalid if it doesn't have the required status condition", func() {
+			uncheckedIntegrationTestScenario := integrationTestScenario.DeepCopy()
+			uncheckedIntegrationTestScenario.Status.Conditions = []metav1.Condition{}
+			Expect(uncheckedIntegrationTestScenario).NotTo(BeNil())
+			Expect(helpers.IsScenarioValid(uncheckedIntegrationTestScenario)).To(BeFalse())
+		})
 	})
 })


### PR DESCRIPTION
* If the ITS hasn't yet been validated, the snapshot adapter will run into a nil-pointer error when fetching all scenarios and checking if that scenario is valid
* This fixes the issue by also checking if the status condition for the ITS is set in the first place

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
