### PR TITLE
fix(STONEINTG-1259): increase the lease renewal time

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -31,6 +31,9 @@ spec:
         - /manager
         args:
         - --leader-elect
+        - "--lease-duration=30s"
+        - "--leader-renew-deadline=15s"
+        - "--leader-elector-retry-period=5s"
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION
* This change tries to fix/decrease the daily crashes of the integration controller by increasing the lease renew time.

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
