### PR TITLE
feat(STONEINTG-1215): new serviceaccount for integration pipelineRuns

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -762,6 +762,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 		WithIntegrationLabels(integrationTestScenario).
 		WithIntegrationAnnotations(integrationTestScenario).
 		WithApplication(a.application).
+		WithServiceAccount(tektonconsts.DefaultIntegrationPipelineServiceAccount).
 		WithExtraParams(integrationTestScenario.Spec.Params).
 		WithFinalizer(h.IntegrationPipelineRunFinalizer).
 		WithIntegrationTimeouts(integrationTestScenario, a.logger.Logger)

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -1124,6 +1124,16 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(found).To(BeFalse())
 		})
 
+		It("ensures serviceAccount is generated correctly for the Integration test PLR", func() {
+			serviceAccountName := tektonconsts.DefaultIntegrationPipelineServiceAccount
+
+			pipelineRun, err := adapter.createIntegrationPipelineRun(hasApp, integrationTestScenario, hasSnapshot)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pipelineRun).ToNot(BeNil())
+
+			Expect(pipelineRun.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
+		})
+
 		When("pull request updates repo with integration test", func() {
 
 			const (

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -55,6 +55,9 @@ const (
 	// Value of ResourceKind field for remote pipelineruns
 	ResourceKindPipelineRun = "pipelinerun"
 
+	// DefaultIntegrationPipelineServiceAccount denotes the service account which is used by default in integration pipelines
+	DefaultIntegrationPipelineServiceAccount = "konflux-integration-runner"
+
 	/*
 	 * Build PipelineConstants
 	 */

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -338,6 +338,13 @@ func (r *IntegrationPipelineRun) WithApplication(application *applicationapiv1al
 	return r
 }
 
+// WithServiceAccount adds the specified service account to the Integration PipelineRun's TaskRunTemplate.
+func (r *IntegrationPipelineRun) WithServiceAccount(serviceAccountName string) *IntegrationPipelineRun {
+	r.Spec.TaskRunTemplate.ServiceAccountName = serviceAccountName
+
+	return r
+}
+
 // WithIntegrationTimeouts fetches the Integration timeouts from either the integrationTestScenario annotations or
 // the environment variables and adds them to the integration PipelineRun.
 func (r *IntegrationPipelineRun) WithIntegrationTimeouts(integrationTestScenario *v1beta2.IntegrationTestScenario, logger logr.Logger) *IntegrationPipelineRun {

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -577,5 +577,14 @@ var _ = Describe("Integration pipeline", Ordered, func() {
 				"test.appstudio.openshift.io/future": "future",
 			}))
 		})
+
+		It("sets the service account correctly", func() {
+			serviceAccountName := "konflux-integration-runner"
+
+			ipr := tekton.IntegrationPipelineRun{}
+			ipr.WithServiceAccount(serviceAccountName)
+
+			Expect(ipr.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
+		})
 	})
 })


### PR DESCRIPTION
* Set the new `konflux-integration-runner` serviceaccount for integration pipelineRuns

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
