### PR TITLE
feat(STONEINTG-1396): implement millisec-preci timestamp for snapshot…

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1090,6 +1090,15 @@ func (a *Adapter) isSnapshotOlderThanLastBuild(snapshot *applicationapiv1alpha1.
 	if componentlastBuiltTimeIntErr != nil {
 		return false
 	}
+
+	// Normalize BuildPipelineRunStartTime to seconds if it's in milliseconds
+	// Millisecond timestamps are > 1000000000000 (year 2001 in milliseconds)
+	// Second timestamps are < 10000000000 (year 2286 in seconds)
+	if snapshotBuildStartTimeInt > 10000000000 {
+		// It's in milliseconds, convert to seconds for comparison
+		snapshotBuildStartTimeInt = snapshotBuildStartTimeInt / 1000
+	}
+
 	if snapshotBuildStartTimeInt < componentlastBuiltTimeInt {
 		return true
 	}

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -108,18 +108,18 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		integrationPipelineRunOld                 *tektonv1.PipelineRun
 	)
 	const (
-		SampleRepoLink      = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		sample_image        = "quay.io/redhat-appstudio/sample-image"
-		sample_revision     = "random-value"
-		sampleDigest        = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-		customLabel         = "custom.appstudio.openshift.io/custom-label"
-		sourceRepoRef       = "db2c043b72b3f8d292ee0e38768d0a94859a308b"
-		hasComSnapshot1Name = "hascomsnapshot1-sample"
-		hasComSnapshot2Name = "hascomsnapshot2-sample"
-		hasComSnapshot3Name = "hascomsnapshot3-sample"
-		prGroup             = "feature1"
-		prGroupSha          = "feature1hash"
-		plrstarttime        = 1775992257
+		SampleRepoLink            = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		sample_image              = "quay.io/redhat-appstudio/sample-image"
+		sample_revision           = "random-value"
+		sampleDigest              = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		customLabel               = "custom.appstudio.openshift.io/custom-label"
+		sourceRepoRef             = "db2c043b72b3f8d292ee0e38768d0a94859a308b"
+		hasComSnapshot1Name       = "hascomsnapshot1-sample"
+		hasComSnapshot2Name       = "hascomsnapshot2-sample"
+		hasComSnapshot3Name       = "hascomsnapshot3-sample"
+		prGroup                   = "feature1"
+		prGroupSha                = "feature1hash"
+		plrstarttime        int64 = 1775992257000 // milliseconds (was 1775992257 seconds)
 	)
 
 	BeforeAll(func() {
@@ -410,7 +410,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.PipelineAsCodePullRequestAnnotation: "2",
 				},
 				Annotations: map[string]string{
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime, 10),
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeRepoURLAnnotation:        "repo-url",
@@ -434,7 +434,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.PipelineAsCodePullRequestAnnotation: "2",
 				},
 				Annotations: map[string]string{
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 100),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+100000, 10), // +100 seconds = +100000 milliseconds
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeRepoURLAnnotation:        "repo-url",
@@ -548,7 +548,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					// SnapshotTypeLabel will be set in each test
 				},
 				Annotations: map[string]string{
-					gitops.BuildPipelineRunStartTime: "1703123000", // OLDER timestamp
+					gitops.BuildPipelineRunStartTime: "1703123000000", // OLDER timestamp (milliseconds)
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -654,7 +654,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime, 10),
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodePullRequestAnnotation:    "1",
@@ -702,7 +702,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 100),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+100000, 10), // +100 seconds = +100000 milliseconds
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -740,7 +740,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 200),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+200000, 10), // +200 seconds = +200000 milliseconds
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodePullRequestAnnotation:    "1",

