### PR TITLE
fix(STONEINTG-1252): return status codes in status updates

### DIFF
--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -229,9 +229,10 @@ var _ = Describe("Client", func() {
 	})
 
 	It("can create app installation tokens", func() {
-		token, err := client.CreateAppInstallationToken(context.TODO(), 1, 1, []byte(samplePrivateKey))
+		token, statusCode, err := client.CreateAppInstallationToken(context.TODO(), 1, 1, []byte(samplePrivateKey))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(token).To(Equal("example-token"))
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("accepts an OAuth token", func() {
@@ -252,15 +253,17 @@ var _ = Describe("Client", func() {
 	})
 
 	It("can create comments", func() {
-		id, err := client.CreateComment(context.TODO(), "", "", 1, "example-comment")
+		id, statusCode, err := client.CreateComment(context.TODO(), "", "", 1, "example-comment")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(id).To(Equal(int64(40)))
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("can create commit statuses", func() {
-		id, err := client.CreateCommitStatus(context.TODO(), "", "", "", "", "", "", "")
+		id, statusCode, err := client.CreateCommitStatus(context.TODO(), "", "", "", "", "", "", "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(id).To(Equal(int64(50)))
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("can set and get details URL", func() {
@@ -271,26 +274,30 @@ var _ = Describe("Client", func() {
 	})
 
 	It("can create check runs", func() {
-		checkRunID, err := client.CreateCheckRun(context.TODO(), checkRunAdapter)
+		checkRunID, statusCode, err := client.CreateCheckRun(context.TODO(), checkRunAdapter)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkRunID).ToNot(BeNil())
 		Expect(*checkRunID).To(Equal(int64(10)))
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("can update check runs", func() {
-		err := client.UpdateCheckRun(context.TODO(), 1, checkRunAdapter)
+		statusCode, err := client.UpdateCheckRun(context.TODO(), 1, checkRunAdapter)
 		Expect(err).ToNot(HaveOccurred())
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("can get a check run ID", func() {
-		checkRunID, err := client.GetCheckRunID(context.TODO(), "", "", "", "example-external-id", 1)
+		checkRunID, statusCode, err := client.GetCheckRunID(context.TODO(), "", "", "", "example-external-id", 1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkRunID).ToNot(BeNil())
 		Expect(*checkRunID).To(Equal(int64(20)))
+		Expect(statusCode).NotTo(BeNil())
 
-		checkRunID, err = client.GetCheckRunID(context.TODO(), "", "", "", "unknown-external-id", 1)
+		checkRunID, statusCode, err = client.GetCheckRunID(context.TODO(), "", "", "", "unknown-external-id", 1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checkRunID).To(BeNil())
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("can check if check run updated is needed", func() {
@@ -308,9 +315,10 @@ var _ = Describe("Client", func() {
 			CompletionTime: time.Now(),
 		}
 
-		allCheckRuns, err := client.GetAllCheckRunsForRef(context.TODO(), "", "", "", 1)
+		allCheckRuns, statusCode, err := client.GetAllCheckRunsForRef(context.TODO(), "", "", "", 1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(allCheckRuns).NotTo(BeEmpty())
+		Expect(statusCode).NotTo(BeNil())
 
 		existingCheckRun := client.GetExistingCheckRun(allCheckRuns, checkRunAdapter)
 		Expect(existingCheckRun).NotTo(BeNil())
@@ -318,9 +326,10 @@ var _ = Describe("Client", func() {
 	})
 
 	It("can check if creating a new commit status is needed", func() {
-		commitStatuses, err := client.GetAllCommitStatusesForRef(context.TODO(), "", "", "")
+		commitStatuses, statusCode, err := client.GetAllCommitStatusesForRef(context.TODO(), "", "", "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(commitStatuses).NotTo(BeEmpty())
+		Expect(statusCode).NotTo(BeNil())
 
 		commitStatusExist, err := client.CommitStatusExists(commitStatuses, commitStatusAdapter)
 		Expect(commitStatusExist).To(BeTrue())
@@ -341,23 +350,26 @@ var _ = Describe("Client", func() {
 	})
 
 	It("can get existing comment id", func() {
-		comments, err := client.GetAllCommentsForPR(context.TODO(), "", "", 1)
+		comments, statusCode, err := client.GetAllCommentsForPR(context.TODO(), "", "", 1)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(comments).NotTo(BeEmpty())
+		Expect(statusCode).NotTo(BeNil())
 
 		commentID := client.GetExistingCommentID(comments, "snapshotName", "scenarioName")
 		Expect(*commentID).To(Equal(int64(40)))
 	})
 
 	It("can edit comments", func() {
-		id, err := client.EditComment(context.TODO(), "", "", 1, "example-comment")
+		id, statusCode, err := client.EditComment(context.TODO(), "", "", 1, "example-comment")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(id).To(Equal(int64(1)))
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 	It("can get pull request", func() {
-		pullRequest, err := client.GetPullRequest(context.TODO(), "", "", 60)
+		pullRequest, statusCode, err := client.GetPullRequest(context.TODO(), "", "", 60)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(*pullRequest.State).To(Equal("opened"))
+		Expect(statusCode).NotTo(BeNil())
 	})
 })

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -1532,7 +1532,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			mockStatus = status.NewMockStatusInterface(ctrl)
 			mockReporter.EXPECT().GetReporterName().Return("mocked-reporter").AnyTimes()
 			mockStatus.EXPECT().GetReporter(gomock.Any()).Return(mockReporter).AnyTimes()
-			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasSnapshot, nil).AnyTimes()
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasSnapshot, 0, nil).AnyTimes()
 			mockReporter.EXPECT().GetReporterName().AnyTimes()
 			mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).AnyTimes()
 			mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).AnyTimes()
@@ -1703,7 +1703,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			}
 
 			//mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), hasComSnapshot2).Return(true, nil)
-			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).Return(true, nil).AnyTimes()
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).Return(true, 0, nil).AnyTimes()
 
 			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -902,13 +902,15 @@ func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Appli
 		applicationComponent := applicationComponent // G601
 
 		var foundSnapshotWithOpenedPR *applicationapiv1alpha1.Snapshot
+		var statusCode int
 		if slices.Contains(componentsToCheck, applicationComponent.Name) {
 			snapshots, err := a.loader.GetMatchingComponentSnapshotsForComponentAndPRGroupHash(a.context, a.client, application.Namespace, applicationComponent.Name, prGroupHash, application.Name)
 			if err != nil {
 				a.logger.Error(err, "Failed to fetch Snapshots for component", "component.Name", applicationComponent.Name)
 				return nil, nil, err
 			}
-			foundSnapshotWithOpenedPR, err = a.status.FindSnapshotWithOpenedPR(a.context, snapshots)
+			foundSnapshotWithOpenedPR, statusCode, err = a.status.FindSnapshotWithOpenedPR(a.context, snapshots)
+			a.logger.Error(err, "failed to find snapshot with open PR or MR", "statusCode", statusCode)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -2347,8 +2347,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			ctrl := gomock.NewController(GinkgoT())
 			mockStatus := status.NewMockStatusInterface(ctrl)
-			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot2, nil)
-			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot3, nil)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot2, 0, nil)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot3, 0, nil)
 			// mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).Return(true, nil)
 			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/internal/controller/statusreport/statusreport_adapter_test.go
+++ b/internal/controller/statusreport/statusreport_adapter_test.go
@@ -811,8 +811,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			adapter = NewAdapter(ctx, githubSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
-			err := adapter.ReportSnapshotStatus(githubSnapshot)
+			statusCode, err := adapter.ReportSnapshotStatus(githubSnapshot)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		It("doesn't report anything when data are older", func() {
@@ -827,8 +828,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			hasPRSnapshot.Annotations["test.appstudio.openshift.io/git-reporter-status"] = "{\"scenarios\":{\"scenario1-snapshot-pr-sample\":{\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\"}}}"
 			adapter = NewAdapter(ctx, hasPRSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
-			err := adapter.ReportSnapshotStatus(adapter.snapshot)
+			statusCode, err := adapter.ReportSnapshotStatus(adapter.snapshot)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		It("Report new status if it was updated", func() {
@@ -844,8 +846,9 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			hasPRSnapshot.Annotations["test.appstudio.openshift.io/group-test-info"] = "[{\"namespace\":\"default\",\"component\":\"devfile-sample-java-springboot-basic-8969\",\"buildPipelineRun\":\"build-plr-java-qjfxz\",\"snapshot\":\"app-8969-bbn7d\",\"pullRuestNumber\":\"1\",\"repoUrl\":\"https://example.com\"},{\"namespace\":\"default\",\"component\":\"devfile-sample-go-basic-8969\",\"buildPipelineRun\":\"build-plr-go-jmsjq\",\"snapshot\":\"app-8969-kzq2l\",\"pullRuestNumber\":\"1\",\"repoUrl\":\"https://example.com\"}]"
 			adapter = NewAdapter(ctx, hasPRSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
-			err := adapter.ReportSnapshotStatus(adapter.snapshot)
+			statusCode, err := adapter.ReportSnapshotStatus(adapter.snapshot)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		It("Report new status if it was updated (old way - migration test)", func() {
@@ -860,9 +863,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			hasPRSnapshot.Annotations["test.appstudio.openshift.io/pr-last-update"] = "2023-08-26T17:57:49+02:00"
 			adapter = NewAdapter(ctx, hasPRSnapshot, hasApp, logger, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
-			err := adapter.ReportSnapshotStatus(adapter.snapshot)
+			statusCode, err := adapter.ReportSnapshotStatus(adapter.snapshot)
 			fmt.Fprintf(GinkgoWriter, "-------test: %v\n", "")
 			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		It("report expected textual data for InProgress test scenario", func() {
@@ -891,9 +895,10 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Eq(expectedTestReport)).Times(1)
 			adapter = NewAdapter(ctx, hasPRSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
 			adapter.status = mockStatus
-			err = adapter.ReportSnapshotStatus(adapter.snapshot)
+			statusCode, err := adapter.ReportSnapshotStatus(adapter.snapshot)
 			fmt.Fprintf(GinkgoWriter, "-------test: %v\n", buf.String())
 			Expect(err).NotTo(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 		})
 	})
 

--- a/status/mock_reporter.go
+++ b/status/mock_reporter.go
@@ -83,15 +83,26 @@ func (mr *MockReporterInterfaceMockRecorder) Initialize(arg0, arg1 any) *gomock.
 }
 
 // ReportStatus mocks base method.
-func (m *MockReporterInterface) ReportStatus(arg0 context.Context, arg1 TestReport) error {
+func (m *MockReporterInterface) ReportStatus(arg0 context.Context, arg1 TestReport) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ReportStatus", arg0, arg1)
 	ret0, _ := ret[0].(error)
-	return ret0
+	return 200, ret0
 }
 
 // ReportStatus indicates an expected call of ReportStatus.
 func (mr *MockReporterInterfaceMockRecorder) ReportStatus(arg0, arg1 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReportStatus", reflect.TypeOf((*MockReporterInterface)(nil).ReportStatus), arg0, arg1)
+}
+
+func (mr *MockReporterInterface) ReturnCodeIsUnrecoverable(statusCode int) bool {
+	mr.ctrl.T.Helper()
+	return false
+}
+
+func (mr *MockReporterInterfaceMockRecorder) ReturnCodeIsUnrecoverable(arg0 any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReturnCodeIsUnrecoverable", reflect.TypeOf((*MockReporterInterface)(nil).ReportStatus), arg0)
+
 }

--- a/status/mock_reporter.go
+++ b/status/mock_reporter.go
@@ -69,11 +69,11 @@ func (mr *MockReporterInterfaceMockRecorder) GetReporterName() *gomock.Call {
 }
 
 // Initialize mocks base method.
-func (m *MockReporterInterface) Initialize(arg0 context.Context, arg1 *v1alpha1.Snapshot) error {
+func (m *MockReporterInterface) Initialize(arg0 context.Context, arg1 *v1alpha1.Snapshot) (int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Initialize", arg0, arg1)
 	ret0, _ := ret[0].(error)
-	return ret0
+	return 0, ret0
 }
 
 // Initialize indicates an expected call of Initialize.

--- a/status/mock_status.go
+++ b/status/mock_status.go
@@ -55,12 +55,13 @@ func (mr *MockStatusInterfaceMockRecorder) GetReporter(arg0 any) *gomock.Call {
 }
 
 // IsMRInSnapshotOpened mocks base method.
-func (m *MockStatusInterface) IsMRInSnapshotOpened(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) (bool, error) {
+func (m *MockStatusInterface) IsMRInSnapshotOpened(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) (bool, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsMRInSnapshotOpened", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // IsMRInSnapshotOpened indicates an expected call of IsMRInSnapshotOpened.
@@ -70,12 +71,13 @@ func (mr *MockStatusInterfaceMockRecorder) IsMRInSnapshotOpened(arg0, arg1, arg2
 }
 
 // IsPRInSnapshotOpened mocks base method.
-func (m *MockStatusInterface) IsPRInSnapshotOpened(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) (bool, error) {
+func (m *MockStatusInterface) IsPRInSnapshotOpened(arg0 context.Context, arg1 ReporterInterface, arg2 *v1alpha1.Snapshot) (bool, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPRInSnapshotOpened", arg0, arg1, arg2)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // IsPRInSnapshotOpened indicates an expected call of IsPRInSnapshotOpened.
@@ -85,12 +87,13 @@ func (mr *MockStatusInterfaceMockRecorder) IsPRInSnapshotOpened(arg0, arg1, arg2
 }
 
 // IsPRMRInSnapshotOpened mocks base method.
-func (m *MockStatusInterface) IsPRMRInSnapshotOpened(arg0 context.Context, arg1 *v1alpha1.Snapshot) (bool, error) {
+func (m *MockStatusInterface) IsPRMRInSnapshotOpened(arg0 context.Context, arg1 *v1alpha1.Snapshot) (bool, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "IsPRMRInSnapshotOpened", arg0, arg1)
 	ret0, _ := ret[0].(bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // IsPRMRInSnapshotOpened indicates an expected call of IsPRMRInSnapshotOpened.
@@ -100,12 +103,13 @@ func (mr *MockStatusInterfaceMockRecorder) IsPRMRInSnapshotOpened(arg0, arg1 any
 }
 
 // FindSnapshotWithOpenedPR mocks base method.
-func (m *MockStatusInterface) FindSnapshotWithOpenedPR(arg0 context.Context, arg1 *[]v1alpha1.Snapshot) (*v1alpha1.Snapshot, error) {
+func (m *MockStatusInterface) FindSnapshotWithOpenedPR(arg0 context.Context, arg1 *[]v1alpha1.Snapshot) (*v1alpha1.Snapshot, int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "FindSnapshotWithOpenedPR", arg0, arg1)
 	ret0, _ := ret[0].(*v1alpha1.Snapshot)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(int)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // FindSnapshotWithOpenedPR indicates an expected call of FindSnapshotWithOpenedPR.

--- a/status/reporter.go
+++ b/status/reporter.go
@@ -66,7 +66,9 @@ type ReporterInterface interface {
 	// Get plain reporter name
 	GetReporterName() string
 	// Update status of the integration test
-	ReportStatus(context.Context, TestReport) error
+	ReportStatus(context.Context, TestReport) (int, error)
+	// Is the return code a recoverable error
+	ReturnCodeIsUnrecoverable(statusCode int) bool
 }
 
 // GetPACGitProviderToken lookup for configured repo and fetch token from namespace

--- a/status/reporter.go
+++ b/status/reporter.go
@@ -62,7 +62,7 @@ type ReporterInterface interface {
 	// Detect if the reporter can be used with the snapshot
 	Detect(*applicationapiv1alpha1.Snapshot) bool
 	// Initialize reporter to be able to update statuses (authenticate, fetching metadata)
-	Initialize(context.Context, *applicationapiv1alpha1.Snapshot) error
+	Initialize(context.Context, *applicationapiv1alpha1.Snapshot) (int, error)
 	// Get plain reporter name
 	GetReporterName() string
 	// Update status of the integration test

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -271,8 +271,9 @@ var _ = Describe("GitHubReporter", func() {
 
 			mockGitHubClient = &MockGitHubClient{}
 			reporter = status.NewGitHubReporter(log, mockK8sClient, status.WithGitHubClient(mockGitHubClient))
-			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		It("failed to initialize when invalid pac secret and private names is not found", func() {
@@ -280,8 +281,9 @@ var _ = Describe("GitHubReporter", func() {
 			os.Setenv("PAC_SECRET", "invalid")
 			os.Setenv("GITHUBAPPLICATION_ID", "invalid")
 			os.Setenv("GITHUBPRIVATE_KEY", "invalid")
-			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 			os.Setenv("INTEGRATION_NS", "integration-service")
 			os.Setenv("PAC_SECRET", "pipelines-as-code-secret")
 			os.Setenv("GITHUBAPPLICATION_ID", "github-application-id")
@@ -305,26 +307,31 @@ var _ = Describe("GitHubReporter", func() {
 		It("doesn't report status when the credentials are invalid/missing", func() {
 			// Invalid installation ID value
 			hasSnapshot.Annotations["pac.test.appstudio.openshift.io/installation-id"] = "bad-installation-id"
-			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
+			Expect(statusCode).NotTo(BeNil())
 			hasSnapshot.Annotations["pac.test.appstudio.openshift.io/installation-id"] = "123"
 
 			// Invalid app ID value
 			secretData["github-application-id"] = []byte("bad-app-id")
-			err = reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err = reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 			secretData["github-application-id"] = []byte("456")
 
 			// Missing app ID value
 			delete(secretData, "github-application-id")
-			err = reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err = reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 			secretData["github-application-id"] = []byte("456")
 
 			// Missing private key
 			delete(secretData, "github-private-key")
-			err = reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err = reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(HaveOccurred())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		DescribeTable(
@@ -549,8 +556,9 @@ var _ = Describe("GitHubReporter", func() {
 			mockGitHubClient = &MockGitHubClient{}
 			reporter = status.NewGitHubReporter(log, mockK8sClient, status.WithGitHubClient(mockGitHubClient))
 
-			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
+			Expect(statusCode).NotTo(BeNil())
 		})
 
 		It("creates a commit status for snapshot with correct textual data", func() {

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -98,25 +98,24 @@ type MockGitHubClient struct {
 	EditCommentResult
 }
 
-func (c *MockGitHubClient) CreateAppInstallationToken(ctx context.Context, appID int64, installationID int64, privateKey []byte) (string, error) {
-	//nolint:staticcheck // Ignore QF1008
-	return c.CreateAppInstallationTokenResult.Token, c.CreateAppInstallationTokenResult.Error
+func (c *MockGitHubClient) CreateAppInstallationToken(ctx context.Context, appID int64, installationID int64, privateKey []byte) (string, int, error) {
+	return c.Token, 0, c.CreateAppInstallationTokenResult.Error
 }
 
 func (c *MockGitHubClient) SetOAuthToken(ctx context.Context, token string) {}
 
-func (c *MockGitHubClient) CreateCheckRun(ctx context.Context, cra *github.CheckRunAdapter) (*int64, error) {
+func (c *MockGitHubClient) CreateCheckRun(ctx context.Context, cra *github.CheckRunAdapter) (*int64, int, error) {
 	c.CreateCheckRunResult.cra = cra
-	return c.CreateCheckRunResult.ID, c.CreateCheckRunResult.Error
+	return c.CreateCheckRunResult.ID, 200, c.CreateCheckRunResult.Error
 }
 
-func (c *MockGitHubClient) UpdateCheckRun(ctx context.Context, checkRunID int64, cra *github.CheckRunAdapter) error {
+func (c *MockGitHubClient) UpdateCheckRun(ctx context.Context, checkRunID int64, cra *github.CheckRunAdapter) (int, error) {
 	c.UpdateCheckRunResult.cra = cra
-	return c.UpdateCheckRunResult.Error
+	return 0, c.UpdateCheckRunResult.Error
 }
 
-func (c *MockGitHubClient) GetCheckRunID(context.Context, string, string, string, string, int64) (*int64, error) {
-	return c.GetCheckRunIDResult.ID, c.GetCheckRunIDResult.Error
+func (c *MockGitHubClient) GetCheckRunID(context.Context, string, string, string, string, int64) (*int64, int, error) {
+	return c.GetCheckRunIDResult.ID, 200, c.GetCheckRunIDResult.Error
 }
 
 func (c *MockGitHubClient) GetExistingCheckRun(checkRuns []*ghapi.CheckRun, cra *github.CheckRunAdapter) *ghapi.CheckRun {
@@ -136,22 +135,22 @@ func (c *MockGitHubClient) CommitStatusExists(res []*ghapi.RepoStatus, commitSta
 }
 
 //nolint:staticcheck // Ignore QF1008
-func (c *MockGitHubClient) CreateComment(ctx context.Context, owner string, repo string, issueNumber int, body string) (int64, error) {
+func (c *MockGitHubClient) CreateComment(ctx context.Context, owner string, repo string, issueNumber int, body string) (int64, int, error) {
 	c.CreateCommentResult.body = body
 	c.CreateCommentResult.issueNumber = issueNumber
-	return c.CreateCommentResult.ID, c.CreateCommentResult.Error
+	return c.CreateCommentResult.ID, 200, c.CreateCommentResult.Error
 }
 
-func (c *MockGitHubClient) EditComment(ctx context.Context, owner string, repo string, commentID int64, body string) (int64, error) {
+func (c *MockGitHubClient) EditComment(ctx context.Context, owner string, repo string, commentID int64, body string) (int64, int, error) {
 	c.EditCommentResult.body = body
 	c.EditCommentResult.ID = commentID
-	return c.EditCommentResult.ID, c.EditCommentResult.Error
+	return c.EditCommentResult.ID, 200, c.EditCommentResult.Error
 }
 
-func (c *MockGitHubClient) GetAllCommentsForPR(ctx context.Context, owner string, repo string, pr int) ([]*ghapi.IssueComment, error) {
+func (c *MockGitHubClient) GetAllCommentsForPR(ctx context.Context, owner string, repo string, pr int) ([]*ghapi.IssueComment, int, error) {
 	var id int64 = 20
 	comments := []*ghapi.IssueComment{{ID: &id}}
-	return comments, nil
+	return comments, 200, nil
 }
 
 func (c *MockGitHubClient) GetExistingCommentID(comments []*ghapi.IssueComment, snapshotName, scenarioName string) *int64 {
@@ -159,40 +158,40 @@ func (c *MockGitHubClient) GetExistingCommentID(comments []*ghapi.IssueComment, 
 }
 
 //nolint:staticcheck  // Ignore QF1008
-func (c *MockGitHubClient) CreateCommitStatus(ctx context.Context, owner string, repo string, SHA string, state string, description string, statusContext string, targetURL string) (int64, error) {
+func (c *MockGitHubClient) CreateCommitStatus(ctx context.Context, owner string, repo string, SHA string, state string, description string, statusContext string, targetURL string) (int64, int, error) {
 	var id int64 = 60
 	c.CreateCommitStatusResult.ID = id
 	c.CreateCommitStatusResult.state = state
 	c.CreateCommitStatusResult.description = description
 	c.CreateCommitStatusResult.statusContext = statusContext
 	c.CreateCommitStatusResult.targetURL = targetURL
-	return c.CreateCommitStatusResult.ID, c.CreateCommitStatusResult.Error
+	return c.CreateCommitStatusResult.ID, 200, c.CreateCommitStatusResult.Error
 }
 
 func (c *MockGitHubClient) GetAllCheckRunsForRef(
 	ctx context.Context, owner string, repo string, ref string, appID int64,
-) ([]*ghapi.CheckRun, error) {
+) ([]*ghapi.CheckRun, int, error) {
 	var id int64 = 20
 	var externalID = "example-external-id"
 	checkRuns := []*ghapi.CheckRun{{ID: &id, ExternalID: &externalID}}
-	return checkRuns, nil
+	return checkRuns, 200, nil
 }
 
 func (c *MockGitHubClient) GetAllCommitStatusesForRef(
-	ctx context.Context, owner, repo, sha string) ([]*ghapi.RepoStatus, error) {
+	ctx context.Context, owner, repo, sha string) ([]*ghapi.RepoStatus, int, error) {
 	var id int64 = 60
 	var state = "pending"
 	var description = "Integration test for snapshot snapshot-sample and scenario scenario2 is pending"
 	var statusContext = "test/scenario2"
 	repoStatus := &ghapi.RepoStatus{ID: &id, State: &state, Context: &statusContext, Description: &description}
-	return []*ghapi.RepoStatus{repoStatus}, nil
+	return []*ghapi.RepoStatus{repoStatus}, 200, nil
 }
 
-func (c *MockGitHubClient) GetPullRequest(ctx context.Context, owner string, repo string, prID int) (*ghapi.PullRequest, error) {
+func (c *MockGitHubClient) GetPullRequest(ctx context.Context, owner string, repo string, prID int) (*ghapi.PullRequest, int, error) {
 	var id int64 = 60
 	var state = "opened"
 	pullRequest := &ghapi.PullRequest{ID: &id, State: &state}
-	return pullRequest, nil
+	return pullRequest, 200, nil
 }
 
 var _ = Describe("GitHubReporter", func() {
@@ -332,12 +331,15 @@ var _ = Describe("GitHubReporter", func() {
 			"reports correct github title and conclusion from test statuses",
 			func(teststatus integrationteststatus.IntegrationTestStatus, title string, conclusion string) {
 
-				Expect(reporter.ReportStatus(
+				statusCode, err := reporter.ReportStatus(
 					context.TODO(),
 					status.TestReport{
 						ScenarioName: "scenario1",
 						Status:       teststatus,
-					})).To(Succeed())
+					})
+
+				Expect(err).To(Succeed(), "ReportStatus should succeed")
+				Expect(statusCode).To(Equal(200))
 				Expect(mockGitHubClient.CreateCheckRunResult.cra).NotTo(BeNil())
 				Expect(mockGitHubClient.CreateCheckRunResult.cra.Title).To(Equal(title))
 				Expect(mockGitHubClient.CreateCheckRunResult.cra.Conclusion).To(Equal(conclusion))
@@ -359,19 +361,22 @@ var _ = Describe("GitHubReporter", func() {
 
 		It("check if all integration tests statuses are supported", func() {
 			for _, teststatus := range integrationteststatus.IntegrationTestStatusValues() {
-				Expect(reporter.ReportStatus(
+				statusCode, err := reporter.ReportStatus(
 					context.TODO(),
 					status.TestReport{
 						ScenarioName: "scenario1",
 						Status:       teststatus,
-					})).To(Succeed())
+					})
+
+				Expect(err).To(Succeed(), "ReportStatus should succeed")
+				Expect(statusCode).To(Equal(200))
 			}
 		})
 
 		It("reports all details of snapshot tests status via CheckRuns", func() {
 			now := time.Now()
 
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:       "test-name",
@@ -382,7 +387,10 @@ var _ = Describe("GitHubReporter", func() {
 					Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment",
 					StartTime:      &now,
 					CompletionTime: &now,
-				})).To(Succeed())
+				})
+
+			Expect(err).To(Succeed(), "ReportStatus should succeed")
+			Expect(statusCode).To(Equal(200))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra).NotTo(BeNil())
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
@@ -398,7 +406,7 @@ var _ = Describe("GitHubReporter", func() {
 		It("reports all details of snapshot tests status via CheckRuns for a Snapshot without a component", func() {
 			now := time.Now()
 
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:       "test-name",
@@ -408,7 +416,10 @@ var _ = Describe("GitHubReporter", func() {
 					Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment",
 					StartTime:      &now,
 					CompletionTime: &now,
-				})).To(Succeed())
+				})
+
+			Expect(err).To(Succeed(), "ReportStatus should succeed")
+			Expect(statusCode).To(Equal(200))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra).NotTo(BeNil())
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
@@ -431,7 +442,7 @@ var _ = Describe("GitHubReporter", func() {
 			// Update existing CheckRun w/failure
 			//nolint:staticcheck  // Ignore QF1008
 			mockGitHubClient.GetCheckRunResult.cr = &ghapi.CheckRun{ID: &id, ExternalID: &externalID, Conclusion: &conclusion}
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:       "test-name",
@@ -442,7 +453,10 @@ var _ = Describe("GitHubReporter", func() {
 					Summary:        "Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment",
 					StartTime:      &now,
 					CompletionTime: &now,
-				})).To(Succeed())
+				})
+
+			Expect(err).To(Succeed(), "ReportStatus should succeed")
+			Expect(statusCode).To(Equal(0))
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra).NotTo(BeNil())
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment"))
 			Expect(mockGitHubClient.UpdateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
@@ -465,7 +479,7 @@ var _ = Describe("GitHubReporter", func() {
 			//nolint:staticcheck  // Ignore QF1008
 			mockGitHubClient.GetCheckRunResult.cr = &ghapi.CheckRun{ID: &id, ExternalID: &externalID, Status: &checkrunStatus}
 
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:      "test-name",
@@ -475,7 +489,9 @@ var _ = Describe("GitHubReporter", func() {
 					Status:        integrationteststatus.IntegrationTestStatusInProgress,
 					Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 is in progress",
 					StartTime:     &now,
-				})).To(Succeed())
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(200))
 
 			expectedLogEntry = "found existing checkrun"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
@@ -539,7 +555,7 @@ var _ = Describe("GitHubReporter", func() {
 
 		It("creates a commit status for snapshot with correct textual data", func() {
 			hasSnapshot.Labels["pac.test.appstudio.openshift.io/pull-request"] = "999"
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:      "fullname/scenario1",
@@ -549,7 +565,10 @@ var _ = Describe("GitHubReporter", func() {
 					Status:        integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
 					Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 failed",
 					Text:          "detailed text here",
-				})).To(Succeed())
+				})
+
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal(gitops.IntegrationTestStatusErrorGithub))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 failed"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("fullname/scenario1"))
@@ -559,7 +578,7 @@ var _ = Describe("GitHubReporter", func() {
 		It("creates a commit status for snapshot with correct textual data, but does not create a comment for push event", func() {
 			delete(hasSnapshot.Annotations, "pac.test.appstudio.openshift.io/pull-request")
 			hasSnapshot.Labels["pac.test.appstudio.openshift.io/event-type"] = "push"
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:      "fullname/scenario1",
@@ -569,8 +588,10 @@ var _ = Describe("GitHubReporter", func() {
 					Status:        integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
 					Summary:       "Integration test for snapshot snapshot-sample and scenario scenario1 failed",
 					Text:          "detailed text here",
-				})).To(Succeed(), "ReportStatus should succeed")
+				})
 
+			Expect(err).To(Succeed(), "ReportStatus should succeed")
+			Expect(statusCode).To(Equal(0))
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal(gitops.IntegrationTestStatusErrorGithub))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 failed"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("fullname/scenario1"))
@@ -581,12 +602,14 @@ var _ = Describe("GitHubReporter", func() {
 			"reports correct github statuses from test statuses",
 			func(teststatus integrationteststatus.IntegrationTestStatus, ghstatus string) {
 
-				Expect(reporter.ReportStatus(
+				statusCode, err := reporter.ReportStatus(
 					context.TODO(),
 					status.TestReport{
 						ScenarioName: "scenario1",
 						Status:       teststatus,
-					})).To(Succeed())
+					})
+				Expect(err).To(Succeed(), "ReportStatus should succeed")
+				Expect(statusCode).To(Equal(0))
 				Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal(ghstatus))
 			},
 			Entry("Provision error", integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated, gitops.IntegrationTestStatusErrorGithub),
@@ -605,12 +628,15 @@ var _ = Describe("GitHubReporter", func() {
 
 		It("check if all integration tests statuses are supported", func() {
 			for _, teststatus := range integrationteststatus.IntegrationTestStatusValues() {
-				Expect(reporter.ReportStatus(
+				statusCode, err := reporter.ReportStatus(
 					context.TODO(),
 					status.TestReport{
 						ScenarioName: "scenario1",
 						Status:       teststatus,
-					})).To(Succeed())
+					})
+
+				Expect(err).To(Succeed(), "ReportStatus should succeed")
+				Expect(statusCode).To(Equal(0))
 			}
 		})
 
@@ -621,7 +647,9 @@ var _ = Describe("GitHubReporter", func() {
 				Status:       integrationteststatus.IntegrationTestStatusPending,
 				Summary:      "Integration test for snapshot snapshot-sample and scenario scenario2 is pending",
 			}
-			Expect(reporter.ReportStatus(context.TODO(), testReport)).To(Succeed())
+			statusCode, err := reporter.ReportStatus(context.TODO(), testReport)
+			Expect(err).To(Succeed(), "ReportStatus should succeed")
+			Expect(statusCode).To(Equal(0))
 			expectedLogEntry := "found existing commitStatus for scenario test status of snapshot, no need to create new commit status"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
@@ -634,7 +662,10 @@ var _ = Describe("GitHubReporter", func() {
 				Status:       integrationteststatus.IntegrationTestStatusPending,
 				Summary:      "Integration test for snapshot snapshot-sample and scenario scenario2 is pending",
 			}
-			Expect(reporter.ReportStatus(context.TODO(), testReport)).To(Succeed())
+			statusCode, err := reporter.ReportStatus(context.TODO(), testReport)
+			Expect(err).To(Succeed(), "ReportStatus should succeed")
+			Expect(statusCode).To(Equal(0))
+
 			expectedLogEntry := "Won't create/update commitStatus since there is access limitation for different source and target Repo Owner"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -178,8 +178,9 @@ var _ = Describe("GitLabReporter", func() {
 
 			reporter = status.NewGitLabReporter(log, mockK8sClient)
 
-			err := reporter.Initialize(context.TODO(), hasSnapshot)
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 
 		})
 
@@ -193,7 +194,9 @@ var _ = Describe("GitLabReporter", func() {
 			} else {
 				delete(hasSnapshot.Annotations, missingKey)
 			}
-			Expect(reporter.Initialize(context.TODO(), hasSnapshot)).ToNot(Succeed())
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
+			Expect(err).ToNot(Succeed())
+			Expect(statusCode).To(Equal(0))
 		},
 			Entry("Missing repo_url", gitops.PipelineAsCodeRepoURLAnnotation, false),
 			Entry("Missing SHA", gitops.PipelineAsCodeSHALabel, true),
@@ -230,14 +233,15 @@ var _ = Describe("GitLabReporter", func() {
 
 			pushEventReporter := status.NewGitLabReporter(log, mockK8sClient)
 
-			err := pushEventReporter.Initialize(context.TODO(), pushSnapshot)
+			statusCode, err := pushEventReporter.Initialize(context.TODO(), pushSnapshot)
 			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 
 			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
 
 			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
 
-			statusCode, err := pushEventReporter.ReportStatus(
+			statusCode, err = pushEventReporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:     "fullname/scenario1",
@@ -345,7 +349,9 @@ var _ = Describe("GitLabReporter", func() {
 
 		It("don't create commit status when source and target project ID are different", func() {
 			Expect(metadata.SetAnnotation(hasSnapshot, gitops.PipelineAsCodeSourceProjectIDAnnotation, "0")).To(Succeed())
-			Expect(reporter.Initialize(context.TODO(), hasSnapshot)).To(Succeed())
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 
 			PipelineRunName := "TestPipeline"
 			expectedURL := status.FormatPipelineURL(PipelineRunName, hasSnapshot.Namespace, logr.Discard())
@@ -354,7 +360,7 @@ var _ = Describe("GitLabReporter", func() {
 			muxMergeNotes(mux, sourceProjectID, mergeRequest, "")
 			muxCommitStatusesGet(mux, sourceProjectID, digest, nil)
 
-			statusCode, err := reporter.ReportStatus(
+			statusCode, err = reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:            "fullname/scenario1",

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -208,7 +208,7 @@ var _ = Describe("GitLabReporter", func() {
 			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
 			muxMergeNotes(mux, targetProjectID, mergeRequest, summary)
 
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:     "fullname/scenario1",
@@ -216,7 +216,9 @@ var _ = Describe("GitLabReporter", func() {
 					Status:       integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
 					Summary:      summary,
 					Text:         "detailed text here",
-				})).To(Succeed())
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 		})
 
 		It("creates a commit status for push snapshot with correct textual data without comments", func() {
@@ -235,7 +237,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
 
-			Expect(pushEventReporter.ReportStatus(
+			statusCode, err := pushEventReporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:     "fullname/scenario1",
@@ -243,7 +245,9 @@ var _ = Describe("GitLabReporter", func() {
 					Status:       integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
 					Summary:      summary,
 					Text:         "detailed text here",
-				})).To(Succeed())
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 		})
 
 		It("creates a commit status for snapshot with TargetURL in CommitStatus", func() {
@@ -255,7 +259,7 @@ var _ = Describe("GitLabReporter", func() {
 			muxMergeNotes(mux, sourceProjectID, mergeRequest, "")
 			muxCommitStatusesGet(mux, sourceProjectID, digest, nil)
 
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:            "fullname/scenario1",
@@ -264,7 +268,9 @@ var _ = Describe("GitLabReporter", func() {
 					Status:              integrationteststatus.IntegrationTestStatusInProgress,
 					Summary:             "summary",
 					Text:                "detailed text here",
-				})).To(Succeed())
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 		})
 
 		It("does not create a commit status or comment for snapshot with existing matching checkRun in running state", func() {
@@ -280,7 +286,9 @@ var _ = Describe("GitLabReporter", func() {
 
 			muxCommitStatusesGet(mux, sourceProjectID, digest, &report)
 
-			Expect(reporter.ReportStatus(context.TODO(), report)).To(Succeed())
+			statusCode, err := reporter.ReportStatus(context.TODO(), report)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 		})
 
 		It("can get an existing commitStatus that matches the report", func() {
@@ -346,7 +354,7 @@ var _ = Describe("GitLabReporter", func() {
 			muxMergeNotes(mux, sourceProjectID, mergeRequest, "")
 			muxCommitStatusesGet(mux, sourceProjectID, digest, nil)
 
-			Expect(reporter.ReportStatus(
+			statusCode, err := reporter.ReportStatus(
 				context.TODO(),
 				status.TestReport{
 					FullName:            "fullname/scenario1",
@@ -355,7 +363,9 @@ var _ = Describe("GitLabReporter", func() {
 					Status:              integrationteststatus.IntegrationTestStatusInProgress,
 					Summary:             "summary",
 					Text:                "detailed text here",
-				})).To(Succeed())
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
 
 			expectedLogEntry := "Won't create/update commitStatus due to the access limitation for forked repo"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -474,7 +474,7 @@ var _ = Describe("Status Adapter", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		mockReporter = status.NewMockReporterInterface(ctrl)
 		mockReporter.EXPECT().GetReporterName().Return("mocked-reporter").AnyTimes()
-		mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(0, nil).AnyTimes()
 		mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).Return(0, nil).AnyTimes()
 
 		os.Setenv("CONSOLE_NAME", "Red Hat Konflux")
@@ -712,40 +712,46 @@ var _ = Describe("Status Adapter", func() {
 		})
 
 		It("can return unrecoverable error when label is not defined for githubReporter", func() {
-			err := metadata.DeleteLabel(hasSnapshot, gitops.PipelineAsCodeURLOrgLabel)
-			Expect(err).ToNot(HaveOccurred())
+			metadataErr := metadata.DeleteLabel(hasSnapshot, gitops.PipelineAsCodeURLOrgLabel)
+			Expect(metadataErr).ToNot(HaveOccurred())
 			githubReporter := status.NewGitHubReporter(logr.Discard(), mockK8sClient)
-			err = githubReporter.Initialize(context.Background(), hasSnapshot)
+			statusCode, err := githubReporter.Initialize(context.Background(), hasSnapshot)
 			Expect(helpers.IsUnrecoverableMetadataError(err)).To(BeTrue())
+			Expect(statusCode).To(Equal(0))
 
 			err = metadata.SetLabel(hasSnapshot, gitops.PipelineAsCodeURLOrgLabel, "org")
 			Expect(err).ToNot(HaveOccurred())
 			err = metadata.DeleteLabel(hasSnapshot, gitops.PipelineAsCodeURLRepositoryLabel)
 			Expect(err).ToNot(HaveOccurred())
-			err = githubReporter.Initialize(context.Background(), hasSnapshot)
+			statusCode, err = githubReporter.Initialize(context.Background(), hasSnapshot)
 			Expect(helpers.IsUnrecoverableMetadataError(err)).To(BeTrue())
+			Expect(statusCode).To(Equal(0))
 
 			err = metadata.SetLabel(hasSnapshot, gitops.PipelineAsCodeURLRepositoryLabel, "repo")
 			Expect(err).ToNot(HaveOccurred())
 			err = metadata.DeleteLabel(hasSnapshot, gitops.PipelineAsCodeSHALabel)
 			Expect(err).ToNot(HaveOccurred())
-			err = githubReporter.Initialize(context.Background(), hasSnapshot)
+			statusCode, err = githubReporter.Initialize(context.Background(), hasSnapshot)
 			Expect(helpers.IsUnrecoverableMetadataError(err)).To(BeTrue())
+			Expect(statusCode).To(Equal(0))
+
 		})
 
 		It("can return unrecoverable error when label/annotation is not defined for gitlabReporter", func() {
 			err := metadata.DeleteAnnotation(hasSnapshot, gitops.PipelineAsCodeRepoURLAnnotation)
 			Expect(err).ToNot(HaveOccurred())
 			gitlabReporter := status.NewGitLabReporter(logr.Discard(), mockK8sClient)
-			err = gitlabReporter.Initialize(context.Background(), hasSnapshot)
+			statusCode, err := gitlabReporter.Initialize(context.Background(), hasSnapshot)
 			Expect(helpers.IsUnrecoverableMetadataError(err)).To(BeTrue())
+			Expect(statusCode).To(Equal(0))
 
 			err = metadata.SetAnnotation(hasSnapshot, gitops.PipelineAsCodeRepoURLAnnotation, "https://test-repo.example.com")
 			Expect(err).ToNot(HaveOccurred())
 			err = metadata.SetAnnotation(hasSnapshot, gitops.PipelineAsCodeSourceProjectIDAnnotation, "qqq")
 			Expect(err).ToNot(HaveOccurred())
-			err = gitlabReporter.Initialize(context.Background(), hasSnapshot)
+			statusCode, err = gitlabReporter.Initialize(context.Background(), hasSnapshot)
 			Expect(helpers.IsUnrecoverableMetadataError(err)).To(BeTrue())
+			Expect(statusCode).To(Equal(0))
 		})
 	})
 

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -475,7 +475,7 @@ var _ = Describe("Status Adapter", func() {
 		mockReporter = status.NewMockReporterInterface(ctrl)
 		mockReporter.EXPECT().GetReporterName().Return("mocked-reporter").AnyTimes()
 		mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-		mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+		mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).Return(0, nil).AnyTimes()
 
 		os.Setenv("CONSOLE_NAME", "Red Hat Konflux")
 	})
@@ -754,7 +754,9 @@ var _ = Describe("Status Adapter", func() {
 			Status:  integrationteststatus.GroupSnapshotCreationFailed,
 			Details: "details",
 		}
-		Expect(status.IterateIntegrationTestInStatusReport(context.Background(), mockK8sClient, mockReporter, hasSnapshot, &[]v1beta2.IntegrationTestScenario{*integrationTestScenario}, integrationTestStatusDetail, "test")).Should(Succeed())
+		statusCode, err := status.IterateIntegrationTestInStatusReport(context.Background(), mockK8sClient, mockReporter, hasSnapshot, &[]v1beta2.IntegrationTestScenario{*integrationTestScenario}, integrationTestStatusDetail, "test")
+		Expect(err).Should(Succeed())
+		Expect(statusCode).NotTo(BeNil())
 	})
 
 })


### PR DESCRIPTION
* Return the response status code when querying git APIs both for GitLab and GitHub and bubble them up to the controller calls
* Ensure that controllers which run into unrecoverable issues such as 403 codes when reporting to git provider don't  endlessly requeue the reconciliations for the affected resource

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
