### PR TITLE
feat(KFLUXDP-239): remove quality dashboard task

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -40,9 +40,6 @@ spec:
     - name: oci-container-repo
       default: 'quay.io/konflux-test-storage/konflux-team/integration-service'
       description: The OCI container used to store all test artifacts.
-    - name: quality-dashboard-api
-      default: 'none'
-      description: 'Contains the url of the backend to send metrics for quality purposes.'
     - name: component-image
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
@@ -209,27 +206,6 @@ spec:
           value: $(params.cloud-credential-key)
         - name: pipeline-aggregate-status
           value: $(tasks.status)
-    - name: quality-dashboard-upload
-      taskRef:
-        resolver: git
-        params:
-          - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
-          - name: revision
-            value: main
-          - name: pathInRepo
-            value: common/tasks/quality-dashboard/0.1/quality-dashboard-upload.yaml
-      params:
-        - name: oci-container
-          value: $(params.oci-container-repo):$(context.pipelineRun.name)
-        - name: quality-dashboard-api
-          value: $(params.quality-dashboard-api)
-        - name: pipeline-aggregate-status
-          value: $(tasks.status)
-        - name: test-event-type
-          value: $(tasks.test-metadata.results.test-event-type)
-        - name: test-name
-          value: $(context.pipelineRun.name)
     - name: pull-request-status-message
       taskRef:
         resolver: git


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)

We dont need anymore to push artifacts to quality dashboard. The dashboard is able to pull the artifacts automatically after implementing https://issues.redhat.com/browse/KFLUXDP-240

