### PR TITLE
fix(STONEINTG-1315): check buildtimes sc (draft/wip)

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -104,6 +104,9 @@ const (
 	// BuildPipelineRunStartTime contains the start time of build pipelineRun
 	BuildPipelineRunStartTime = "test.appstudio.openshift.io/pipelinerunstarttime"
 
+	// BuildPipelineLastBuiltTime contains the time of the last built pipelineRun
+	BuildPipelineLastBuiltTime = "test.appstudio.openshift.io/lastbuilttime"
+
 	// BuildPipelineRunPrefix contains the build pipeline run related labels and annotations
 	BuildPipelineRunPrefix = "build.appstudio"
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"time"
 
@@ -470,10 +471,14 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 
 	autoReleaseMessage := ""
 	if len(*releasePlans) > 0 {
-		if err := a.createMissingReleasesForReleasePlans(a.application, releasePlans, a.snapshot); err != nil {
-			return a.handleReleaseError(err, "Failed to create new release")
+		if a.isSnapshotOlderThanLastBuild(a.snapshot) {
+			autoReleaseMessage = "Released in newer Snapshot"
+		} else {
+			if err := a.createMissingReleasesForReleasePlans(a.application, releasePlans, a.snapshot); err != nil {
+				return a.handleReleaseError(err, "Failed to create new release")
+			}
+			autoReleaseMessage = "The Snapshot was auto-released"
 		}
-		autoReleaseMessage = "The Snapshot was auto-released"
 	} else {
 		autoReleaseMessage = "Skipping auto-release of the Snapshot because no ReleasePlans have the 'auto-release' label set to 'true'"
 	}
@@ -1126,4 +1131,35 @@ func (a *Adapter) cancelAllPipelineRunsForSnapshot(snapshot *applicationapiv1alp
 		}
 	}
 	return nil
+}
+
+func (a *Adapter) isSnapshotOlderThanLastBuild(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	componentName := snapshot.Labels[gitops.SnapshotComponentLabel]
+	if componentName == "" {
+		return false
+	}
+	snapshotBuildStartTime := snapshot.Annotations[gitops.BuildPipelineRunStartTime]
+	if snapshotBuildStartTime == "" {
+		return false
+	}
+	component, err := a.loader.GetComponentFromSnapshot(a.context, a.client, snapshot)
+	if err != nil {
+		return false
+	}
+	componentlastBuiltTime := component.Annotations[gitops.BuildPipelineLastBuiltTime]
+	if componentlastBuiltTime == "" {
+		return false //if no other builttime in component exists this snapshot and possibly component is new
+	}
+	snapshotBuildStartTimeInt, snapshotBuildStartTimeIntErr := strconv.ParseInt(snapshotBuildStartTime, 10, 64)
+	if snapshotBuildStartTimeIntErr != nil {
+		return false
+	}
+	componentlastBuiltTimeInt, componentlastBuiltTimeIntErr := strconv.ParseInt(componentlastBuiltTime, 10, 64)
+	if componentlastBuiltTimeIntErr != nil {
+		return false
+	}
+	if snapshotBuildStartTimeInt < componentlastBuiltTimeInt {
+		return true
+	}
+	return false
 }

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -1575,6 +1575,16 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 	})
 
+	When("snapshot is older than last build", func() {
+		It("ensures that snapshot as is marked with correct auto-release message", func() {
+			// CREATE COMPONENT WITH NEWER BUILD TIME+
+			// CREATE SNAPSHOT WITH OLDER BUILD TIME
+			// CREATE RELEASE PLAN
+			// RUN THE FUNCTION USING AN ADAPTER
+			// ENSURE THAT SNAPSHOT IS MARKED WITH CORRECT AUTO-RELEASE MESSAGE "Released in newer Snapshot"
+		})
+	})
+
 	Describe("EnsureRerunPipelineRunsExist", func() {
 
 		When("manual re-run of scenario using static env is trigerred", func() {


### PR DESCRIPTION
- implement a check to prevent old snapshots overriding new code when multible prs are merged closely
- added isSnapshotOlderThanLastBuild()
- modified EnsureAllReleasesExist()
- older snapshots are marked accordingly
- TODO unit test(s)

DRAFT PR DO NOT MERGE

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
