### PR TITLE
fix(STONEINTG-1216): add annotation when no git provider snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -98,6 +98,9 @@ const (
 	// PRGroupCreationAnnotation contains the info of groupsnapshot creation
 	PRGroupCreationAnnotation = "test.appstudio.openshift.io/create-groupsnapshot-status"
 
+	// GitReportingFailureAnnotation contains information about git reporting failures
+	GitReportingFailureAnnotation = "test.appstudio.openshift.io/git-reporting-failure"
+
 	// BuildPipelineRunStartTime contains the start time of build pipelineRun
 	BuildPipelineRunStartTime = "test.appstudio.openshift.io/pipelinerunstarttime"
 

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -1879,6 +1879,61 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 
+		It("add annotation to snapshot when no git provider is found", func() {
+			// Create a snapshot WITHOUT git provider info but WITH proper component labels
+			snapshotWithoutGitProvider := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-snapshot-no-git",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:      gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel: "test-component",
+					},
+					Annotations: map[string]string{
+						"test.appstudio.openshift.io/status": "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]",
+					},
+					// NO git provider labels!
+				},
+			}
+
+			// Create a buffer for logging
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			// Set up mocks
+			ctrl := gomock.NewController(GinkgoT())
+			mockReporter = status.NewMockReporterInterface(ctrl)
+			mockStatus := status.NewMockStatusInterface(ctrl)
+
+			// Mock GetReporter to return nil (no git provider found)
+			mockStatus.EXPECT().GetReporter(gomock.Any()).Return(nil)
+
+			// Create adapter
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+
+			// Create the required test data
+			integrationTestScenarios := []v1beta2.IntegrationTestScenario{*integrationTestScenario}
+			testStatus := intgteststat.IntegrationTestStatusInProgress
+			componentName := "test-component"
+
+			// Call the method
+			statusCode, err := adapter.ReportIntegrationTestStatusAccordingToBuildPLR(
+				buildPipelineRun,
+				snapshotWithoutGitProvider,
+				&integrationTestScenarios,
+				testStatus,
+				componentName)
+
+			// Check results
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statusCode).To(BeTrue())
+			Expect(snapshotWithoutGitProvider.Annotations).To(HaveKey(gitops.GitReportingFailureAnnotation))
+
+			// Check that the error was logged
+			Expect(buf.String()).Should(ContainSubstring("Failed to get git reporter for snapshot - missing required labels/annotations"))
+		})
+
 		It("Ensure group context integration test can be initialized", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}

--- a/internal/controller/statusreport/statusreport_adapter_test.go
+++ b/internal/controller/statusreport/statusreport_adapter_test.go
@@ -869,6 +869,51 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(statusCode).NotTo(BeNil())
 		})
 
+		It("add annotation to snapshot when no git provider is found", func() {
+			// Create a snapshot WITHOUT git provider info but WITH proper component labels
+			snapshotWithoutGitProvider := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-snapshot-no-git",
+					Namespace: "test-namespace",
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:      gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel: "test-component",
+					},
+					Annotations: map[string]string{
+						"test.appstudio.openshift.io/status": "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]",
+					},
+					// NO git provider labels!
+				},
+			}
+
+			// Create a buffer for logging
+			buf := bytes.Buffer{}
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			// Set up mocks
+			ctrl := gomock.NewController(GinkgoT())
+			mockReporter = status.NewMockReporterInterface(ctrl)
+			mockStatus := status.NewMockStatusInterface(ctrl)
+
+			// Mock GetReporter to return nil (no git provider found)
+			mockStatus.EXPECT().GetReporter(gomock.Any()).Return(nil)
+
+			// Create adapter
+			adapter = NewAdapter(ctx, snapshotWithoutGitProvider, hasApp, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+
+			// Call the method
+			statusCode, err := adapter.ReportSnapshotStatus(snapshotWithoutGitProvider)
+
+			// Check results
+			Expect(err).ToNot(HaveOccurred())
+			Expect(statusCode).To(BeTrue())
+			Expect(snapshotWithoutGitProvider.Annotations).To(HaveKey(gitops.GitReportingFailureAnnotation))
+
+			// Check that the error was logged
+			Expect(buf.String()).Should(ContainSubstring("Failed to get git reporter for snapshot - missing required labels/annotations"))
+		})
+
 		It("report expected textual data for InProgress test scenario", func() {
 			os.Setenv("CONSOLE_NAME", "Konflux Staging")
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}


### PR DESCRIPTION
- Add annotation to snapshot(s) when no git provider is found
- Add unit tests in both buildpipeline and snapshot controller

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
