### PR TITLE
feat(STONEINTG-1253): add workflow type annotation to snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -108,6 +108,9 @@ const (
 	// BuildPipelineLastBuiltTime contains the time of the last built pipelineRun
 	BuildPipelineLastBuiltTime = "test.appstudio.openshift.io/lastbuilttime"
 
+	// IntegrationWorkflowAnnotation contains the workflow type that triggered the snapshot (push or pull-request)
+	IntegrationWorkflowAnnotation = "test.appstudio.openshift.io/integration-workflow"
+
 	// BuildPipelineRunPrefix contains the build pipeline run related labels and annotations
 	BuildPipelineRunPrefix = "build.appstudio"
 
@@ -185,6 +188,12 @@ const (
 
 	// PipelineAsCodeMergeRequestType is the type of merge request event which triggered the pipelinerun in build service
 	PipelineAsCodeMergeRequestType = "merge request"
+
+	// IntegrationWorkflowPushValue is the value for push workflow snapshots
+	IntegrationWorkflowPushValue = "push"
+
+	// IntegrationWorkflowPullRequestValue is the value for pull request workflow snapshots
+	IntegrationWorkflowPullRequestValue = "pull-request"
 
 	// PipelineAsCodeGitHubProviderType is the git provider type for a GitHub event which triggered the pipelinerun in build service.
 	PipelineAsCodeGitHubProviderType = "github"

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -486,6 +486,13 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 		snapshot.Annotations[gitops.BuildPipelineRunStartTime] = strconv.FormatInt(pipelineRun.Status.StartTime.Unix(), 10)
 	}
 
+	// Set the integration workflow annotation based on the PipelineRun type
+	if tekton.IsPLRCreatedByPACPushEvent(pipelineRun) {
+		snapshot.Annotations[gitops.IntegrationWorkflowAnnotation] = gitops.IntegrationWorkflowPushValue
+	} else {
+		snapshot.Annotations[gitops.IntegrationWorkflowAnnotation] = gitops.IntegrationWorkflowPullRequestValue
+	}
+
 	return snapshot, nil
 }
 


### PR DESCRIPTION
Add a new annotation "test.appstudio.openshift.io/integration-workflow" to snapshots created from build pipelines. The annotation value is set to either "push" or "pull-request" based on the PipelineRun's event type.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
