### PR TITLE
feat(konflux-8553): allow users to define auto-release logic

### DIFF
--- a/gitops/release.go
+++ b/gitops/release.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+)
+
+// EvaluateSnapshotAutoReleaseAnnotation evaluates the provided auto-release annotation CEL-like expression
+// against the given Snapshot and returns whether it allows auto-release.
+func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *applicationapiv1alpha1.Snapshot) (bool, error) {
+	// Empty or missing annotation: do not auto-release
+	if len(autoReleaseExpr) == 0 {
+		return false, nil
+	}
+
+	// Convert snapshot to a JSON-like map so field selections like
+	// snapshot.metadata.creationTimestamp work naturally with CEL and
+	// to allow custom functions to access the snapshot contents.
+	objMap, err := convertToCELObjectMap(snapshot)
+	if err != nil {
+		return false, fmt.Errorf("failed to convert snapshot: %w", err)
+	}
+
+	// Build a CEL environment
+	// The with a dynamic 'snapshot' variable represents the snapshot object
+	funcs := snapshotCELFunctions{snapshot: objMap}
+	env, err := cel.NewEnv(
+		cel.DefaultUTCTimeZone(true),
+		cel.Variable("snapshot", cel.DynType),
+		cel.Variable("now", cel.TimestampType),
+		// Register custom function: updatedComponentIs(name: string) -> bool
+		cel.Function("updatedComponentIs",
+			cel.Overload("updatedComponentIs_string_bool",
+				[]*cel.Type{cel.StringType},
+				cel.BoolType,
+				cel.UnaryBinding(funcs.updatedComponentIs),
+			),
+		),
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to create CEL env: %w", err)
+	}
+
+	// Compile the expression
+	ast, iss := env.Compile(autoReleaseExpr)
+	if iss != nil && iss.Err() != nil {
+		return false, fmt.Errorf("invalid cel expression: %w", iss.Err())
+	}
+
+	prog, err := env.Program(ast)
+	if err != nil {
+		return false, fmt.Errorf("failed to create cel program: %w", err)
+	}
+
+	activation := map[string]any{}
+	activation["snapshot"] = objMap
+	activation["now"] = time.Now().UTC()
+
+	// Evaluate
+	out, _, err := prog.ContextEval(context.Background(), activation)
+	if err != nil {
+		return false, err
+	}
+
+	// Expect a boolean result
+	if b, ok := out.Value().(bool); ok {
+		return b, nil
+	}
+	return false, fmt.Errorf("cel expression did not evaluate to a boolean")
+}
+
+// snapshotCELFunctions contains named implementations of custom CEL functions which
+// may access the current snapshot via the captured map.
+// Note: The method value used during registration is not an anonymous function.
+// It captures the receiver 'snapshotCELFunctions' instance with the prepared snapshot map.
+// This helps avoid global state while keeping a named function.
+
+type snapshotCELFunctions struct {
+	snapshot map[string]any
+}
+
+func (sf snapshotCELFunctions) updatedComponentIs(arg ref.Val) ref.Val {
+	name, ok := arg.Value().(string)
+	if !ok {
+		return types.Bool(false)
+	}
+	// Navigate snapshot.spec.components[].name
+	spec, ok := sf.snapshot["spec"].(map[string]any)
+	if !ok {
+		return types.Bool(false)
+	}
+	components, ok := spec["components"].([]any)
+	if !ok {
+		return types.Bool(false)
+	}
+	for _, c := range components {
+		cm, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if compName, ok := cm["name"].(string); ok && compName == name {
+			return types.Bool(true)
+		}
+	}
+	return types.Bool(false)
+}
+
+// convertToCELObjectMap marshals the typed object to JSON and back to a
+// map[string]any, ensuring JSON field names (e.g., metadata.creationTimestamp)
+// are available to CEL.
+func convertToCELObjectMap(obj any) (map[string]any, error) {
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(raw, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/gitops/release_test.go
+++ b/gitops/release_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gitops_test
+
+import (
+	"time"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/gitops"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
+	var (
+		hasSnapshot *applicationapiv1alpha1.Snapshot
+	)
+
+	const (
+		namespace    = "default"
+		snapshotName = "auto-release-snapshot"
+	)
+
+	BeforeAll(func() {
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        snapshotName,
+				Namespace:   namespace,
+				Labels:      map[string]string{},
+				Annotations: map[string]string{},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: "test-application",
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: "quay.io/redhat-appstudio/sample-image:latest",
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasSnapshot)).To(Succeed())
+
+		// Ensure it's created and retrievable
+		Eventually(func() error {
+			return k8sClient.Get(ctx, types.NamespacedName{Name: snapshotName, Namespace: namespace}, hasSnapshot)
+		}, time.Second*10).ShouldNot(HaveOccurred())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, hasSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("returns false when the auto-release annotation is missing", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		autoReleaseAnnotation := ""
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowed).To(BeFalse())
+	})
+
+	It("returns true when the auto-release annotation is 'true'", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		autoReleaseAnnotation := "true"
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowed).To(BeTrue())
+	})
+
+	It("returns false when the auto-release annotation is 'false'", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		autoReleaseAnnotation := "false"
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowed).To(BeFalse())
+	})
+
+	It("returns true when the snapshot is older than 1 week", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		snapshotCopy.CreationTimestamp = metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+		autoReleaseAnnotation := "timestamp(snapshot.metadata.creationTimestamp) < (timestamp(now) - duration('168h'))"
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowed).To(BeTrue())
+	})
+
+	It("returns true  when the updated component is 'component-sample'", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		autoReleaseAnnotation := "updatedComponentIs('component-sample')"
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowed).To(BeTrue())
+	})
+
+	It("returns error and false when the auto-release annotation is an invalid CEL expression", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		autoReleaseAnnotation := "invalid expression$" // syntactically invalid
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		Expect(err).To(HaveOccurred())
+		Expect(allowed).To(BeFalse())
+	})
+})

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/bradleyfalzon/ghinstallation/v2 v2.16.0
 	github.com/ghodss/yaml v1.0.0
 	github.com/go-logr/logr v1.4.3
+	github.com/google/cel-go v0.23.1
 	github.com/google/go-containerregistry v0.20.6
 	github.com/google/go-github/v45 v45.2.0
 	github.com/konflux-ci/application-api v0.0.0-20250324201748-5a9670bf7679
@@ -68,7 +69,6 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20241129210726-2c02b8208cf8 // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
-	github.com/google/cel-go v0.23.1 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/go-github/v72 v72.0.0 // indirect


### PR DESCRIPTION
This change gives users more power over whether they auto-release push snapshots.  For example, if a user has an operator bundle they are now able to auto-release only if the bundle image is the updated component in their snapshot. The `release.appstudio.openshift.io/auto-release` label now accepts cel expressions.  A missing or empty label still evaluates to true.  Since 'true' and 'false' are valid cel expression this change is fully backward compatible.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
