### PR TITLE
feat(STONEINTG-1468): support annotation snapshot-param-as-name in ITS

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -861,7 +861,7 @@ func (a *Adapter) createIntegrationPipelineRun(application *applicationapiv1alph
 		return nil, err
 	}
 
-	pipelineRunBuilder = pipelineRunBuilder.WithSnapshot(snapshot).
+	pipelineRunBuilder = pipelineRunBuilder.WithSnapshot(snapshot, integrationTestScenario).
 		WithIntegrationLabels(integrationTestScenario).
 		WithIntegrationAnnotations(integrationTestScenario).
 		WithApplication(a.application).


### PR DESCRIPTION
* when annotation test.appstudio.openshift.io/snapshot-param-as-name is set to true in ITS, then the name of snapshot is set to the value of the param SNAPSHOT of integration plr

Assisted-by: Claude Code AI
Signed-off-by: Hongwei Liu hongliu@redhat.com

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
