### PR TITLE
fix(STONEINTG-1319): add one more unrecoverable error to http repsonse

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -282,6 +282,7 @@ func (a *Adapter) EnsureIntegrationTestReportedToGitProvider() (controller.Opera
 				if isErrorRecoverable {
 					return controller.RequeueWithError(err)
 				} else {
+					a.logger.Error(err, "meeting unrecoverable error, stop reporting build pipelinerun status to git provider integration test scenario")
 					return controller.ContinueProcessing()
 				}
 			}

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -447,10 +447,6 @@ func (a *Adapter) iterateIntegrationTestStatusDetailsInStatusReport(reporter sta
 				a.logger.Error(reportStatusErr, fmt.Sprintf("failed to report status to git provider for completed integration pipelinerun %s/%s, then finalizer test.appstudio.openshift.io/pipelinerun might not be removed from it later", testedSnapshot.Namespace, integrationTestStatusDetail.TestPipelineRunName))
 			}
 
-			if writeErr := status.WriteSnapshotReportStatus(a.context, a.client, testedSnapshot, srs); writeErr != nil { // try to write what was already written
-				return fmt.Errorf("failed to report status AND write snapshot report status metadata: %w", e.Join(reportStatusErr, writeErr))
-			}
-
 			if reporter.ReturnCodeIsUnrecoverable(statusCode) {
 				a.logger.Error(reportStatusErr, fmt.Sprintf("failed to report status to git provider for integration pipelinerun %s/%s, the statusCode %d is not easily recoverable", testedSnapshot.Namespace, integrationTestStatusDetail.TestPipelineRunName, statusCode))
 				return nil
@@ -458,6 +454,11 @@ func (a *Adapter) iterateIntegrationTestStatusDetailsInStatusReport(reporter sta
 				return fmt.Errorf("failed to update status: %w", reportStatusErr)
 			}
 		}
+
+		if writeErr := status.WriteSnapshotReportStatus(a.context, a.client, testedSnapshot, srs); writeErr != nil { // try to write what was already written
+			return fmt.Errorf("failed to report status AND write snapshot report status metadata: %w", writeErr)
+		}
+
 		a.logger.Info("Successfully report integration test status for snapshot",
 			"testedSnapshot.Name", testedSnapshot.Name,
 			"destinationSnapshot.Name", destinationSnapshot.Name,

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -674,5 +674,5 @@ func (r *GitHubReporter) ReportStatus(ctx context.Context, report TestReport) (i
 }
 
 func (r *GitHubReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest
 }

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -318,7 +318,7 @@ func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) (i
 }
 
 func (r *GitLabReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest
 }
 
 // GenerateGitlabCommitState transforms internal integration test state into Gitlab state


### PR DESCRIPTION
    * add one more unrecoverable error to http respoonse of reporting status
      to avoid repeated requeue so that no change to call
      remove test finalizer from build and integration pipelinerun

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
