### PR TITLE
fix(api): remove 'env' from descriptions

### DIFF
--- a/api/v1alpha1/integrationtestscenario_types.go
+++ b/api/v1alpha1/integrationtestscenario_types.go
@@ -43,7 +43,7 @@ type EnvironmentTarget struct {
 // EnvironmentConfiguration contains Environment-specific configurations details, to be used when generating
 // Component/Application GitOps repository resources.
 type DeprecatedEnvironmentConfiguration struct {
-	// Env is an array of standard environment variables
+	// An array of standard environment variables
 	Env []EnvVarPair `json:"env,omitempty"`
 
 	// Target is used to reference a DeploymentTargetClaim for a target Environment.

--- a/api/v1beta1/integrationtestscenario_types.go
+++ b/api/v1beta1/integrationtestscenario_types.go
@@ -43,7 +43,7 @@ type EnvironmentTarget struct {
 // EnvironmentConfiguration contains Environment-specific configurations details, to be used when generating
 // Component/Application GitOps repository resources.
 type DeprecatedEnvironmentConfiguration struct {
-	// Env is an array of standard environment variables
+	// An array of standard environment variables
 	Env []EnvVarPair `json:"env,omitempty"`
 
 	// Target is used to reference a DeploymentTargetClaim for a target Environment.

--- a/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
+++ b/config/crd/bases/appstudio.redhat.com_integrationtestscenarios.yaml
@@ -80,7 +80,7 @@ spec:
                       Component/Application GitOps repository resources.
                     properties:
                       env:
-                        description: Env is an array of standard environment variables
+                        description: An array of standard environment variables
                         items:
                           description: EnvVarPair describes environment variables
                             to use for the component
@@ -281,7 +281,7 @@ spec:
                       Component/Application GitOps repository resources.
                     properties:
                       env:
-                        description: Env is an array of standard environment variables
+                        description: An array of standard environment variables
                         items:
                           description: EnvVarPair describes environment variables
                             to use for the component


### PR DESCRIPTION
When generating API docs from here and running the generated docs through Vale, Red Hat has a rule that looks for
'env' in text and forces a change to `environment' (see example pipeline run [here](https://github.com/konflux-ci/docs/actions/runs/19974100136/job/57285797073?pr=534)).

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
