### PR TITLE
feat: add artifact-browser-url to PR comment task

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -36,6 +36,10 @@ spec:
       default: 'none'
       description: 'Container image built from any konflux git repo. Use this param only when you run Konflux e2e tests
         in another Konflux component repo. Will pass the component built image from the snapshot.'
+    - name: artifact-browser-url
+      description: "URL to the artifact browser deployment. If provided, a link will be added to PR comments."
+      default: ""
+      type: string
   tasks:
     - name: test-metadata
       taskRef:
@@ -262,3 +266,5 @@ spec:
           value: kind-aws-provision.log
         - name: enable-test-results-analysis
           value: "true"
+        - name: artifact-browser-url
+          value: $(params.artifact-browser-url)


### PR DESCRIPTION
Add the artifact-browser-url pipeline parameter and pass it to the pull-request-comment task. This enables linking to the OCI artifact browser in PR comments when the URL is provided.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
