### PR TITLE
test(STONEINTG-1332): test e2e pr 1683

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -110,10 +110,12 @@ spec:
         - name: extra-port-mappings
           value: >-
             '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}]'
+        - name: spot
+          value: "false"
         - name: cpus
-          value: 32
+          value: 48
         - name: memory
-          value: 64
+          value: 192
     - name: deploy-konflux
       runAfter:
         - provision-kind-cluster
@@ -151,9 +153,9 @@ spec:
         resolver: git
         params:
           - name: url
-            value: https://github.com/konflux-ci/e2e-tests.git
+            value: https://github.com/hongweiliu17/e2e-tests.git
           - name: revision
-            value: main
+            value: test-integration-1261
           - name: pathInRepo
             value: integration-tests/tasks/konflux-e2e-tests/0.2/konflux-e2e-tests.yaml
       params:


### PR DESCRIPTION
This is to test e2e pr https://github.com/konflux-ci/e2e-tests/pull/1683

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
