### PR TITLE
fix(STONEINTG-1248) adjust non-pr-snapshots count for gc

### DIFF
--- a/config/snapshotgc/snapshotgc.yaml
+++ b/config/snapshotgc/snapshotgc.yaml
@@ -16,7 +16,7 @@ spec:
                 - /snapshotgc
                 - --zap-log-level=debug
                 - --pr-snapshots-to-keep=70
-                - --non-pr-snapshots-to-keep=600
+                - --non-pr-snapshots-to-keep=500
               imagePullPolicy: Always
               resources:
                 requests:

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -91,7 +91,7 @@ snapshotgc:
   args:
     - --zap-log-level=debug
     - --pr-snapshots-to-keep=70
-    - --non-pr-snapshots-to-keep=600
+    - --non-pr-snapshots-to-keep=500
   resources:
     requests:
       cpu: 1000m


### PR DESCRIPTION
## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
