### PR TITLE
feat: add validation webhook for snapshot component immutability

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -178,6 +178,10 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IntegrationTestScenario")
 		os.Exit(1)
 	}
+	if err = iswebhook.SetupSnapshotWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "Snapshot")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -52,3 +52,24 @@ webhooks:
     resources:
     - integrationtestscenarios
   sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
+      path: /validate-appstudio-redhat-com-v1alpha1-snapshot
+  failurePolicy: Fail
+  name: vsnapshot.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1alpha1
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - snapshots
+  sideEffects: None

--- a/internal/controller/snapshot/snapshot_controller_test.go
+++ b/internal/controller/snapshot/snapshot_controller_test.go
@@ -196,7 +196,7 @@ var _ = Describe("SnapshotController", func() {
 				Namespace: hasSnapshot.Namespace,
 				Name:      hasSnapshot.Name,
 			}, hasSnapshot)
-			return err == nil
+			return err == nil && len(hasSnapshot.ObjectMeta.OwnerReferences) > 0
 		}).Should(BeTrue())
 		Expect(hasSnapshot.ObjectMeta.OwnerReferences).ToNot(BeNil())
 		Expect(hasSnapshot.ObjectMeta.GetOwnerReferences()[0].Name).To(Equal(hasApp.Name))

--- a/internal/webhook/v1beta2/snapshot_webhook.go
+++ b/internal/webhook/v1beta2/snapshot_webhook.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	ctrl "sigs.k8s.io/controller-runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"context"
+	"fmt"
+	"reflect"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var snapshotlog = logf.Log.WithName("snapshot-webhook")
+
+func SetupSnapshotWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&applicationapiv1alpha1.Snapshot{}).
+		WithValidator(&SnapshotCustomValidator{}).
+		Complete()
+}
+
+// SnapshotCustomValidator is a webhook handler and does not need deepcopy methods.
+// +k8s:deepcopy-gen=false
+type SnapshotCustomValidator struct {
+	// TODO(user): Add more fields as needed for validation
+}
+
+// +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshot,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshots,verbs=create;update;delete,versions=v1alpha1,name=vsnapshot.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomValidator = &SnapshotCustomValidator{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (v *SnapshotCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	snapshot, ok := obj.(*applicationapiv1alpha1.Snapshot)
+	if !ok {
+		return nil, fmt.Errorf("expected a Snapshot object but got %T", obj)
+	}
+
+	snapshotlog.Info("Validating Snapshot upon creation", "name", snapshot.GetName())
+
+	// No specific validation needed for create operations
+	// Components can be set during creation
+
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (v *SnapshotCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	oldSnapshot, ok := oldObj.(*applicationapiv1alpha1.Snapshot)
+	if !ok {
+		return nil, fmt.Errorf("expected a Snapshot object for oldObj but got %T", oldObj)
+	}
+
+	newSnapshot, ok := newObj.(*applicationapiv1alpha1.Snapshot)
+	if !ok {
+		return nil, fmt.Errorf("expected a Snapshot object for newObj but got %T", newObj)
+	}
+
+	snapshotlog.Info("Validating Snapshot upon update", "name", newSnapshot.GetName())
+
+	// Check if components field has been modified
+	if !reflect.DeepEqual(oldSnapshot.Spec.Components, newSnapshot.Spec.Components) {
+		snapshotlog.Info("Components field modification detected", "name", newSnapshot.GetName())
+		return nil, field.Invalid(
+			field.NewPath("spec").Child("components"),
+			newSnapshot.Spec.Components,
+			"components field is immutable and cannot be modified after creation",
+		)
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (v *SnapshotCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	snapshot, ok := obj.(*applicationapiv1alpha1.Snapshot)
+	if !ok {
+		return nil, fmt.Errorf("expected a Snapshot object but got %T", obj)
+	}
+
+	snapshotlog.Info("Validating Snapshot upon deletion", "name", snapshot.GetName())
+
+	// No specific validation needed for delete operations
+
+	return nil, nil
+}

--- a/internal/webhook/v1beta2/snapshot_webhook_test.go
+++ b/internal/webhook/v1beta2/snapshot_webhook_test.go
@@ -1,0 +1,253 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	types "k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Snapshot webhook", Ordered, func() {
+
+	var (
+		snapshot           *applicationapiv1alpha1.Snapshot
+		hasApp             *applicationapiv1alpha1.Application
+		originalComponents []applicationapiv1alpha1.SnapshotComponent
+	)
+
+	BeforeAll(func() {
+		hasApp = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-application",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "test-application",
+				Description: "This is a test application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
+
+		originalComponents = []applicationapiv1alpha1.SnapshotComponent{
+			{
+				Name:           "component-1",
+				ContainerImage: "registry.io/image1:v1.0.0",
+			},
+			{
+				Name:           "component-2",
+				ContainerImage: "registry.io/image2:v1.0.0",
+			},
+		}
+	})
+
+	BeforeEach(func() {
+		snapshot = &applicationapiv1alpha1.Snapshot{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "appstudio.redhat.com/v1alpha1",
+				Kind:       "Snapshot",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: "test-application",
+				DisplayName: "Test Snapshot",
+				Components:  originalComponents,
+			},
+		}
+	})
+
+	AfterEach(func() {
+		err := k8sClient.Delete(ctx, snapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, hasApp)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should successfully create a snapshot with components", func() {
+		Expect(k8sClient.Create(ctx, snapshot)).Should(Succeed())
+
+		// Verify the snapshot was created with the correct components
+		createdSnapshot := &applicationapiv1alpha1.Snapshot{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			}, createdSnapshot)
+		}).Should(Succeed())
+
+		Expect(createdSnapshot.Spec.Components).To(Equal(originalComponents))
+	})
+
+	It("should reject updates to the components field", func() {
+		// Create the snapshot first
+		Expect(k8sClient.Create(ctx, snapshot)).Should(Succeed())
+
+		// Try to update the components field
+		updatedSnapshot := &applicationapiv1alpha1.Snapshot{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			}, updatedSnapshot)
+		}).Should(Succeed())
+
+		// Modify the components
+		updatedSnapshot.Spec.Components = append(updatedSnapshot.Spec.Components, applicationapiv1alpha1.SnapshotComponent{
+			Name:           "component-3",
+			ContainerImage: "registry.io/image3:v1.0.0",
+		})
+
+		// This update should fail due to webhook validation
+		Expect(k8sClient.Update(ctx, updatedSnapshot)).ShouldNot(Succeed())
+	})
+
+	It("should reject modifications to existing components", func() {
+		// Create the snapshot first
+		Expect(k8sClient.Create(ctx, snapshot)).Should(Succeed())
+
+		// Try to modify an existing component
+		updatedSnapshot := &applicationapiv1alpha1.Snapshot{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			}, updatedSnapshot)
+		}).Should(Succeed())
+
+		// Modify the container image of the first component
+		updatedSnapshot.Spec.Components[0].ContainerImage = "registry.io/image1:v2.0.0"
+
+		// This update should fail due to webhook validation
+		Expect(k8sClient.Update(ctx, updatedSnapshot)).ShouldNot(Succeed())
+	})
+
+	It("should reject removal of components", func() {
+		// Create the snapshot first
+		Expect(k8sClient.Create(ctx, snapshot)).Should(Succeed())
+
+		// Try to remove a component
+		updatedSnapshot := &applicationapiv1alpha1.Snapshot{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			}, updatedSnapshot)
+		}).Should(Succeed())
+
+		// Remove the last component
+		updatedSnapshot.Spec.Components = updatedSnapshot.Spec.Components[:len(updatedSnapshot.Spec.Components)-1]
+
+		// This update should fail due to webhook validation
+		Expect(k8sClient.Update(ctx, updatedSnapshot)).ShouldNot(Succeed())
+	})
+
+	It("should handle invalid object types gracefully", func() {
+		validator := &SnapshotCustomValidator{}
+
+		// Test ValidateCreate with wrong object type
+		_, err := validator.ValidateCreate(ctx, hasApp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected a Snapshot object"))
+
+		// Test ValidateUpdate with wrong oldObj type
+		_, err = validator.ValidateUpdate(ctx, hasApp, snapshot)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected a Snapshot object for oldObj"))
+
+		// Test ValidateUpdate with wrong newObj type
+		_, err = validator.ValidateUpdate(ctx, snapshot, hasApp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected a Snapshot object for newObj"))
+
+		// Test ValidateDelete with wrong object type
+		_, err = validator.ValidateDelete(ctx, hasApp)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("expected a Snapshot object"))
+	})
+
+	It("should directly test validator methods without cluster", func() {
+		validator := &SnapshotCustomValidator{}
+
+		// Test ValidateCreate directly
+		_, err := validator.ValidateCreate(ctx, snapshot)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test ValidateUpdate with identical components (should succeed)
+		snapshot2 := snapshot.DeepCopy()
+		_, err = validator.ValidateUpdate(ctx, snapshot, snapshot2)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test ValidateUpdate with different components (should fail)
+		snapshot3 := snapshot.DeepCopy()
+		snapshot3.Spec.Components[0].ContainerImage = "registry.io/image1:v2.0.0"
+		_, err = validator.ValidateUpdate(ctx, snapshot, snapshot3)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("components field is immutable"))
+
+		// Test ValidateDelete directly
+		_, err = validator.ValidateDelete(ctx, snapshot)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should allow updates to other fields while preserving components", func() {
+		// Create the snapshot first
+		Expect(k8sClient.Create(ctx, snapshot)).Should(Succeed())
+
+		// Update non-components fields
+		updatedSnapshot := &applicationapiv1alpha1.Snapshot{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			}, updatedSnapshot)
+		}).Should(Succeed())
+
+		// Modify display name and description (but keep components unchanged)
+		updatedSnapshot.Spec.DisplayName = "Updated Test Snapshot"
+		updatedSnapshot.Spec.DisplayDescription = "Updated description"
+
+		// This update should succeed as components are not modified
+		Expect(k8sClient.Update(ctx, updatedSnapshot)).Should(Succeed())
+
+		// Verify the changes were applied
+		Eventually(func() error {
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			}, updatedSnapshot)
+			if err != nil {
+				return err
+			}
+			if updatedSnapshot.Spec.DisplayName != "Updated Test Snapshot" {
+				return errors.NewBadRequest("DisplayName was not updated")
+			}
+			return nil
+		}).Should(Succeed())
+
+		// Verify components remained unchanged
+		Expect(updatedSnapshot.Spec.Components).To(Equal(originalComponents))
+	})
+})

