### PR TITLE
fix: set snapshot webhook failurepolicy to ignore

### DIFF
--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -59,7 +59,7 @@ webhooks:
       name: webhook-service
       namespace: system
       path: /validate-appstudio-redhat-com-v1alpha1-snapshot
-  failurePolicy: Fail
+  failurePolicy: Ignore
   name: vsnapshot.kb.io
   rules:
   - apiGroups:

--- a/internal/webhook/v1beta2/snapshot_webhook.go
+++ b/internal/webhook/v1beta2/snapshot_webhook.go
@@ -47,7 +47,7 @@ type SnapshotCustomValidator struct {
 	// TODO(user): Add more fields as needed for validation
 }
 
-// +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshot,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=snapshots,verbs=create;update;delete,versions=v1alpha1,name=vsnapshot.kb.io,admissionReviewVersions=v1
+// +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1alpha1-snapshot,mutating=false,failurePolicy=ignore,sideEffects=None,groups=appstudio.redhat.com,resources=snapshots,verbs=create;update;delete,versions=v1alpha1,name=vsnapshot.kb.io,admissionReviewVersions=v1
 
 var _ webhook.CustomValidator = &SnapshotCustomValidator{}
 


### PR DESCRIPTION
Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
