### PR TITLE
fix: update deprecated task path

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -209,7 +209,7 @@ spec:
           - name: revision
             value: main
           - name: pathInRepo
-            value: common/tasks/pull-request-comment/0.1/pull-request-comment.yaml
+            value: tasks/pull-request-comment/0.1/pull-request-comment.yaml
       params:
         - name: test-name
           value: $(context.pipelineRun.name)


### PR DESCRIPTION
Updates the deprecated "common/tasks/" path to "tasks/". Path should be updated before 31/10/25 to avoid breaking changes.