### PR TITLE
fix(STONEINTG-1313): don't require event-type for PR groups

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -424,11 +424,6 @@ func (l *loader) GetPipelineRunsWithPRGroupHash(ctx context.Context, adapterClie
 	if err != nil {
 		return nil, err
 	}
-
-	eventTypeLabelRequirement, err := labels.NewRequirement("pipelinesascode.tekton.dev/event-type", selection.NotIn, []string{"push", "Push"})
-	if err != nil {
-		return nil, err
-	}
 	prGroupLabelRequirement, err := labels.NewRequirement("test.appstudio.openshift.io/pr-group-sha", selection.In, []string{prGroupHash})
 	if err != nil {
 		return nil, err
@@ -440,7 +435,6 @@ func (l *loader) GetPipelineRunsWithPRGroupHash(ctx context.Context, adapterClie
 
 	labelSelector := labels.NewSelector().
 		Add(*applicationLabelRequirement).
-		Add(*eventTypeLabelRequirement).
 		Add(*prGroupLabelRequirement).
 		Add(*plrTypeLabelRequirement)
 
@@ -464,10 +458,6 @@ func (l *loader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx con
 	if err != nil {
 		return nil, err
 	}
-	eventTypeLabelRequirement, err := labels.NewRequirement("pac.test.appstudio.openshift.io/event-type", selection.NotIn, []string{"push", "Push"})
-	if err != nil {
-		return nil, err
-	}
 	componentLabelRequirement, err := labels.NewRequirement("appstudio.openshift.io/component", selection.In, []string{componentName})
 	if err != nil {
 		return nil, err
@@ -483,7 +473,6 @@ func (l *loader) GetMatchingComponentSnapshotsForComponentAndPRGroupHash(ctx con
 
 	labelSelector := labels.NewSelector().
 		Add(*applicationLabelRequirement).
-		Add(*eventTypeLabelRequirement).
 		Add(*componentLabelRequirement).
 		Add(*prGroupLabelRequirement).
 		Add(*snapshotTypeLabelRequirement)
@@ -508,10 +497,6 @@ func (l *loader) GetMatchingGroupSnapshotsForPRGroupHash(ctx context.Context, c 
 	if err != nil {
 		return nil, err
 	}
-	eventTypeLabelRequirement, err := labels.NewRequirement("pac.test.appstudio.openshift.io/event-type", selection.NotIn, []string{"push", "Push"})
-	if err != nil {
-		return nil, err
-	}
 	prGroupLabelRequirement, err := labels.NewRequirement("test.appstudio.openshift.io/pr-group-sha", selection.In, []string{prGroupHash})
 	if err != nil {
 		return nil, err
@@ -523,7 +508,6 @@ func (l *loader) GetMatchingGroupSnapshotsForPRGroupHash(ctx context.Context, c 
 
 	labelSelector := labels.NewSelector().
 		Add(*applicationLabelRequirement).
-		Add(*eventTypeLabelRequirement).
 		Add(*prGroupLabelRequirement).
 		Add(*snapshotTypeLabelRequirement)
 
@@ -547,10 +531,6 @@ func (l *loader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Context
 	if err != nil {
 		return nil, err
 	}
-	eventTypeLabelRequirement, err := labels.NewRequirement("pac.test.appstudio.openshift.io/event-type", selection.NotIn, []string{"push", "Push"})
-	if err != nil {
-		return nil, err
-	}
 	prGroupLabelRequirement, err := labels.NewRequirement("test.appstudio.openshift.io/pr-group-sha", selection.In, []string{prGroupHash})
 	if err != nil {
 		return nil, err
@@ -562,7 +542,6 @@ func (l *loader) GetMatchingComponentSnapshotsForPRGroupHash(ctx context.Context
 
 	labelSelector := labels.NewSelector().
 		Add(*applicationLabelRequirement).
-		Add(*eventTypeLabelRequirement).
 		Add(*prGroupLabelRequirement).
 		Add(*snapshotTypeLabelRequirement)
 
@@ -605,6 +584,10 @@ func (l *loader) GetComponentsFromSnapshotForPRGroup(ctx context.Context, client
 
 	var componentNames []string
 	for _, snapshot := range *snapshots {
+		// We skip a push-type workflow Snapshot just in case
+		if snapshot.Annotations[gitops.IntegrationWorkflowAnnotation] == gitops.IntegrationWorkflowPushValue {
+			continue
+		}
 		componentName := snapshot.Labels[gitops.SnapshotComponentLabel]
 		if slices.Contains(componentNames, componentName) {
 			continue


### PR DESCRIPTION
* Since the merge queue pipelineRuns and Snapshots will have the PaC event-type set to `push`, we don't want to enforce that label when filtering for pr groups

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
