### PR TITLE
fix(STONEINTG-1408): ignore cancelled build PLR when reporting status

### DIFF
--- a/status/format.go
+++ b/status/format.go
@@ -67,7 +67,6 @@ const shortSummaryTemplate = `
 <ul>
 <li><b>Pipelinerun</b>: <a href="{{ formatPipelineURL $pipelineRunName $namespace $logger }}">{{ $pipelineRunName }}</a></li>
 </ul>
-<hr>
 
 {{ if .ComponentSnapshotInfos}}
 The group snapshot is generated for pr group {{ .PRGroup }} and the component snasphots as below:

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -548,7 +548,7 @@ var _ = Describe("Status Adapter", func() {
 			SnapshotName:        "snapshot-sample",
 			ComponentName:       "component-sample",
 			Text:                text,
-			ShortText:           "<ul>\n<li><b>Pipelinerun</b>: <a href=\"https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun\">test-pipelinerun</a></li>\n</ul>\n<hr>\n\n",
+			ShortText:           "<ul>\n<li><b>Pipelinerun</b>: <a href=\"https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun\">test-pipelinerun</a></li>\n</ul>\n\n",
 			Summary:             "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 has passed",
 			Status:              integrationteststatus.IntegrationTestStatusTestPassed,
 			StartTime:           &ts,


### PR DESCRIPTION
* ignore cancelled build PLR when reporting integration test status
* don't need 'hr' for successful integration test. Observed in https://gitlab.com/hongliu126/hacbs-test-project-integration/-/merge_requests/29#note_3043132996

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
