### PR TITLE
fix: don't send comments if commitStatus update succeeds

### DIFF
--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -304,7 +304,9 @@ func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) (i
 	}
 
 	if statusCode, err := r.setCommitStatus(report); err != nil {
-		return statusCode, fmt.Errorf("failed to set gitlab commit status: %w", err)
+		r.logger.Error(err, "failed to set gitlab commit status, will attempt to leave a comment on the MR")
+	} else {
+		return statusCode, nil
 	}
 
 	// Create a note when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -220,7 +220,7 @@ var _ = Describe("GitLabReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(200))
 		})
 
 		It("creates a commit status for push snapshot with correct textual data without comments", func() {
@@ -250,7 +250,7 @@ var _ = Describe("GitLabReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(200))
 		})
 
 		It("creates a commit status for snapshot with TargetURL in CommitStatus", func() {
@@ -273,7 +273,7 @@ var _ = Describe("GitLabReporter", func() {
 					Text:                "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(200))
 		})
 
 		It("does not create a commit status or comment for snapshot with existing matching checkRun in running state", func() {
@@ -291,7 +291,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			statusCode, err := reporter.ReportStatus(context.TODO(), report)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(200))
 		})
 
 		It("can get an existing commitStatus that matches the report", func() {


### PR DESCRIPTION
* If we successfuly manage to post a commitStatus to a gitLab MR, we don't want to send a comment too
* Conversely if we don't manage to post the commitStatus, we then attempt to send a comment
* The controller was running into nil pointer errors on account of the wrong error variable being used to detect enqueing via pending edge case

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
