### PR TITLE
chore: increase resultionRequest wait factor

### DIFF
--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -204,7 +204,7 @@ func getPipelineRunYamlFromPipelineRunResolver(client client.Client, ctx context
 	resolverBackoff := wait.Backoff{
 		Steps:    60,
 		Duration: 1 * time.Second,
-		Factor:   1.0,
+		Factor:   1.25,
 		Jitter:   0.5,
 	}
 	var resolvedRequest resolutionv1beta1.ResolutionRequest


### PR DESCRIPTION
When the integration service watches a new ResolutionRequest for completion it has a factor of 1, meaning the duration between attempts stays the same (no exponential backoff).  This commit increases the factor slightly in order to give a greater grace period in which the resolutionrequest can be updated.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
