### PR TITLE
feat(STONEINTG-1360): set the skipped GL commit status for optional t…

### DIFF
--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -353,7 +353,7 @@ var _ = Describe("GitLabReporter", func() {
 			"reports correct gitlab statuses from test statuses",
 			func(teststatus integrationteststatus.IntegrationTestStatus, glState gitlab.BuildStateValue) {
 
-				state, err := status.GenerateGitlabCommitState(teststatus)
+				state, err := status.GenerateGitlabCommitState(teststatus, false)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(state).To(Equal(glState))
 			},
@@ -373,9 +373,19 @@ var _ = Describe("GitLabReporter", func() {
 
 		It("check if all integration tests statuses are supported", func() {
 			for _, teststatus := range integrationteststatus.IntegrationTestStatusValues() {
-				_, err := status.GenerateGitlabCommitState(teststatus)
+				_, err := status.GenerateGitlabCommitState(teststatus, false)
 				Expect(err).ToNot(HaveOccurred())
 			}
+		})
+		It("check if optional integration test returns skipped status for failed test", func() {
+			state, err := status.GenerateGitlabCommitState(integrationteststatus.IntegrationTestStatusTestFail, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(gitlab.Skipped))
+		})
+		It("check if optional integration test returns skipped status for invalid test", func() {
+			state, err := status.GenerateGitlabCommitState(integrationteststatus.IntegrationTestStatusTestInvalid, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal(gitlab.Skipped))
 		})
 	})
 })


### PR DESCRIPTION
Change allows to diplay optional integration tests as skipped in gitlab in case they should be set as failed.

Optional tests > fail > displayed as `skipped`
NON-optional test > fail > displayed as `failed`

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
