### PR TITLE
fix: decrease ResoltuionRequest wait.backoff retries

### DIFF
--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -202,7 +202,7 @@ func getPipelineRunYamlFromPipelineRunResolver(client client.Client, ctx context
 	}()
 
 	resolverBackoff := wait.Backoff{
-		Steps:    60,
+		Steps:    20,
 		Duration: 1 * time.Second,
 		Factor:   1.25,
 		Jitter:   0.5,


### PR DESCRIPTION
Decrease the number of retries for getting resolved ResolutionRequests from 60 to 20.  With 60 retries we'll wait a total of 3 million seconds before giving up.  With 20 we only wait 480 seconds

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
