### PR TITLE
chore(STONEINTG-1268): upgrade go to 1.24

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.6"
+          go-version: "1.24.4"
       - name: Run tests
         run: make test
       - name: Codecov

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.6"
+          go-version: "1.24.4"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: "1.23.6"
+          go-version: "1.24.4"
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372 as builder
+FROM registry.access.redhat.com/ubi9/go-toolset:1.24.4@sha256:a90b4605b47c396c74de55f574d0f9e03b24ca177dec54782f86cdf702c97dbc as builder
 
 USER 1001
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/konflux-ci/integration-service
 
-go 1.23.0
-
-toolchain go1.23.6
+go 1.24.4
 
 require (
 	github.com/agiledragon/gomonkey/v2 v2.13.0


### PR DESCRIPTION
Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
