### PR TITLE
feat(STONEINTG-1171): refactor reporting expected Snapshots

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -2132,9 +2132,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				},
 			})
 			result, err := adapter.EnsureIntegrationTestReportedToGitProvider()
-			expectedLogEntry := "pr group info has not been added to build pipelineRun metadata, try again"
+			expectedLogEntry := "pr group info has not been added to build pipelineRun metadata, skipping reporting tests for the build pipelineRun"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			Expect(result.RequeueRequest && err != nil).To(BeTrue())
+			Expect(!result.RequeueRequest && err == nil).To(BeTrue())
 		})
 	})
 	createAdapter = func() *Adapter {

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -157,6 +157,7 @@ func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) er
 		Named("buildpipelinerun").
 		WithEventFilter(predicate.Or(
 			tekton.BuildPipelineRunSignedAndSucceededPredicate(),
+			tekton.BuildPipelineRunGroupInfoAddedPredicate(),
 			tekton.BuildPipelineRunFailedPredicate(),
 			tekton.BuildPipelineRunCreatedPredicate(),
 			tekton.BuildPipelineRunDeletingPredicate(),


### PR DESCRIPTION
* Extract the common functionality for reporting expected Snapshots in the build pipeline adapter into reportStatusForExpectedSnapshot()
* Reduce the cognitive complexity for the above ensure function
* Add predicate which filters out all objects except Build PipelineRuns which have their group information added and haven't had a Snapshot created for them

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
