### PR TITLE
fix(konflux-10792): evaluate releasePlan auto-release label

### DIFF
--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -663,7 +663,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		hasSnapshot.Annotations[gitops.AutoReleaseLabel] = "false"
 		canBePromoted, reasons = gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())
-		Expect(reasons).To(HaveLen(4))
+		Expect(reasons).To(HaveLen(3))
 
 	})
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -511,7 +511,7 @@ func (a *Adapter) shouldProcessReleases() bool {
 
 // getAutoReleasePlans fetch release plans
 func (a *Adapter) getAutoReleasePlans() (*[]releasev1alpha1.ReleasePlan, error) {
-	releasePlans, err := a.loader.GetAutoReleasePlansForApplication(a.context, a.client, a.application)
+	releasePlans, err := a.loader.GetAutoReleasePlansForApplication(a.context, a.client, a.application, a.snapshot)
 	if err != nil {
 		a.logger.Error(err, "Failed to get all ReleasePlans")
 		return nil, err

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -1020,66 +1020,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
 		})
 
-		It("creates a Release for valid CEL expression", func() {
-			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
-
-			hasSnapshot.Labels[gitops.AutoReleaseLabel] = "updatedComponentIs('component-sample')"
-			err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Snapshot integration status condition is finished since all testing pipelines completed")
-			Expect(err).ToNot(HaveOccurred())
-			err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "test passed")
-			Expect(err).To(Succeed())
-			Expect(gitops.HaveAppStudioTestsFinished(hasSnapshot)).To(BeTrue())
-			Expect(gitops.HaveAppStudioTestsSucceeded(hasSnapshot)).To(BeTrue())
-			adapter = NewAdapter(ctx, hasSnapshot, hasApp, log, loader.NewMockLoader(), k8sClient)
-
-			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
-				{
-					ContextKey: loader.ApplicationContextKey,
-					Resource:   hasApp,
-				},
-				{
-					ContextKey: loader.ComponentContextKey,
-					Resource:   hasComp,
-				},
-				{
-					ContextKey: loader.SnapshotContextKey,
-					Resource:   hasSnapshot,
-				},
-				{
-					ContextKey: loader.AutoReleasePlansContextKey,
-					Resource:   []releasev1alpha1.ReleasePlan{*testReleasePlan},
-				},
-				{
-					ContextKey: loader.ReleaseContextKey,
-					Resource:   &releasev1alpha1.Release{},
-				},
-			})
-
-			Eventually(func() bool {
-				result, err := adapter.EnsureAllReleasesExist()
-				return !result.CancelRequest && err == nil
-			}, time.Second*10).Should(BeTrue())
-
-			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{
-					Name:      hasSnapshot.Name,
-					Namespace: "default",
-				}, hasSnapshot)
-				return err == nil && gitops.IsSnapshotMarkedAsAutoReleased(hasSnapshot)
-			}, time.Second*10).Should(BeTrue())
-
-			// Check if the adapter function detects that it already released the snapshot
-			result, err := adapter.EnsureAllReleasesExist()
-			Expect(err).ShouldNot(HaveOccurred())
-			Expect(result.CancelRequest).To(BeFalse())
-
-			expectedLogEntry := "The Snapshot was previously auto-released, skipping auto-release."
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-
-			condition := meta.FindStatusCondition(hasSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
-			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
-		})
-
 		It("no action when EnsureAllReleasesExist function runs when AppStudio Tests failed and the snapshot is invalid", func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
@@ -1108,7 +1048,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			expectedLogEntry = "the Snapshot was created for a PaC pull request event"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
-			expectedLogEntry = fmt.Sprintf("the Snapshot '%s' label expression evaluated to 'false'", gitops.AutoReleaseLabel)
+			expectedLogEntry = fmt.Sprintf("the Snapshot '%s' label is 'false'", gitops.AutoReleaseLabel)
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
 

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -185,9 +185,9 @@ func (l *mockLoader) GetAllSnapshots(ctx context.Context, c client.Client, appli
 }
 
 // GetAutoReleasePlansForApplication returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *mockLoader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error) {
 	if ctx.Value(AutoReleasePlansContextKey) == nil {
-		return l.loader.GetAutoReleasePlansForApplication(ctx, c, application)
+		return l.loader.GetAutoReleasePlansForApplication(ctx, c, application, snapshot)
 	}
 	autoReleasePlans, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AutoReleasePlansContextKey, []releasev1alpha1.ReleasePlan{})
 	return &autoReleasePlans, err

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -256,7 +256,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   releasePlans,
 				},
 			})
-			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil)
+			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil, nil)
 			Expect(resource).To(Equal(&releasePlans))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -565,7 +565,7 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures the ReleasePlan can be gotten for Application", func() {
-		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
+		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(gottenReleasePlanItems).NotTo(BeNil())
 
@@ -612,7 +612,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is set to true", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(HaveLen(1))
@@ -652,7 +652,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is missing", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(HaveLen(1))
@@ -695,7 +695,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is set to false", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(BeEmpty())


### PR DESCRIPTION
The previous implementation of this ticket evaluated the snapshot's auto-release label rather than the releasePlans auto-release label (which can use the snapshot itself to determine whether to release said snapshot). This fixes that and uses an annotation with the same name as the label as the home for the CEL expressions

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
