### PR TITLE
fix: fix itn-2025-00176 nil ptr when git source is not defined in comp

### DIFF
--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -90,7 +90,11 @@ func (a *Adapter) EnsureComponentIsCleanedUp() (controller.OperationResult, erro
 		component := individualComponent
 		if a.component.Name != component.Name {
 			containerImage := component.Status.LastPromotedImage
-			componentSource := gitops.GetComponentSourceFromComponent(&component)
+			componentSource, err := gitops.GetComponentSourceFromComponent(&component)
+			if err != nil {
+				a.logger.Error(err, "component can not be handle due to missing git source", "component.Name", component.Name)
+				continue
+			}
 			snapshotComponents = append(snapshotComponents, applicationapiv1alpha1.SnapshotComponent{
 				Name:           component.Name,
 				ContainerImage: containerImage,

--- a/internal/controller/component/component_adapter_test.go
+++ b/internal/controller/component/component_adapter_test.go
@@ -90,7 +90,8 @@ var _ = Describe("Component Adapter", Ordered, func() {
 				Source: applicationapiv1alpha1.ComponentSource{
 					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
 						GitSource: &applicationapiv1alpha1.GitSource{
-							URL: SampleRepoLink,
+							URL:      SampleRepoLink,
+							Revision: "revision",
 						},
 					},
 				},

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -917,7 +917,11 @@ func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Appli
 
 		a.logger.Info("can't find snapshot with open pull/merge request for component, try to find snapshotComponent from Global Candidate List", "component", applicationComponent.Name)
 		// if there is no component snapshot found for open PR/MR, we get snapshotComponent from gcl
-		componentSource := gitops.GetComponentSourceFromComponent(&applicationComponent)
+		componentSource, err := gitops.GetComponentSourceFromComponent(&applicationComponent)
+		if err != nil {
+			a.logger.Error(err, "component cannot be added to snapshot for application due to missing git source", "component.Name", applicationComponent.Name)
+			continue
+		}
 		containerImage := applicationComponent.Status.LastPromotedImage
 		if containerImage == "" {
 			a.logger.Info("component cannot be added to snapshot for application due to missing containerImage", "component.Name", applicationComponent.Name)

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -214,7 +214,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Source: applicationapiv1alpha1.ComponentSource{
 					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
 						GitSource: &applicationapiv1alpha1.GitSource{
-							URL: SampleRepoLink,
+							URL:      SampleRepoLink,
+							Revision: "revision",
 						},
 					},
 				},
@@ -237,7 +238,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Source: applicationapiv1alpha1.ComponentSource{
 					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
 						GitSource: &applicationapiv1alpha1.GitSource{
-							URL: SampleRepoLink,
+							URL:      SampleRepoLink,
+							Revision: "revision",
 						},
 					},
 				},
@@ -260,7 +262,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Source: applicationapiv1alpha1.ComponentSource{
 					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
 						GitSource: &applicationapiv1alpha1.GitSource{
-							URL: SampleRepoLink,
+							URL:      SampleRepoLink,
+							Revision: "revision",
 						},
 					},
 				},
@@ -283,7 +286,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				Source: applicationapiv1alpha1.ComponentSource{
 					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
 						GitSource: &applicationapiv1alpha1.GitSource{
-							URL: SampleRepoLink,
+							URL:      SampleRepoLink,
+							Revision: "revision",
 						},
 					},
 				},


### PR DESCRIPTION
* fix the nil pointer when git source is not defined in component

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
