### PR TITLE
chore: add Nigel to the codeowners config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @14rcole @jencull
+* @dirgim @hongweiliu17 @jsztuka @Josh-Everett @kasemAlem @sonam1412 @14rcole @jencull @NigelByrne1


### PR DESCRIPTION
Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
