### PR TITLE
fix(STONEINTG-1371): add Snapshot name length validation webhook

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -707,9 +707,16 @@ func CanSnapshotBePromoted(snapshot *applicationapiv1alpha1.Snapshot) (bool, []s
 
 // NewSnapshot creates a new snapshot based on the supplied application and components
 func NewSnapshot(application *applicationapiv1alpha1.Application, snapshotComponents *[]applicationapiv1alpha1.SnapshotComponent) *applicationapiv1alpha1.Snapshot {
+	// truncate the application name so the GenerateName function can accommodate Kubernetes 63-character limit
+	const maxPrefixLength = 57
+	prefix := application.Name
+	if len(prefix) > maxPrefixLength {
+		prefix = prefix[:maxPrefixLength]
+	}
+
 	snapshot := &applicationapiv1alpha1.Snapshot{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: application.Name + "-",
+			GenerateName: prefix + "-",
 			Namespace:    application.Namespace,
 		},
 		Spec: applicationapiv1alpha1.SnapshotSpec{

--- a/internal/webhook/v1beta2/snapshot_webhook.go
+++ b/internal/webhook/v1beta2/snapshot_webhook.go
@@ -90,8 +90,16 @@ func (v *SnapshotCustomValidator) ValidateCreate(ctx context.Context, obj runtim
 
 	snapshotlog.Info("Validating Snapshot upon creation", "name", snapshot.GetName())
 
-	// No specific validation needed for create operations
-	// Components can be set during creation
+	const maxK8sNameLength = 63
+	// validate user created override snapshots do not exceed max name length
+	if snapshot.Name != "" && len(snapshot.Name) > maxK8sNameLength {
+		return nil, field.Invalid(
+			field.NewPath("metadata").Child("name"),
+			snapshot.Name,
+			fmt.Sprintf("name is too long (%d characters); must be at most %d characters",
+				len(snapshot.Name), maxK8sNameLength),
+		)
+	}
 
 	return nil, nil
 }

--- a/internal/webhook/v1beta2/snapshot_webhook_unit_test.go
+++ b/internal/webhook/v1beta2/snapshot_webhook_unit_test.go
@@ -63,6 +63,47 @@ func TestSnapshotCustomValidator_ValidateCreate(t *testing.T) {
 			t.Errorf("Unexpected error message: %v", err)
 		}
 	})
+
+	t.Run("should reject Name longer than 63 characters", func(t *testing.T) {
+		// Name with 64 characters (exceeds max of 63)
+		longName := "this-is-a-very-long-override-snapshot-name-that-exceeds-the-max-"
+		snapshotWithLongName := &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      longName,
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: "test-app",
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, snapshotWithLongName)
+		if err == nil {
+			t.Error("ValidateCreate should error for Name longer than 63 characters")
+		}
+		if err != nil && err.Error() != "metadata.name: Invalid value: \"this-is-a-very-long-override-snapshot-name-that-exceeds-the-max-\": name is too long (64 characters); must be at most 63 characters" {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("should allow Name with exactly 63 characters", func(t *testing.T) {
+		// Name with exactly 63 characters (at the limit)
+		maxName := "this-is-a-very-long-override-snapshot-name-that-is-at-max------"
+		snapshotWithMaxName := &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      maxName,
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: "test-app",
+			},
+		}
+
+		_, err := validator.ValidateCreate(ctx, snapshotWithMaxName)
+		if err != nil {
+			t.Errorf("ValidateCreate should not error for Name with 63 characters, got: %v", err)
+		}
+	})
 }
 
 func TestSnapshotCustomValidator_ValidateUpdate(t *testing.T) {


### PR DESCRIPTION
Since Snapshot names are used in labels for resources such as build pipelineRuns and Releases the validation webhook has been updated to check that newly created Snapshots don't have a name that's longer than than 63 characters (the limit for label length).

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
