### PR TITLE
fix(STONEINTG-1329): increase memory for shanpshotgc

### DIFF
--- a/config/snapshotgc/snapshotgc.yaml
+++ b/config/snapshotgc/snapshotgc.yaml
@@ -21,10 +21,10 @@ spec:
               resources:
                 requests:
                   cpu: 1000m
-                  memory: 500Mi
+                  memory: 1000Mi
                 limits:
                   cpu: 1000m
-                  memory: 500Mi
+                  memory: 1000Mi
               securityContext:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true


### PR DESCRIPTION
This PR to fix issue of crashing snapshotgc pods on out of memory crash  

[STONEINTG-1329](https://issues.redhat.com/browse/STONEINTG-1329)

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
