### PR TITLE
fix: add more memory to snapshot garbage collector

### DIFF
--- a/config/snapshotgc/snapshotgc.yaml
+++ b/config/snapshotgc/snapshotgc.yaml
@@ -21,10 +21,10 @@ spec:
               resources:
                 requests:
                   cpu: 1000m
-                  memory: 1000Mi
+                  memory: 2000Mi
                 limits:
                   cpu: 1000m
-                  memory: 1000Mi
+                  memory: 2000Mi
               securityContext:
                 readOnlyRootFilesystem: true
                 runAsNonRoot: true


### PR DESCRIPTION
* The gc is running into OOM errors on very busy clusters

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
