### PR TITLE
fix(STONEINTG-1433): download pac crd in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,7 @@ download-crds: ## Vendoring doesn't fetch CRDs yaml files due pruning of depende
 	go mod download github.com/konflux-ci/application-api
 	go mod download github.com/konflux-ci/release-service
 	go mod download github.com/tektoncd/pipeline
+	go mod download github.com/openshift-pipelines/pipelines-as-code
 
 .PHONY: test
 test: manifests generate fmt vet envtest download-crds ## Run tests.

--- a/status/status.go
+++ b/status/status.go
@@ -712,7 +712,7 @@ func IterateIntegrationTestScenarioWithSameStatus(ctx context.Context, client cl
 			log.Info("Try to post gitlab merge request comment for the latest test report", "snapshot.Namespace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
 			commentPrefix := GenerateTestSummaryPrefixForComponent(componentNameOrPrGroup)
 			commentText, _ := GenerateSummaryForAllScenarios(integrationTestStatusDetail.Status, componentNameOrPrGroup)
-			commentText, _ = FormatComment(commentText, "")
+			commentText, _ = FormatComment(commentText, integrationTestStatusDetail.Details)
 			if err != nil {
 				return statusCode, fmt.Errorf("failed to generate summary message: %w", err)
 			}

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -804,7 +804,7 @@ var _ = Describe("Status Adapter", func() {
 		mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).Return(0, nil).AnyTimes()
 		mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).Return(0, nil).AnyTimes()
 		commentText, _ := status.GenerateSummaryForAllScenarios(integrationTestStatusDetail.Status, "component-sample")
-		commentText, _ = status.FormatComment(commentText, "")
+		commentText, _ = status.FormatComment(commentText, integrationTestStatusDetail.Details)
 		mockReporter.EXPECT().UpdateStatusInComment(status.GenerateTestSummaryPrefixForComponent("component-sample"), commentText).Return(0, nil).AnyTimes()
 		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "gitlab"
 		hasSnapshot.Annotations[gitops.PipelineAsCodePullRequestAnnotation] = "123"


### PR DESCRIPTION
* download pac crd in makefile to fix https://github.com/konflux-ci/integration-service/actions/runs/21347801519/job/61440035340
* report details when integrqation has not be triggered

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
