### PR TITLE
fix: create comment for all integration test status if no commitStatus

### DIFF
--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -481,7 +481,7 @@ func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestRep
 	}
 	// Create a comment when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful and there is commitStatus for all statuses
 	_, isPullRequest := csu.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
-	if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && isPullRequest {
+	if isPullRequest {
 		statusCode, err := csu.updateStatusInComment(ctx, report)
 		if err != nil {
 			csu.logger.Error(err, "failed to update comment", "snapshot.NameSpace", csu.snapshot.Namespace, "snapshot.Name", csu.snapshot.Name, "scenarioName", report.ScenarioName)

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -322,7 +322,7 @@ func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) (i
 
 	// Create a note when integration test is neither pending nor inprogress since comment for pending/inprogress is less meaningful
 	_, isMergeRequest := r.snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
-	if report.Status != intgteststat.IntegrationTestStatusPending && report.Status != intgteststat.IntegrationTestStatusInProgress && report.Status != intgteststat.SnapshotCreationFailed && isMergeRequest {
+	if isMergeRequest {
 		statusCode, err := r.updateStatusInComment(report)
 		if err != nil {
 			return statusCode, err


### PR DESCRIPTION
* create comment for any integration test status to show all status on MR/PR comment since comment is created only when commitStatus can't be created

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
