### PR TITLE
feat(STONEINTG-1332): update gitops.HasPRGroupProcessed()

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -1140,10 +1140,11 @@ func FilterIntegrationTestScenariosWithContext(scenarios *[]v1beta2.IntegrationT
 	return &filteredScenarioList
 }
 
-// HasPRGroupProcessed checks if the pr group has been handled by snapshot adapter
-// to avoid duplicate check, if yes, won't handle the snapshot again
+// HasPRGroupProcessed checks if the group creation has been handled for this snapshot by snapshot adapter when
+// to avoid duplicate check when reconciling this snapshot, if yes, won't handle the snapshot again
+// the annotation updated from other component pipelinerun should not be counted in
 func HasPRGroupProcessed(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return metadata.HasAnnotation(snapshot, PRGroupCreationAnnotation)
+	return metadata.HasAnnotation(snapshot, PRGroupCreationAnnotation) && !strings.Contains(snapshot.GetAnnotations()[PRGroupCreationAnnotation], "waiting for it to create a new group Snapshot for PR group")
 }
 
 // GetPRGroup gets the value of label test.appstudio.openshift.io/pr-group-sha and annotation from component snapshot or pipelinerun

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -938,6 +938,9 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Expect(prGroup).To(Equal(expectedPRGroup))
 				Expect(prGroupSha).To(Equal(expectedPRGoupSha))
 				Expect(gitops.HasPRGroupProcessed(hasComSnapshot1)).To(BeTrue())
+
+				hasComSnapshot1.Annotations[gitops.PRGroupCreationAnnotation] = "a new build PLR component-sample-on-pull-request-jhctk is running for component component-sample, waiting for it to create a new group Snapshot for PR group test-branch"
+				Expect(gitops.HasPRGroupProcessed(hasComSnapshot1)).To(BeFalse())
 			})
 
 			It("Can find the correct snapshotComponent for the given component name", func() {


### PR DESCRIPTION
* update gitops.HasPRGroupProcessed to not counting the annnotaton update from other component pipelinerun then the group snapshot creation in snapshot adapter will not be interrupted.

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
