### PR TITLE
feat(stoneintg-1347): set neutral github check status for optional tests

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -255,6 +255,9 @@ const (
 	//IntegrationTestStatusCancelledGithub is the status reported to github when integration test is cancelled
 	IntegrationTestStatusCancelledGithub = "cancelled"
 
+	//IntegrationTestStatusNeutralGithub is the status reported to github when integration test is neutral
+	IntegrationTestStatusNeutralGithub = "neutral"
+
 	ComponentNameForGroupSnapshot = "pr group"
 
 	FailedToCreateGroupSnapshotMsg = "Failed to create group snapshot for pr group"

--- a/helpers/scenario.go
+++ b/helpers/scenario.go
@@ -17,6 +17,7 @@ limitations under the License.
 package helpers
 
 import (
+	"github.com/konflux-ci/operator-toolkit/metadata"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -53,4 +54,8 @@ func SetScenarioIntegrationStatusAsValid(scenario *v1beta2.IntegrationTestScenar
 		Reason:  AppStudioIntegrationStatusValid,
 		Message: message,
 	})
+}
+
+func IsIntegrationTestScenarioOptional(scenario *v1beta2.IntegrationTestScenario) bool {
+	return metadata.HasLabelWithValue(scenario, "test.appstudio.openshift.io/optional", "true")
 }

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -678,4 +678,30 @@ var _ = Describe("GitHubReporter", func() {
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 	})
+
+	Context("Testing GenerateCheckRunConclusion", func() {
+		It("Returns 'success' when optional tests pass", func() {
+			conclusion, err := status.GenerateCheckRunConclusion(integrationteststatus.IntegrationTestStatusTestPassed, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conclusion).To(Equal("success"))
+		})
+
+		It("Returns 'neutral' when optional tests fail", func() {
+			conclusion, err := status.GenerateCheckRunConclusion(integrationteststatus.IntegrationTestStatusTestFail, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conclusion).To(Equal("neutral"))
+		})
+
+		It("Returns 'success' when required tests pass", func() {
+			conclusion, err := status.GenerateCheckRunConclusion(integrationteststatus.IntegrationTestStatusTestPassed, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conclusion).To(Equal("success"))
+		})
+
+		It("Returns 'failure' when required tests fail", func() {
+			conclusion, err := status.GenerateCheckRunConclusion(integrationteststatus.IntegrationTestStatusTestFail, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(conclusion).To(Equal("failure"))
+		})
+	})
 })


### PR DESCRIPTION
Reporting failed optional integration tests as failures to Github is creating noise for users.  Users want to be able to clearly see the difference between a failed required check and a failed optional check so they can determine whether to merge and/or release their changes. Reporting failed optional integration tests using the 'neutral' github status gives users more clarity on how they should proceed given the test results.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
