### PR TITLE
fix: build matching arch binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,8 @@ COPY --chown=1001:0 go.sum go.sum
 COPY --chown=1001:0 . .
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager cmd/main.go \
- && CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o snapshotgc cmd/snapshotgc/snapshotgc.go
+RUN CGO_ENABLED=0 go build -a -o manager cmd/main.go \
+ && CGO_ENABLED=0 go build -a -o snapshotgc cmd/snapshotgc/snapshotgc.go
 
 ARG ENABLE_WEBHOOKS=true
 ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}


### PR DESCRIPTION
The configured Tekton pipeline allows us to build x86 and arm but both images have an arm binary in them.

We can remove these parameters so that a binary is built matching the running architecture since these multi-arch images are built on a matching VM.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
