### PR TITLE
fix: wait for buildpipeline creation in controller unit test

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_controller_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller_test.go
@@ -379,6 +379,14 @@ var _ = Describe("PipelineController", func() {
 		})
 
 		It("reconcile with application taken from pipelinerun (build pipeline)", func() {
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Namespace: buildPipelineRunNoComponent.Namespace,
+					Name:      buildPipelineRunNoComponent.Name,
+				}, buildPipelineRunNoComponent)
+				return err == nil
+			}, time.Second*10).Should(BeTrue())
+
 			result, err := pipelineReconciler.Reconcile(ctx, reqNoComponent)
 			Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
* The build pipeline in the "pipelinerun has no component" unit test case can take too long to get created when executed in low resource environments - added eventually block to account for that

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