--- a/internal/controller/statusreport/statusreport_adapter_test.go
+++ b/internal/controller/statusreport/statusreport_adapter_test.go
@@ -65,16 +65,16 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		integrationTestScenario *v1beta2.IntegrationTestScenario
 	)
 	const (
-		SampleRepoLink      = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		SampleImage         = "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-		SampleDigest        = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-		SampleCommit        = "a2ba645d50e471d5f084b"
-		SampleRevision      = "random-value"
-		hasComSnapshot2Name = "hascomsnapshot2-sample"
-		hasComSnapshot3Name = "hascomsnapshot3-sample"
-		prGroup             = "feature1"
-		prGroupSha          = "feature1hash"
-		plrstarttime        = 1775992257
+		SampleRepoLink            = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		SampleImage               = "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		SampleDigest              = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		SampleCommit              = "a2ba645d50e471d5f084b"
+		SampleRevision            = "random-value"
+		hasComSnapshot2Name       = "hascomsnapshot2-sample"
+		hasComSnapshot3Name       = "hascomsnapshot3-sample"
+		prGroup                   = "feature1"
+		prGroupSha                = "feature1hash"
+		plrstarttime        int64 = 1775992257000 // milliseconds (was 1775992257 seconds)
 	)
 
 	BeforeAll(func() {
@@ -148,7 +148,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 100),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+100000, 10), // +100 seconds = +100000 milliseconds
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -186,7 +186,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 200),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+200000, 10), // +200 seconds = +200000 milliseconds
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodePullRequestAnnotation:    "1",

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -101,11 +101,11 @@ var _ = Describe("Status Adapter", func() {
 		hasComSnapshot2Name = "hascomsnapshot2-sample"
 		hasComSnapshot3Name = "hascomsnapshot3-sample"
 
-		prGroup      = "feature1"
-		prGroupSha   = "feature1hash"
-		plrstarttime = 1775992257
-		SampleImage  = "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-		SampleDigest = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		prGroup            = "feature1"
+		prGroupSha         = "feature1hash"
+		plrstarttime int64 = 1775992257000 // milliseconds (was 1775992257 seconds)
+		SampleImage        = "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		SampleDigest       = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
 	)
 
 	BeforeEach(func() {
@@ -330,7 +330,7 @@ var _ = Describe("Status Adapter", func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 100),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+100000, 10), // +100 seconds = +100000 milliseconds
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
@@ -367,7 +367,7 @@ var _ = Describe("Status Adapter", func() {
 				},
 				Annotations: map[string]string{
 					"test.appstudio.openshift.io/pr-last-update":  "2023-08-26T17:57:50+02:00",
-					gitops.BuildPipelineRunStartTime:              strconv.Itoa(plrstarttime + 200),
+					gitops.BuildPipelineRunStartTime:              strconv.FormatInt(plrstarttime+200000, 10), // +200 seconds = +200000 milliseconds
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
 					gitops.PipelineAsCodePullRequestAnnotation:    "1",


### PR DESCRIPTION
## Summary

Implements millisecond-precision timestamp-based snapshot naming with automatic collision handling to prevent naming collisions.

## Key Changes

- **Timestamp-based naming**: Added `GenerateSnapshotNameWithTimestamp()` using `UnixMilli()` (format: `prefix-YYYYMMDD-HHMMSS-mmm`)
- **Collision handling**: Automatic retry with random 2-char suffix when name collisions occur (up to 5 retries)
- **Updated functions**: `NewSnapshot()`, `prepareSnapshotForPipelineRun()`, and `SortSnapshots()` to use millisecond precision
- **Prefix length**: Set to 43 chars (without suffix) or 40 chars (with suffix) to fit within Kubernetes' 63-char limit
- **Error handling**: Fixed chains incomplete error to properly return errors instead of silently continuing

## Testing

- Added tests for collision handling, timestamp format, and prefix truncation
- Updated all test fixtures to use millisecond precision
- Fixed test mocks to properly isolate scenarios

## Benefits

- Prevents naming collisions even when multiple PipelineRuns start simultaneously
- Maintains human-readable, chronologically ordered names
- Automatic recovery from collisions without user intervention


[STONEINTG-1396](https://issues.redhat.com/browse/STONEINTG-1396)
Assisted -by: Cursor
AI tool