### PR TITLE
fix(stoneintg-1187): Prevent 'resource name empty' error

### DIFF
--- a/cmd/snapshotgc/snapshotgc.go
+++ b/cmd/snapshotgc/snapshotgc.go
@@ -238,7 +238,7 @@ func isNonPrSnapshot(
 func filterSnapshotsWithKeepSnapshotAnnotation(
 	snapshots []applicationapiv1alpha1.Snapshot,
 ) ([]applicationapiv1alpha1.Snapshot, int, int) {
-	nonReservedSnapshots := make([]applicationapiv1alpha1.Snapshot, len(snapshots))
+	nonReservedSnapshots := make([]applicationapiv1alpha1.Snapshot, 0, len(snapshots))
 	keptNonPrSnapshots := 0
 	keptPrSnapshots := 0
 	for _, snap := range snapshots {

--- a/cmd/snapshotgc/snapshotgc_test.go
+++ b/cmd/snapshotgc/snapshotgc_test.go
@@ -981,6 +981,7 @@ var _ = Describe("Test garbage collection for snapshots", func() {
 			Expect(filteredSnapshotList).Should(ContainElement(snapDiscardPR))
 			Expect(keptPr).To(Equal(1))
 			Expect(keptNonPr).To(Equal(1))
+			Expect(filteredSnapshotList).To(HaveLen(2))
 
 		})
 	})


### PR DESCRIPTION
The filterSnapshotsWithKeepSnapshotAnnotation function was initializing its results slice using make([]T, len). This created a slice pre-filled with blank, zero-value snapshot objects before any real snapshots were appended.

When the garbage collector processed this slice, it would immediately try to delete the first blank entry, causing a fatal error because the resource name was an empty string.

This change corrects the slice initialization to use make([]T, 0, cap), which creates a truly empty slice. This ensures that only valid snapshots are processed for deletion. The corresponding unit test has also been updated to assert the slice length.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
