### PR TITLE
fix: show plr url to user in check

### DIFF
--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -133,13 +133,14 @@ func (a *Adapter) EnsureIntegrationPipelineRunLogURL() (controller.OperationResu
 
 // GetIntegrationPipelineRunStatus checks the Tekton results for a given PipelineRun and returns status of test.
 func (a *Adapter) GetIntegrationPipelineRunStatus(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun) (intgteststat.IntegrationTestStatus, string, error) {
+	integrationPipelineRunURL := status.FormatPipelineURL(pipelineRun.Name, pipelineRun.Namespace, a.logger.Logger)
 	// Check if the pipelineRun finished from the condition of status
 	if !h.HasPipelineRunFinished(pipelineRun) {
 		// Mark the pipelineRun's status as "Deleted" if its not finished yet and is marked for deletion (with a non-nil deletionTimestamp)
 		if pipelineRun.GetDeletionTimestamp() != nil {
 			return intgteststat.IntegrationTestStatusDeleted, fmt.Sprintf("Integration test which is running as pipeline run '%s', has been deleted", pipelineRun.Name), nil
 		} else {
-			return intgteststat.IntegrationTestStatusInProgress, fmt.Sprintf("Integration test is running as pipeline run '%s'", pipelineRun.Name), nil
+			return intgteststat.IntegrationTestStatusInProgress, fmt.Sprintf("Integration test is running as pipeline run '%s'", integrationPipelineRunURL), nil
 		}
 	}
 


### PR DESCRIPTION
- show the PLR url to users when in progress
- otherwise, users have to copy the name and then manually goto Konflux UI and filter for the PLR

![Screenshot from 2025-06-04 11-10-38](https://github.com/user-attachments/assets/89f60df0-7de6-42b7-aff8-25a9009ce5a2)

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
