### PR TITLE
test(sealights): test PR for sealights do not merge

### DIFF
--- a/config/samples/appstudio_v1beta1_integrationtestscenario.yaml
+++ b/config/samples/appstudio_v1beta1_integrationtestscenario.yaml
@@ -12,5 +12,19 @@ metadata:
     app.kubernetes.io/part-of: integration-service
     app.kubernetes.io/managed-by: kustomize
     app.kubernetes.io/created-by: integration-service
+    test.appstudio.openshift.io/optional: "false"
   name: integrationtestscenario-sample
 spec:
+  application: "test-failing-app"
+  resolverRef:
+    resolver: "git"
+    params:
+    - name: "url"
+      value: "https://github.com/redhat-appstudio/integration-examples.git"
+    - name: "revision"
+      value: "main"
+    - name: "pathInRepo"
+      value: "pipelineruns/nonexistent_pipeline.yaml"  # This will cause TestInvalid status
+  contexts:
+  - name: "component"
+    description: "Component testing with invalid pipeline"

--- a/config/samples/appstudio_v1beta2_integrationtestscenario.yaml
+++ b/config/samples/appstudio_v1beta2_integrationtestscenario.yaml
@@ -14,3 +14,16 @@ metadata:
     app.kubernetes.io/created-by: integration-service
   name: integrationtestscenario-sample-v2
 spec:
+  application: "test-failing-app"
+  resolverRef:
+    resolver: "git"
+    params:
+    - name: "url"
+      value: "https://github.com/redhat-appstudio/integration-examples.git"
+    - name: "revision"
+      value: "main"
+    - name: "pathInRepo"
+      value: "pipelineruns/integration_pipelinerun_pas.yaml"  # TYPO: missing 's' in 'pass'
+  contexts:
+  - name: "component"
+    description: "Component testing with typo to cause failure"


### PR DESCRIPTION
testing sealights for test recommendations on a
failing ITS

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
