### PR TITLE
fix(STONEINTG-1390): use stricter string to search existing comment

### DIFF
--- a/git/github/github.go
+++ b/git/github/github.go
@@ -430,7 +430,9 @@ func (c *Client) GetExistingCheckRun(checkRuns []*ghapi.CheckRun, newCheckRun *C
 // GetExistingComment returns existing GitHub comment for the scenario of ref.
 func (c *Client) GetExistingCommentID(comments []*ghapi.IssueComment, componentName, scenarioName string) *int64 {
 	for _, comment := range comments {
-		if strings.Contains(*comment.Body, componentName) && strings.Contains(*comment.Body, scenarioName) {
+		// get existing note by search "Integration test for componentName" and " scenario scenarioName " in report summary
+		// GetExistingNoteID for gitlab comment has the similar logic
+		if strings.Contains(*comment.Body, fmt.Sprintf("Integration test for %s ", componentName)) && strings.Contains(*comment.Body, fmt.Sprintf(" scenario %s ", scenarioName)) {
 			c.logger.Info("found comment ID with a matching scenarioName", "scenarioName", scenarioName)
 			return comment.ID
 		}

--- a/git/github/github_test.go
+++ b/git/github/github_test.go
@@ -114,7 +114,7 @@ func (MockIssuesService) CreateComment(
 func (MockIssuesService) ListComments(ctx context.Context, owner string, repo string,
 	number int, opts *ghapi.IssueListCommentsOptions) ([]*ghapi.IssueComment, *ghapi.Response, error) {
 	var id int64 = 40
-	var body = "Integration test for component component-sample snapshot snapshotName and scenario scenarioName"
+	var body = "Integration test for component component-sample snapshot snapshotName and scenario scenarioName failed"
 	issueComments := []*ghapi.IssueComment{{ID: &id, Body: &body}}
 	return issueComments, nil, nil
 }
@@ -355,7 +355,7 @@ var _ = Describe("Client", func() {
 		Expect(comments).NotTo(BeEmpty())
 		Expect(statusCode).NotTo(BeNil())
 
-		commentID := client.GetExistingCommentID(comments, "component-sample", "scenarioName")
+		commentID := client.GetExistingCommentID(comments, "component component-sample", "scenarioName")
 		Expect(*commentID).To(Equal(int64(40)))
 	})
 

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -296,8 +296,10 @@ func (r *GitLabReporter) GetExistingCommitStatus(commitStatuses []*gitlab.Commit
 // GetExistingNoteID returns existing GitLab note for the scenario of ref.
 func (r *GitLabReporter) GetExistingNoteID(notes []*gitlab.Note, scenarioName, componentName string) *int {
 	for _, note := range notes {
-		if strings.Contains(note.Body, componentName) && strings.Contains(note.Body, scenarioName) {
-			r.logger.Info("found note ID with a matching componentName and scenarioName", "omponentName", componentName, "scenarioName", scenarioName, "noteID", &note.ID)
+		// get existing note by search "Integration test for componentName" and " scenario scenarioName " in report summary
+		// GetExistingCommentID for github comment has the similar logic
+		if strings.Contains(note.Body, fmt.Sprintf("Integration test for %s ", componentName)) && strings.Contains(note.Body, fmt.Sprintf(" scenario %s ", scenarioName)) {
+			r.logger.Info("found note ID with a matching componentName and scenarioName", "componentName", componentName, "scenarioName", scenarioName, "noteID", &note.ID)
 			return &note.ID
 		}
 	}

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -205,7 +205,7 @@ var _ = Describe("GitLabReporter", func() {
 
 		It("creates a commit status for snapshot with correct textual data", func() {
 
-			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 failed"
 
 			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
 			muxMergeNotes(mux, targetProjectID, mergeRequest, summary)
@@ -236,7 +236,7 @@ var _ = Describe("GitLabReporter", func() {
 			Expect(err).To(Succeed())
 			Expect(statusCode).To(Equal(0))
 
-			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 failed"
 
 			muxCommitStatusPost(mux, sourceProjectID, digest, summary)
 
@@ -277,7 +277,7 @@ var _ = Describe("GitLabReporter", func() {
 		})
 
 		It("does not create a commit status or comment for snapshot with existing matching checkRun in running state", func() {
-			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 is running"
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 is running"
 
 			report := status.TestReport{
 				FullName:     "fullname/scenario1",
@@ -295,7 +295,7 @@ var _ = Describe("GitLabReporter", func() {
 		})
 
 		It("can get an existing commitStatus that matches the report", func() {
-			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 failed"
 			report := status.TestReport{
 				FullName:     "fullname/scenario1",
 				ScenarioName: "scenario1",
@@ -322,14 +322,15 @@ var _ = Describe("GitLabReporter", func() {
 		})
 
 		It("can get an existing mergeRequest note that matches the report", func() {
-			summary := "Integration test for snapshot snapshot-sample and scenario scenario1 failed"
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 failed"
 			report := status.TestReport{
-				FullName:     "fullname/scenario1",
-				ScenarioName: "scenario1",
-				SnapshotName: "snapshot-sample",
-				Status:       integrationteststatus.IntegrationTestStatusTestPassed,
-				Summary:      summary,
-				Text:         "detailed text here",
+				FullName:      "fullname/scenario1",
+				ScenarioName:  "scenario1",
+				SnapshotName:  "snapshot-sample",
+				Status:        integrationteststatus.IntegrationTestStatusTestPassed,
+				Summary:       summary,
+				ComponentName: "component-sample",
+				Text:          "detailed text here",
 			}
 			comment, err := status.FormatComment(report.Summary, report.Text)
 			Expect(err).ToNot(HaveOccurred())
@@ -341,8 +342,8 @@ var _ = Describe("GitLabReporter", func() {
 			notes := []*gitlab.Note{
 				&note,
 			}
-			existingNoteID := reporter.GetExistingNoteID(notes, report.ScenarioName, report.SnapshotName)
 
+			existingNoteID := reporter.GetExistingNoteID(notes, report.ScenarioName, status.GenerateComponentNameWithPrefix(report.ComponentName))
 			Expect(*existingNoteID).To(Equal(note.ID))
 		})
 	})


### PR DESCRIPTION
* use stricter string to search existing comment(GH) and note(GL)

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
