### PR TITLE
feat(STONEINTG-1385): add support for merge queue snapshots

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -558,6 +558,14 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 		snapshot.Labels[gitops.BuildPipelineRunFinishTimeLabel] = strconv.FormatInt(time.Now().Unix(), 10)
 	}
 
+	if gitops.IsSnapshotCreatedByPACMergeQueueEvent(snapshot) {
+		pullRequestNumber := gitops.ExtractPullRequestNumberFromMergeQueueSnapshot(snapshot)
+		if pullRequestNumber != "" {
+			snapshot.Labels[gitops.PipelineAsCodePullRequestAnnotation] = pullRequestNumber
+			snapshot.Annotations[gitops.PipelineAsCodePullRequestAnnotation] = pullRequestNumber
+		}
+	}
+
 	if pipelineRun.Status.StartTime != nil {
 		snapshot.Annotations[gitops.BuildPipelineRunStartTime] = strconv.FormatInt(pipelineRun.Status.StartTime.Unix(), 10)
 	}

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -105,6 +105,12 @@ func GenerateSHA(str string) string {
 
 // IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
 func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
+	if branch, found := plr.Annotations[consts.PipelineAsCodeSourceBranchAnnotation]; found {
+		if strings.HasPrefix(branch, consts.PipelineAsCodeGitHubMergeQueueBranchPrefix) {
+			return false
+		}
+	}
+
 	return !metadata.HasLabel(plr, consts.PipelineAsCodePullRequestLabel) ||
 		metadata.HasLabelWithValue(plr, consts.PipelineAsCodeEventTypeLabel, consts.PipelineAsCodePushType) ||
 		metadata.HasLabelWithValue(plr, consts.PipelineAsCodeEventTypeLabel, consts.PipelineAsCodeGLPushType)

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -149,6 +149,12 @@ var _ = Describe("build pipeline", func() {
 			Expect(tekton.GenerateSHA(prGroup)).NotTo(BeNil())
 		})
 
+		It("can detect that the build pipelineRun originated from a merge queue and not consider it a push pipelineRun", func() {
+			buildPipelineRun.Labels[tektonconsts.PipelineAsCodeEventTypeLabel] = "push"
+			buildPipelineRun.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "gh-readonly-queue/main/pr-2987-bda9b312bf224a6b5fb1e7ed6ae76dd9e6b1b75b"
+			Expect(tekton.IsPLRCreatedByPACPushEvent(buildPipelineRun)).To(BeFalse())
+		})
+
 		It("can get the latest build pipelinerun for given component", func() {
 			plrs := []tektonv1.PipelineRun{*buildPipelineRun, *buildPipelineRun2}
 			Expect(tekton.IsLatestBuildPipelineRunInComponent(buildPipelineRun, &plrs)).To(BeTrue())

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -88,6 +88,9 @@ const (
 	// PipelineAsCodeGLPushType is the type of gitlab push event which triggered the pipelinerun in build service
 	PipelineAsCodeGLPushType = "Push"
 
+	// PipelineAsCodeGitHubMergeQueueBranchPrefix is the prefix added to temporary branches which are created for merge queues
+	PipelineAsCodeGitHubMergeQueueBranchPrefix = "gh-readonly-queue/"
+
 	/*
 	 * Utils constants
 	 */


### PR DESCRIPTION
* Add the ability to detect if a Snapshot was created for a merge queue via IsSnapshotCreatedByPACMergeQueueEvent
* Treat the merge queue Snapshots as pull request ones
* Extract the pull request number for merge queue Snapshots from either existing labels/annotations or the source branch and add it to its labels upon creation

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
