### PR TITLE
chore: increase kind resource in e2e-tests

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -110,6 +110,8 @@ spec:
         - name: extra-port-mappings
           value: >-
             '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}]'
+        - name: spot
+          value: "false"
         - name: cpus
           value: 48
         - name: memory


### PR DESCRIPTION
* increase memory and cpu for kind cluster
* disable aws spot instances from https://github.com/konflux-ci/integration-service/pull/1257

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
