### PR TITLE
feat(KFLUXDP-528): specify instance types for Konflux E2E testing

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -90,12 +90,8 @@ spec:
             '[{\"containerPort\":30012,\"hostPort\":8180,\"protocol\":\"TCP\"}]'
         - name: spot
           value: "false"
-        - name: cpus
-          value: 48
-        - name: memory
-          value: 192
         - name: compute-sizes
-          value: ""
+          value: "m5a.large,m6a.large,m7i-flex.12xlarge,m5.12xlarge,m6i.12xlarge"
     - name: deploy-konflux
       runAfter:
         - provision-kind-cluster


### PR DESCRIPTION
Instead of letting mapt choose one, provide a list of suitable, but more affordable instance types.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
