### PR TITLE
fix(KONFLUX-10903): add retry logic for PipelineRun finalizer addition

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -444,7 +444,10 @@ func AddFinalizerToPipelineRun(ctx context.Context, adapterClient client.Client,
 	if ok := controllerutil.AddFinalizer(pipelineRun, finalizer); ok {
 		err := adapterClient.Patch(ctx, pipelineRun, patch)
 		if err != nil {
-			return fmt.Errorf("error occurred while patching the updated PipelineRun after finalizer addition: %w", err)
+			logger.Error(err, "error occurred while patching the updated PipelineRun after finalizer addition",
+				"pipelineRun.Name", pipelineRun.Name)
+			// don't return wrapped err, so we can use RetryOnConflict
+			return err
 		}
 
 		logger.LogAuditEvent("Added Finalizer to the PipelineRun", pipelineRun, LogActionUpdate, "finalizer", finalizer)


### PR DESCRIPTION

The AddFinalizerToPipelineRun function was failing with etcd timeout errors
when patching PipelineRuns. The error was wrapped, preventing RetryOnConflict
from detecting and retrying transient errors.

Changes:
- Modified AddFinalizerToPipelineRun to return unwrapped errors, allowing
  RetryOnConflict to properly detect conflicts and retriable errors
- Updated EnsurePipelineIsFinalized to use RetryOnConflict with PipelineRun
  refetching, matching the pattern used in other adapter operations
- Added check to skip finalizer addition if already present after refetch

This fix handles:
- etcd timeout errors (retried automatically)
- Resource conflicts (retried with exponential backoff)
- Transient API server errors

Fixes: etcdserver: request timed out errors when adding finalizers to PipelineRuns"

More info in [KONFLUX-10903](https://issues.redhat.com/browse/KONFLUX-10903)