### PR TITLE
fix: update gitlint ignore author

### DIFF
--- a/.gitlint
+++ b/.gitlint
@@ -14,4 +14,4 @@ line-length=72
 [contrib-title-conventional-commits]
 
 [ignore-by-author-name]
-regex=((.*dependabot.*)|(red-hat-konflux))
+regex=(.*)(dependabot|red-hat-konflux)(.*)


### PR DESCRIPTION
Ignore all `*red-hat-konflux*` bot accounts for gitlint rules to include more than the base bot.

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
