### PR TITLE
fix(STONEINTG-1441): remove schedule from renovate config file

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,6 @@
     "gomodTidy",
     "gomodVendor"
   ],
-  "schedule": ["0 0 * * 0,6"],
   "packageRules": [
     {
       "description": "Group Red Hat UBI image updates",


### PR DESCRIPTION
* remove schedule from renovate configuration file since we have had packages groups, then we can have more chance to run renovate jogs in case some runs fails or we can dependency update prs triggered timely

Signed-off-by: Hongwei Liu <hongliu@redhat.com>
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
