### PR TITLE
fix: give integrationservice admins all persmissions on scenario/status

### DIFF
--- a/config/rbac/integrationtestscenario_admin_role.yaml
+++ b/config/rbac/integrationtestscenario_admin_role.yaml
@@ -24,4 +24,4 @@ rules:
   resources:
   - integrationtestscenarios/status
   verbs:
-  - get
+  - '*'

--- a/dist/chart/templates/rbac/integrationtestscenario_admin_role.yaml
+++ b/dist/chart/templates/rbac/integrationtestscenario_admin_role.yaml
@@ -24,5 +24,5 @@ rules:
   resources:
   - integrationtestscenarios/status
   verbs:
-  - get
+  - '*'
 {{- end -}}


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
