### PR TITLE
fix: do not block owner deletion in ITS ownerReference

### DIFF
--- a/internal/webhook/v1beta2/integrationtestscenario_webhook.go
+++ b/internal/webhook/v1beta2/integrationtestscenario_webhook.go
@@ -250,7 +250,7 @@ func addOwnerReference(scenario *v1beta2.IntegrationTestScenario, client client.
 			Kind:               application.Kind,
 			Name:               application.Name,
 			UID:                application.UID,
-			BlockOwnerDeletion: ptr.To(true),
+			BlockOwnerDeletion: ptr.To(false),
 			Controller:         ptr.To(false),
 		}
 		scenario.SetOwnerReferences(append(scenario.GetOwnerReferences(), ownerReference))


### PR DESCRIPTION
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
