### PR TITLE
test: kind improvements

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -81,9 +81,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog.git
+            value: https://github.com/psturc/tekton-integration-catalog.git
           - name: revision
-            value: main
+            value: kind-improvements
           - name: pathInRepo
             value: tasks/mapt-oci/kind-aws-spot/provision/0.2/kind-aws-provision.yaml
       params:
@@ -111,9 +111,11 @@ spec:
           value: >-
             '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}]'
         - name: cpus
-          value: 32
-        - name: memory
           value: 64
+        - name: memory
+          value: 128
+        - name: spot
+          value: 'false'
     - name: deploy-konflux
       runAfter:
         - provision-kind-cluster
@@ -121,9 +123,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/tekton-integration-catalog
+            value: https://github.com/psturc/tekton-integration-catalog
           - name: revision
-            value: main
+            value: kind-improvements
           - name: pathInRepo
             value: tasks/konflux-ci/deploy/0.3/deploy-konflux-ci.yaml
       params:


### PR DESCRIPTION
uses changes from [here](https://github.com/konflux-ci/tekton-integration-catalog/compare/main...psturc:tekton-integration-catalog:kind-improvements)

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
