### PR TITLE
feat(STONEINTG-1215): new serviceaccount for integration pipelineRuns

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -771,6 +771,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 		WithIntegrationLabels(integrationTestScenario).
 		WithIntegrationAnnotations(integrationTestScenario).
 		WithApplication(a.application).
+		WithServiceAccount(a.generateServiceAccountNameForSnapshot(snapshot)).
 		WithExtraParams(integrationTestScenario.Spec.Params).
 		WithFinalizer(h.IntegrationPipelineRunFinalizer).
 		WithIntegrationTimeouts(integrationTestScenario, a.logger.Logger)
@@ -1102,4 +1103,10 @@ func (a *Adapter) cancelAllPipelineRunsForSnapshot(snapshot *applicationapiv1alp
 		}
 	}
 	return nil
+}
+
+// generateServiceAccountNameForSnapshot generates the service account name that should be used for
+// integration pipelineRuns for a given snapshot - this function is extracted here to facilitate future changes
+func (a *Adapter) generateServiceAccountNameForSnapshot(snapshot *applicationapiv1alpha1.Snapshot) string {
+	return fmt.Sprintf("%s-pull", snapshot.Spec.Application)
 }

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -1117,6 +1117,19 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(found).To(BeFalse())
 		})
 
+		It("ensures serviceAccount is generated correctly for the Integration test PLR", func() {
+			expectedServiceAccountName := fmt.Sprintf("%s-pull", hasApp.Name)
+			serviceAccountName := adapter.generateServiceAccountNameForSnapshot(hasSnapshot)
+			Expect(serviceAccountName).ToNot(BeNil())
+			Expect(serviceAccountName).To(Equal(expectedServiceAccountName))
+
+			pipelineRun, err := adapter.createIntegrationPipelineRun(hasApp, integrationTestScenario, hasSnapshot)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipelineRun).ToNot(BeNil())
+
+			Expect(pipelineRun.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
+		})
+
 		When("pull request updates repo with integration test", func() {
 
 			const (

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -392,6 +392,13 @@ func (r *IntegrationPipelineRun) WithApplication(application *applicationapiv1al
 	return r
 }
 
+// WithServiceAccount adds the specified service account to the Integration PipelineRun's TaskRunTemplate.
+func (r *IntegrationPipelineRun) WithServiceAccount(serviceAccountName string) *IntegrationPipelineRun {
+	r.Spec.TaskRunTemplate.ServiceAccountName = serviceAccountName
+
+	return r
+}
+
 // WithIntegrationTimeouts fetches the Integration timeouts from either the integrationTestScenario annotations or
 // the environment variables and adds them to the integration PipelineRun.
 func (r *IntegrationPipelineRun) WithIntegrationTimeouts(integrationTestScenario *v1beta2.IntegrationTestScenario, logger logr.Logger) *IntegrationPipelineRun {

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -517,5 +517,14 @@ var _ = Describe("Integration pipeline", func() {
 				"test.appstudio.openshift.io/future": "future",
 			}))
 		})
+
+		It("sets the service account correctly", func() {
+			serviceAccountName := "application-pull"
+
+			ipr := tekton.IntegrationPipelineRun{}
+			ipr.WithServiceAccount(serviceAccountName)
+
+			Expect(ipr.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
+		})
 	})
 })


### PR DESCRIPTION
* Set the new application-based pull serviceaccounts for integration pipelineRuns (`$APPLICATION_NAME-pull`)
* Create the new `generateServiceAccountNameForSnapshot` function to make any future changes to service account name generation logic easier to implement

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
