### PR TITLE
chore: make failing webhooks fail rather than ignore

### DIFF
--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -20,7 +20,7 @@ webhooks:
         name: webhook-service
         namespace: system
         path: /mutate-appstudio-redhat-com-v1beta2-integrationtestscenario
-    failurePolicy: Ignore
+    failurePolicy: Fail
     rules:
     - apiGroups:
       - appstudio.redhat.com
@@ -53,7 +53,7 @@ webhooks:
         name: integration-service-webhook-service
         namespace: {{ .Values.namespace | default .Release.Namespace }}
         path: /validate-appstudio-redhat-com-v1beta2-integrationtestscenario
-    failurePolicy: Ignore
+    failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:
       - v1
@@ -74,7 +74,7 @@ webhooks:
         name: integration-service-webhook-service
         namespace: {{ .Values.namespace | default .Release.Namespace }}
         path: /validate-appstudio-redhat-com-v1beta2-integrationtestscenario
-    failurePolicy: Ignore
+    failurePolicy: Fail
     sideEffects: None
     admissionReviewVersions:
       - v1


### PR DESCRIPTION
Revert the change from#1152 that was made to unblock a hotfix in prod

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
