### PR TITLE
fix(STONEINTG-1332): fix e2e-tests integration test pipeline

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -133,6 +133,10 @@ spec:
           value: kfg-$(context.pipelineRun.name)
         - name: component-name
           value: integration-service
+        - name: component-image-repository
+          value: $(tasks.sealights-refs.results.sealights-container-repo)
+        - name: component-image-tag
+          value: $(tasks.sealights-refs.results.sealights-container-tag)
         - name: component-pr-owner
           value: $(tasks.test-metadata.results.pull-request-author)
         - name: component-pr-sha


### PR DESCRIPTION
* pass component-image-repository and component-image-tag to pipelinerun to deploy the built integration-service image in PR to kind cluster and run e2e-tests against 

Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
