### PR TITLE
fix(KONFLUX-8344): account for trailing slash in ITS git url

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -716,7 +716,7 @@ func urlToGitUrl(url string) string {
 	if strings.HasSuffix(url, ".git") {
 		return url
 	}
-	return url + ".git"
+	return strings.TrimSuffix(url, "/") + ".git"
 }
 
 // shouldUpdateIntegrationTestGitResolver checks if the integration test resolver should be updated based on the source repo


### PR DESCRIPTION
* If an integration test scenario has a trailing slash in git URL, account for it when determining it the source repo info should be overwritten for needs of PR testing
* An URL with a trailing slash is considered valid by Tekton

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
