### PR TITLE
fix(STONEINTG-1475): fix for gitlab setCommitStatus

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -711,10 +711,13 @@ func IterateIntegrationTestScenarioWithSameStatus(ctx context.Context, client cl
 
 			log.Info("Try to post gitlab merge request comment for the latest test report", "snapshot.Namespace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
 			commentPrefix := GenerateTestSummaryPrefixForComponent(componentNameOrPrGroup)
-			commentText, _ := GenerateSummaryForAllScenarios(integrationTestStatusDetail.Status, componentNameOrPrGroup)
-			commentText, _ = FormatComment(commentText, integrationTestStatusDetail.Details)
+			commentText, err := GenerateSummaryForAllScenarios(integrationTestStatusDetail.Status, componentNameOrPrGroup)
 			if err != nil {
 				return statusCode, fmt.Errorf("failed to generate summary message: %w", err)
+			}
+			commentText, err = FormatComment(commentText, integrationTestStatusDetail.Details)
+			if err != nil {
+				return statusCode, fmt.Errorf("failed to format summary message: %w", err)
 			}
 			statusCode, err := reporter.UpdateStatusInComment(commentPrefix, commentText)
 			if err != nil {


### PR DESCRIPTION
* add retry to setCommitStatus to have more chance to succeed
* return real error when failing to set CommitStatus to source/target
   project to help to further debug in case retry still fail or there is any more failure
    
Assisted-by: Claude Code AI
Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
