### PR TITLE
feat(STONEINTG-1379): update task references in PR pipelineRuns

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/konflux-ci/integration-service/api/v1beta2"
@@ -504,4 +505,12 @@ func IsObjectYoungerThanThreshold(obj metav1.Object, threshold time.Duration) bo
 	durationSinceObjectCreation := time.Since(objectCreationTime)
 
 	return durationSinceObjectCreation < threshold
+}
+
+// UrlToGitUrl appends `.git` to the URL if it doesn't already have it
+func UrlToGitUrl(url string) string {
+	if strings.HasSuffix(url, ".git") {
+		return url
+	}
+	return strings.TrimSuffix(url, "/") + ".git"
 }

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -1081,4 +1081,24 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		Expect(result).To(BeFalse())
 	})
 
+	It("correctly parse and normalize git reference urls", func() {
+		expectedGitUrl := "https://github.com/konflux-ci/integration-service.git"
+		gitUrl := "https://github.com/konflux-ci/integration-service"
+		normalizedGitUrl := helpers.UrlToGitUrl(gitUrl)
+		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
+
+		gitUrl = "https://github.com/konflux-ci/integration-service/"
+		normalizedGitUrl = helpers.UrlToGitUrl(gitUrl)
+		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
+
+		gitUrl = "https://github.com/konflux-ci/integration-service.git"
+		normalizedGitUrl = helpers.UrlToGitUrl(gitUrl)
+		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
+
+		expectedGitUrl = "git@github.com:konflux-ci/integration-service.git"
+		gitUrl = "git@github.com:konflux-ci/integration-service.git"
+		normalizedGitUrl = helpers.UrlToGitUrl(gitUrl)
+		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
+	})
+
 })

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -43,6 +43,9 @@ const (
 	// Name of tekton resolver for git
 	TektonResolverGit = "git"
 
+	// TektonResolverBundle is the name of Tekton resolver for bundles
+	TektonResolverBundle = "bundle"
+
 	// Name of tekton git resolver param url
 	TektonResolverGitParamURL = "url"
 


### PR DESCRIPTION
* Update task and/or pipeline references in integration pipelineRuns for matching PRs

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
