### PR TITLE
hotfix: ignore admission webhooks for integrationtestscenarios

### DIFF
--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -20,7 +20,7 @@ webhooks:
         name: webhook-service
         namespace: system
         path: /mutate-appstudio-redhat-com-v1beta2-integrationtestscenario
-    failurePolicy: Fail
+    failurePolicy: Ignore
     rules:
     - apiGroups:
       - appstudio.redhat.com
@@ -53,7 +53,7 @@ webhooks:
         name: integration-service-webhook-service
         namespace: {{ .Values.namespace | default .Release.Namespace }}
         path: /validate-appstudio-redhat-com-v1beta2-integrationtestscenario
-    failurePolicy: Fail
+    failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions:
       - v1
@@ -74,7 +74,7 @@ webhooks:
         name: integration-service-webhook-service
         namespace: {{ .Values.namespace | default .Release.Namespace }}
         path: /validate-appstudio-redhat-com-v1beta2-integrationtestscenario
-    failurePolicy: Fail
+    failurePolicy: Ignore
     sideEffects: None
     admissionReviewVersions:
       - v1


### PR DESCRIPTION
Fixing a bug in prod, roll back once fixed

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
