### PR TITLE
fix: don't overwrite integration plr serviceaccount

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -821,7 +821,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 		WithIntegrationLabels(integrationTestScenario).
 		WithIntegrationAnnotations(integrationTestScenario).
 		WithApplication(a.application).
-		WithServiceAccount(tektonconsts.DefaultIntegrationPipelineServiceAccount).
+		WithDefaultServiceAccount(tektonconsts.DefaultIntegrationPipelineServiceAccount).
 		WithExtraParams(integrationTestScenario.Spec.Params).
 		WithFinalizer(h.IntegrationPipelineRunFinalizer).
 		WithIntegrationTimeouts(integrationTestScenario, a.logger.Logger)

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -420,10 +420,12 @@ func (r *IntegrationPipelineRun) WithApplication(application *applicationapiv1al
 	return r
 }
 
-// WithServiceAccount adds the specified service account to the Integration PipelineRun's TaskRunTemplate.
-func (r *IntegrationPipelineRun) WithServiceAccount(serviceAccountName string) *IntegrationPipelineRun {
-	r.Spec.TaskRunTemplate.ServiceAccountName = serviceAccountName
-
+// WithDefaultServiceAccount adds the specified service account to the Integration PipelineRun's TaskRunTemplate if
+// it doesn't already have one defined.
+func (r *IntegrationPipelineRun) WithDefaultServiceAccount(serviceAccountName string) *IntegrationPipelineRun {
+	if r.Spec.TaskRunTemplate.ServiceAccountName == "" {
+		r.Spec.TaskRunTemplate.ServiceAccountName = serviceAccountName
+	}
 	return r
 }
 

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -582,9 +582,19 @@ var _ = Describe("Integration pipeline", Ordered, func() {
 			serviceAccountName := "konflux-integration-runner"
 
 			ipr := tekton.IntegrationPipelineRun{}
-			ipr.WithServiceAccount(serviceAccountName)
+			ipr.WithDefaultServiceAccount(serviceAccountName)
 
 			Expect(ipr.Spec.TaskRunTemplate.ServiceAccountName).To(Equal(serviceAccountName))
+		})
+
+		It("doesn't overwrite the service account if it's already set", func() {
+			serviceAccountName := "konflux-integration-runner"
+
+			ipr := tekton.IntegrationPipelineRun{}
+			ipr.Spec.TaskRunTemplate.ServiceAccountName = "someotherserviceaccount"
+			ipr.WithDefaultServiceAccount(serviceAccountName)
+
+			Expect(ipr.Spec.TaskRunTemplate.ServiceAccountName).To(Equal("someotherserviceaccount"))
 		})
 	})
 


### PR DESCRIPTION
* If the integration pipelineRun already has a serviceaccount defined, don't overwrite it when attempting to set the default serviceaccount

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