--- a/internal/webhook/v1beta2/snapshot_webhook_unit_test.go
+++ b/internal/webhook/v1beta2/snapshot_webhook_unit_test.go
@@ -1,0 +1,202 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"context"
+	"testing"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSnapshotCustomValidator_ValidateCreate(t *testing.T) {
+	validator := &SnapshotCustomValidator{}
+	ctx := context.Background()
+
+	snapshot := &applicationapiv1alpha1.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-snapshot",
+			Namespace: "default",
+		},
+		Spec: applicationapiv1alpha1.SnapshotSpec{
+			Application: "test-app",
+			Components: []applicationapiv1alpha1.SnapshotComponent{
+				{
+					Name:           "component-1",
+					ContainerImage: "registry.io/image1:v1.0.0",
+				},
+			},
+		},
+	}
+
+	t.Run("should allow snapshot creation", func(t *testing.T) {
+		_, err := validator.ValidateCreate(ctx, snapshot)
+		if err != nil {
+			t.Errorf("ValidateCreate should not error, got: %v", err)
+		}
+	})
+
+	t.Run("should reject non-snapshot object", func(t *testing.T) {
+		app := &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-app"},
+		}
+		_, err := validator.ValidateCreate(ctx, app)
+		if err == nil {
+			t.Error("ValidateCreate should error for non-snapshot object")
+		}
+		if err != nil && err.Error() != "expected a Snapshot object but got *v1alpha1.Application" {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestSnapshotCustomValidator_ValidateUpdate(t *testing.T) {
+	validator := &SnapshotCustomValidator{}
+	ctx := context.Background()
+
+	originalSnapshot := &applicationapiv1alpha1.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-snapshot",
+			Namespace: "default",
+		},
+		Spec: applicationapiv1alpha1.SnapshotSpec{
+			Application: "test-app",
+			Components: []applicationapiv1alpha1.SnapshotComponent{
+				{
+					Name:           "component-1",
+					ContainerImage: "registry.io/image1:v1.0.0",
+				},
+			},
+		},
+	}
+
+	t.Run("should allow update with identical components", func(t *testing.T) {
+		updatedSnapshot := originalSnapshot.DeepCopy()
+		updatedSnapshot.Spec.DisplayName = "Updated Name"
+
+		_, err := validator.ValidateUpdate(ctx, originalSnapshot, updatedSnapshot)
+		if err != nil {
+			t.Errorf("ValidateUpdate should not error for identical components, got: %v", err)
+		}
+	})
+
+	t.Run("should reject update with modified components", func(t *testing.T) {
+		updatedSnapshot := originalSnapshot.DeepCopy()
+		updatedSnapshot.Spec.Components[0].ContainerImage = "registry.io/image1:v2.0.0"
+
+		_, err := validator.ValidateUpdate(ctx, originalSnapshot, updatedSnapshot)
+		if err == nil {
+			t.Error("ValidateUpdate should error for modified components")
+		}
+		if err != nil && err.Error() != "spec.components: Invalid value: []v1alpha1.SnapshotComponent{v1alpha1.SnapshotComponent{Name:\"component-1\", ContainerImage:\"registry.io/image1:v2.0.0\", Source:v1alpha1.ComponentSource{ComponentSourceUnion:v1alpha1.ComponentSourceUnion{GitSource:(*v1alpha1.GitSource)(nil)}}}}: components field is immutable and cannot be modified after creation" {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("should reject update with added components", func(t *testing.T) {
+		updatedSnapshot := originalSnapshot.DeepCopy()
+		updatedSnapshot.Spec.Components = append(updatedSnapshot.Spec.Components, applicationapiv1alpha1.SnapshotComponent{
+			Name:           "component-2",
+			ContainerImage: "registry.io/image2:v1.0.0",
+		})
+
+		_, err := validator.ValidateUpdate(ctx, originalSnapshot, updatedSnapshot)
+		if err == nil {
+			t.Error("ValidateUpdate should error for added components")
+		}
+	})
+
+	t.Run("should reject update with removed components", func(t *testing.T) {
+		multiComponentSnapshot := originalSnapshot.DeepCopy()
+		multiComponentSnapshot.Spec.Components = append(multiComponentSnapshot.Spec.Components, applicationapiv1alpha1.SnapshotComponent{
+			Name:           "component-2",
+			ContainerImage: "registry.io/image2:v1.0.0",
+		})
+
+		updatedSnapshot := multiComponentSnapshot.DeepCopy()
+		updatedSnapshot.Spec.Components = updatedSnapshot.Spec.Components[:1] // Remove last component
+
+		_, err := validator.ValidateUpdate(ctx, multiComponentSnapshot, updatedSnapshot)
+		if err == nil {
+			t.Error("ValidateUpdate should error for removed components")
+		}
+	})
+
+	t.Run("should reject non-snapshot oldObj", func(t *testing.T) {
+		app := &applicationapiv1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Name: "test-app"}}
+		_, err := validator.ValidateUpdate(ctx, app, originalSnapshot)
+		if err == nil {
+			t.Error("ValidateUpdate should error for non-snapshot oldObj")
+		}
+		if err != nil && err.Error() != "expected a Snapshot object for oldObj but got *v1alpha1.Application" {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("should reject non-snapshot newObj", func(t *testing.T) {
+		app := &applicationapiv1alpha1.Application{ObjectMeta: metav1.ObjectMeta{Name: "test-app"}}
+		_, err := validator.ValidateUpdate(ctx, originalSnapshot, app)
+		if err == nil {
+			t.Error("ValidateUpdate should error for non-snapshot newObj")
+		}
+		if err != nil && err.Error() != "expected a Snapshot object for newObj but got *v1alpha1.Application" {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+}
+
+func TestSnapshotCustomValidator_ValidateDelete(t *testing.T) {
+	validator := &SnapshotCustomValidator{}
+	ctx := context.Background()
+
+	snapshot := &applicationapiv1alpha1.Snapshot{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-snapshot",
+			Namespace: "default",
+		},
+		Spec: applicationapiv1alpha1.SnapshotSpec{
+			Application: "test-app",
+			Components: []applicationapiv1alpha1.SnapshotComponent{
+				{
+					Name:           "component-1",
+					ContainerImage: "registry.io/image1:v1.0.0",
+				},
+			},
+		},
+	}
+
+	t.Run("should allow snapshot deletion", func(t *testing.T) {
+		_, err := validator.ValidateDelete(ctx, snapshot)
+		if err != nil {
+			t.Errorf("ValidateDelete should not error, got: %v", err)
+		}
+	})
+
+	t.Run("should reject non-snapshot object", func(t *testing.T) {
+		app := &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-app"},
+		}
+		_, err := validator.ValidateDelete(ctx, app)
+		if err == nil {
+			t.Error("ValidateDelete should error for non-snapshot object")
+		}
+		if err != nil && err.Error() != "expected a Snapshot object but got *v1alpha1.Application" {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+}

--- a/internal/webhook/v1beta2/webhook_suite_test.go
+++ b/internal/webhook/v1beta2/webhook_suite_test.go
@@ -132,6 +132,9 @@ var _ = BeforeSuite(func() {
 	err = SetupIntegrationTestScenarioWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = SetupSnapshotWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:webhook
 
 	go func() {


### PR DESCRIPTION
- Add SnapshotCustomValidator to prevent updates to components field
- Components can be set during creation but become immutable afterward
- Other snapshot fields remain updatable
- Include comprehensive test coverage and integration setup

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
