### PR TITLE
fix(konflux-10792): use auto-release annotation for cel

### DIFF
--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -658,6 +658,13 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(canBePromoted).To(BeFalse())
 		Expect(reasons).To(HaveLen(4))
 
+		// Makes sure the auto-release annotation supercedes the label
+		hasSnapshot.Labels[gitops.AutoReleaseLabel] = "true"
+		hasSnapshot.Annotations[gitops.AutoReleaseLabel] = "false"
+		canBePromoted, reasons = gitops.CanSnapshotBePromoted(hasSnapshot)
+		Expect(canBePromoted).To(BeFalse())
+		Expect(reasons).To(HaveLen(4))
+
 	})
 
 	It("Return false when the image url contains invalid digest", func() {


### PR DESCRIPTION
Since labels can ony contain alphanumeric characters, dashes, and underscores, this commit updates the auto-release logic to evaluate an annotation in the releaseplan with the same name as the auto-release label. If the annotation does not exist, the integration service will still fall back on the auto-release label (with a true/false value) to determine whether the snapshot should be auto-released.  This ensures backwards compatibility

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
