### PR TITLE
feat(STONEINTG-1358): update GCL in build pipelinerun

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -31,6 +31,8 @@ notify_pr_group_failure(annotate Snapshots and in-flight builds in PR group with
 failed_group_pipeline_run{Pipeline failed?}
 update_integrationTestStatus_in_git_provider(Create checkRun/commitStatus in<br>git provider)
 update_build_plr_annotation(Update build pipelineRun annotation<br>test.appstudio.openshift.io/snapshot-creation-report<br>with the status)
+successful_pipeline(Successful build pipelinerun<br>from push event and is signed)
+update_GCL(Update Global Candidate List for the built component)
 
 %% Node connections
 predicate                        --> get_pipeline_run
@@ -38,6 +40,7 @@ predicate                       -->  new_pipeline_run
 predicate                       -->  new_pipeline_run_without_prgroup
 predicate                       -->  failed_pipeline_run
 predicate                       -->  need_to_set_integration_test
+predicate                       -->  successful_pipeline
 new_pipeline_run           --Yes-->  finalizer_exists
 finalizer_exists           --No-->   add_finalizer
 add_finalizer                    --> continue
@@ -63,6 +66,9 @@ need_to_set_integration_test  --Yes --> update_integrationTestStatus_in_git_prov
 need_to_set_integration_test  --No  --> continue
 update_integrationTestStatus_in_git_provider --> update_build_plr_annotation
 update_build_plr_annotation --> continue
+
+successful_pipeline --> update_GCL
+update_GCL          --> continue
 
 %% Assigning styles to nodes
 class predicate Amber;

--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -42,7 +42,7 @@ flowchart TD
   %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureGlobalCandidateImageUpdated() function
 
   %% Node definitions
-  ensure2(Process further if: <br>Snapshot was not created by PAC Pull Request Event OR <br>an override snapshot was created <br>& Snapshot wasn't added to Global Candidate List)
+  ensure2(Process further if: <br>an override snapshot was created <br>& Snapshot wasn't added to Global Candidate List)
   update_container_image("<b>Get</b> all components of snapshot and <br><b>Update</b> the '.status.lastPromotedImage' field of the <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].containerImage field")
   update_last_built_commit("<b>Update</b> the '.status.lastBuiltCommit' field of the given <br>component with the latest value, taken from <br>given Snapshot's .spec.components[x].source.git.revision field")
   mark_snapshot_added_to_GCL(<b>Mark</b> the Snapshot as AddedToGlobalCandidateList)

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -119,6 +119,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsurePipelineIsFinalized,
 		adapter.EnsurePRGroupAnnotated,
 		adapter.EnsureIntegrationTestReportedToGitProvider,
+		adapter.EnsureGlobalCandidateImageUpdated,
 		adapter.EnsureSnapshotExists,
 		adapter.EnsureSupercededSnapshotsCanceled,
 	})
@@ -129,6 +130,7 @@ type AdapterInterface interface {
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureIntegrationTestReportedToGitProvider() (controller.OperationResult, error)
+	EnsureGlobalCandidateImageUpdated() (controller.OperationResult, error)
 	EnsureSnapshotExists() (controller.OperationResult, error)
 	EnsureSupercededSnapshotsCanceled() (controller.OperationResult, error)
 }


### PR DESCRIPTION
* add EnsureGlobalCandidateImageUpdated to updated GCL for push event build pipelinerun
* update GCL for override snapshot in snapshot_adapter
* mark AddedToGlobalCandidateList in build PLR and override snapshot annotation instead of statusCondition as GCL update indicator

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
