### PR TITLE
fix(STONEINTG-1385): ignore refs/heads prefix from source branch

### DIFF
--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -708,6 +708,10 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		pullRequestNumber = gitops.ExtractPullRequestNumberFromMergeQueueSnapshot(mergeQueueSnapshot)
 		Expect(pullRequestNumber).To(Equal("2987"))
 
+		mergeQueueSnapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "refs/heads/gh-readonly-queue/main/pr-7-54e7d2bfec0e0570915f5770c890407c714e6139"
+		pullRequestNumber = gitops.ExtractPullRequestNumberFromMergeQueueSnapshot(mergeQueueSnapshot)
+		Expect(pullRequestNumber).To(Equal("7"))
+
 		mergeQueueSnapshot.Annotations[gitops.PipelineAsCodePullRequestAnnotation] = "214"
 		pullRequestNumber = gitops.ExtractPullRequestNumberFromMergeQueueSnapshot(mergeQueueSnapshot)
 		Expect(pullRequestNumber).To(Equal("214"))
@@ -1068,6 +1072,8 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				snapshot.Labels = make(map[string]string)
 				snapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodePushType
 				snapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "gh-readonly-queue/main/pr-2987-bda9b312bf224a6b5fb1e7ed6ae76dd9e6b1b75b"
+				Expect(gitops.IsSnapshotCreatedByPACPushEvent(snapshot)).To(BeFalse())
+				snapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "refs/heads/gh-readonly-queue/main/pr-7-54e7d2bfec0e0570915f5770c890407c714e6139"
 				Expect(gitops.IsSnapshotCreatedByPACPushEvent(snapshot)).To(BeFalse())
 			})
 

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -106,7 +106,7 @@ func GenerateSHA(str string) string {
 // IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
 func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
 	if branch, found := plr.Annotations[consts.PipelineAsCodeSourceBranchAnnotation]; found {
-		if strings.HasPrefix(branch, consts.PipelineAsCodeGitHubMergeQueueBranchPrefix) {
+		if strings.HasPrefix(strings.TrimPrefix(branch, consts.GitRefBranchPrefix), consts.PipelineAsCodeGitHubMergeQueueBranchPrefix) {
 			return false
 		}
 	}

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -153,6 +153,8 @@ var _ = Describe("build pipeline", func() {
 			buildPipelineRun.Labels[tektonconsts.PipelineAsCodeEventTypeLabel] = "push"
 			buildPipelineRun.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "gh-readonly-queue/main/pr-2987-bda9b312bf224a6b5fb1e7ed6ae76dd9e6b1b75b"
 			Expect(tekton.IsPLRCreatedByPACPushEvent(buildPipelineRun)).To(BeFalse())
+			buildPipelineRun.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "refs/heads/gh-readonly-queue/main/pr-7-54e7d2bfec0e0570915f5770c890407c714e6139"
+			Expect(tekton.IsPLRCreatedByPACPushEvent(buildPipelineRun)).To(BeFalse())
 		})
 
 		It("can get the latest build pipelinerun for given component", func() {

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -70,6 +70,9 @@ const (
 	// main branch in github/gitlab
 	MainBranch = "main"
 
+	// GitRefBranchPrefix is the git prefix denoting a reference is a branch
+	GitRefBranchPrefix = "refs/heads/"
+
 	// PipelineAsCodeSourceBranchAnnotation is the branch name of the the pull request is created from
 	PipelineAsCodeSourceBranchAnnotation = "pipelinesascode.tekton.dev/source-branch"
 


### PR DESCRIPTION
* The pipeline-as-code source branch annotation can contain the `refs/heads` prefix in it which needs to be ignored when detecting merge queues and extracting the PR number

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
