### PR TITLE
 feat(KFLUXDP-528): add support for specifying compute sizes 

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -94,6 +94,8 @@ spec:
           value: 48
         - name: memory
           value: 192
+        - name: compute-sizes
+          value: ""
     - name: deploy-konflux
       runAfter:
         - provision-kind-cluster


### PR DESCRIPTION
Create a new parameter "compute-sizes" that allow explicitly passing the desired computes sizes to 'mapt'.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
