### PR TITLE
fix: check if task has a taskRef

### DIFF
--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -275,7 +275,7 @@ func (iplr *IntegrationPipelineRun) WithUpdatedTasksGitResolver(snapshot *applic
 func shouldUpdateTaskGitResolver(task *tektonv1.PipelineTask, snapshot *applicationapiv1alpha1.Snapshot) bool {
 	// only tekton git resolver is applicable
 	//nolint:staticcheck  // QF1008: We specifically want ResolverRef.Params, not PipelineRef.Params
-	if task.TaskRef.ResolverRef.Resolver != consts.TektonResolverGit {
+	if task.TaskRef == nil || task.TaskRef.ResolverRef.Resolver != consts.TektonResolverGit {
 		return false
 	}
 

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -854,6 +854,16 @@ var _ = Describe("Integration pipeline", Ordered, func() {
 										},
 									},
 								},
+								{
+									Name:   "some-task4",
+									Params: []tektonv1.Param{},
+									TaskSpec: &tektonv1.EmbeddedTask{
+										TaskSpec: tektonv1.TaskSpec{
+											DisplayName: "some-task4",
+											Steps:       []tektonv1.Step{},
+										},
+									},
+								},
 							},
 						},
 					},


### PR DESCRIPTION
* When determining if a task needs to be updated, check if the task has the taskRef field

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
