### PR TITLE
fix: make resourceKind case-insensitive

### DIFF
--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -125,9 +125,9 @@ func NewIntegrationPipelineRun(client client.Client, ctx context.Context, prefix
 	resolver := integrationTestScenario.Spec.ResolverRef.Resolver
 	resourceKind := integrationTestScenario.Spec.ResolverRef.ResourceKind
 	tektonResolverParams := generateTektonResolverParams(resolverParams)
-	if resourceKind == ResourceKindPipeline || resourceKind == "" {
+	if strings.EqualFold(resourceKind, ResourceKindPipeline) || resourceKind == "" {
 		return generateIntegrationPipelineRunFromPipelineResolver(prefix, namespace, resolver, tektonResolverParams), nil
-	} else if resourceKind == ResourceKindPipelineRun {
+	} else if strings.EqualFold(resourceKind, ResourceKindPipelineRun) {
 		base64plr, err := getPipelineRunYamlFromPipelineRunResolver(client, ctx, prefix, namespace, resolver, tektonResolverParams)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Prior to this commit the ITS spec.resolverRef.resourceKind field had to be all lowercase.  This change makes it case insensitive in order to prevent confusion from users that prefer camel case

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
