### PR TITLE
fix(STONEINTG-1317): annotate snapshot for the missed component

### DIFF
--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -102,8 +102,9 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Namespace: namespace,
 			},
 			Spec: applicationapiv1alpha1.ComponentSpec{
-				ComponentName: "bad-component",
-				Application:   applicationName,
+				ComponentName:  "bad-component",
+				Application:    applicationName,
+				ContainerImage: sampleImage,
 			},
 		}
 		Expect(k8sClient.Create(ctx, badComp)).Should(Succeed())
@@ -678,7 +679,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				},
 			},
 		}
-		allApplicationComponents := &[]applicationapiv1alpha1.Component{*hasComp, *hasComp2}
+		allApplicationComponents := &[]applicationapiv1alpha1.Component{*hasComp, *hasComp2, *badComp}
 		snapshot, err := gitops.PrepareSnapshot(ctx, k8sClient, hasApp, allApplicationComponents, hasComp, validImagePullSpec, componentSource)
 		Expect(snapshot).NotTo(BeNil())
 		Expect(err).NotTo(HaveOccurred())
@@ -688,6 +689,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			snapshotComponent := snapshotComponent
 			Expect(snapshotComponent.ContainerImage).NotTo(Equal(invalidImagePullSpec))
 		}
+		Expect(snapshot.Annotations["test.appstudio.openshift.io/create-snapshot-status"]).To(Equal("Component(s) 'second-component, bad-component' is(are) not included in snapshot due to missing valid containerImage or git source"))
 	})
 
 	It("Return false when the image url contains invalid digest", func() {

--- a/helpers/errorhandlers.go
+++ b/helpers/errorhandlers.go
@@ -80,10 +80,10 @@ func IsInvalidImageDigestError(err error) bool {
 	return getReason(err) == ReasonInvalidImageDigestError
 }
 
-func NewMissingValidComponentError(componentName string) error {
+func NewMissingValidComponentError(componentNames string) error {
 	return &IntegrationError{
 		Reason:  ReasonMissingValidComponentError,
-		Message: fmt.Sprintf("The only one component %s is invalid, valid .Status.LastPromotedImage is missing", componentName),
+		Message: fmt.Sprintf("The component(s) '%s' is(are) invalid due to missing valid container image or git source", componentNames),
 	}
 }
 

--- a/helpers/errorhandlers_test.go
+++ b/helpers/errorhandlers_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Helpers for error handlers", Ordered, func() {
 		It("Can define MissingValidComponentError", func() {
 			err := helpers.NewMissingValidComponentError("componentName")
 			Expect(helpers.IsMissingValidComponentError(err)).To(BeTrue())
-			Expect(err.Error()).To(Equal("The only one component componentName is invalid, valid .Status.LastPromotedImage is missing"))
+			Expect(err.Error()).To(Equal("The component(s) 'componentName' is(are) invalid due to missing valid container image or git source"))
 		})
 
 		It("Can handle non integration error", func() {

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -519,9 +519,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			snapshot, err := gitops.PrepareSnapshot(adapter.context, adapter.client, hasApp, applicationComponents, hasComp, imagePullSpec, componentSource)
 			Expect(snapshot).NotTo(BeNil())
 			Expect(err).ToNot(HaveOccurred())
-			Expect(snapshot).NotTo(BeNil())
 			Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field or missing valid digest")
 			Expect(snapshot.Spec.Components[0].Name).To(Equal(hasComp.Name), "The built component should have been added to the snapshot")
+			Expect(snapshot.Annotations[helpers.CreateSnapshotAnnotationName]).To(Equal("Component(s) 'another-component-sample' is(are) not included in snapshot due to missing valid containerImage or git source"))
 		})
 
 		It("ensures that snapshot has label pointing to build pipelinerun", func() {


### PR DESCRIPTION
* annotate the components to snapshot when they are not included in snasphot due to missing valid container image or git source

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
