### PR TITLE
fix: race condition in pipelinerun creation

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -269,9 +269,14 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 				a.logger.Info("IntegrationTestScenario is invalid, will not create pipelineRun for it",
 					"integrationTestScenario.Name", integrationTestScenario.Name)
 				scenarioStatusCondition := meta.FindStatusCondition(integrationTestScenario.Status.Conditions, h.IntegrationTestScenarioValid)
+				// prevents a race condition where the scenario has not been validated yet when a new snapshot is created
+				message := ""
+				if scenarioStatusCondition != nil {
+					message = scenarioStatusCondition.Message
+				}
 				testStatuses.UpdateTestStatusIfChanged(
 					integrationTestScenario.Name, intgteststat.IntegrationTestStatusTestInvalid,
-					fmt.Sprintf("IntegrationTestScenario '%s' is invalid: %s", integrationTestScenario.Name, scenarioStatusCondition.Message))
+					fmt.Sprintf("IntegrationTestScenario '%s' is invalid: %s", integrationTestScenario.Name, message))
 				continue
 			}
 			// Check if an existing integration pipelineRun is registered in the Snapshot's status


### PR DESCRIPTION
When a snapshot is created, we go through the list of scenarios associated with that snapshot's application and create pipelineruns for any valid scenarios.  If a scenario is created at the same time as the snapshot then it may not be marked as valid in time for it to be run. Since the scenario is marked as neither valid nor invalid we were running into a nil point dereference from the missing status condition. This commit handles that edge case.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
