### PR TITLE
chore: enlarge timeout for the test EnsureIntegrationPipelineRunLogURL

### DIFF
--- a/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
@@ -1092,7 +1092,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				return updatedPR.Annotations
-			}).Should(HaveKey(logURLKey))
+			}, time.Second*20).Should(HaveKey(logURLKey))
 
 		})
 


### PR DESCRIPTION
* add timeout to test for EnsureIntegrationPipelineRunLogURL because time is not enought to check plr

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
