### PR TITLE
feat(STONEINTG-1426): add forgejo reporter for I.S.

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -205,6 +205,13 @@ const (
 	// PipelineAsCodeGitLabProviderType is the git provider type for a GitLab event which triggered the pipelinerun in build service.
 	PipelineAsCodeGitLabProviderType = "gitlab"
 
+	// PipelineAsCodeForgejoProviderType is the git provider type for a Forgejo event which triggered the pipelinerun in build service.
+	PipelineAsCodeForgejoProviderType = "forgejo"
+
+	// PipelineAsCodeGiteaProviderType is the git provider type for Gitea. PaC uses this when targeting Forgejo until PaC adds full Forgejo support.
+	// TODO: Remove this once PaC adds full Forgejo support expected March 2026
+	PipelineAsCodeGiteaProviderType = "gitea"
+
 	// PipelineAsCodeGitHubMergeQueueBranchPrefix is the prefix added to temporary branches which are created for merge queues
 	PipelineAsCodeGitHubMergeQueueBranchPrefix = "gh-readonly-queue/"
 

--- a/status/reporter_forgejo.go
+++ b/status/reporter_forgejo.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/operator-toolkit/metadata"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/integration-service/gitops"
+	"github.com/konflux-ci/integration-service/helpers"
+	"github.com/konflux-ci/integration-service/loader"
+	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+)
+
+type ForgejoReporter struct {
+	logger      *logr.Logger
+	k8sClient   client.Client
+	client      *forgejo.Client
+	sha         string
+	owner       string
+	repo        string
+	pullRequest int
+	snapshot    *applicationapiv1alpha1.Snapshot
+}
+
+func NewForgejoReporter(logger logr.Logger, k8sClient client.Client) *ForgejoReporter {
+	return &ForgejoReporter{
+		logger:    &logger,
+		k8sClient: k8sClient,
+	}
+}
+
+var ForgejoProvider = "ForgejoReporter"
+
+// check if interface has been correctly implemented
+var _ ReporterInterface = (*ForgejoReporter)(nil)
+
+// Detect if snapshot has been created from forgejo or gitea provider (PaC uses gitea for Forgejo until PaC adds full Forgejo support).
+func (r *ForgejoReporter) Detect(snapshot *applicationapiv1alpha1.Snapshot) bool {
+	return metadata.HasAnnotationWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeForgejoProviderType) ||
+		metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeForgejoProviderType) ||
+		metadata.HasAnnotationWithValue(snapshot, gitops.PipelineAsCodeGitProviderLabel, gitops.PipelineAsCodeGiteaProviderType) ||
+		metadata.HasLabelWithValue(snapshot, gitops.PipelineAsCodeGitProviderAnnotation, gitops.PipelineAsCodeGiteaProviderType)
+}
+
+// GetReporterName returns the reporter name
+func (r *ForgejoReporter) GetReporterName() string {
+	return ForgejoProvider
+}
+
+// Initialize initializes forgejo reporter
+func (r *ForgejoReporter) Initialize(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot) (int, error) {
+	var unRecoverableError error
+	token, err := GetPACGitProviderToken(ctx, r.k8sClient, snapshot)
+	if err != nil {
+		r.logger.Error(err, "failed to get PAC token from snapshot",
+			"snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, err
+	}
+
+	annotations := snapshot.GetAnnotations()
+	repoUrl, ok := annotations[gitops.PipelineAsCodeRepoURLAnnotation]
+	if !ok {
+		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("failed to get value of %s annotation from the snapshot %s", gitops.PipelineAsCodeRepoURLAnnotation, snapshot.Name))
+		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, unRecoverableError
+	}
+
+	burl, err := url.Parse(repoUrl)
+	if err != nil {
+		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("failed to parse repo-url %s: %s", repoUrl, err.Error()))
+		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, unRecoverableError
+	}
+
+	// Extract owner and repo from URL path
+	// URL format: https://codeberg.org/owner/repo or https://forgejo.example.com/owner/repo
+	pathParts := strings.Split(strings.TrimPrefix(burl.Path, "/"), "/")
+	if len(pathParts) < 2 {
+		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("failed to extract owner/repo from URL path %s", burl.Path))
+		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, unRecoverableError
+	}
+	r.owner = pathParts[0]
+	r.repo = pathParts[1]
+
+	// Construct API base URL (forgejo client automatically adds /api/v1 to all paths)
+	apiURL := fmt.Sprintf("%s://%s", burl.Scheme, burl.Host)
+
+	r.client, err = forgejo.NewClient(apiURL, forgejo.SetToken(token))
+	if err != nil {
+		r.logger.Error(err, "failed to create forgejo client", "apiURL", apiURL, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, err
+	}
+
+	labels := snapshot.GetLabels()
+	sha, found := labels[gitops.PipelineAsCodeSHALabel]
+	if !found {
+		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("sha label not found %q", gitops.PipelineAsCodeSHALabel))
+		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, unRecoverableError
+	}
+	r.sha = sha
+
+	pullRequestStr, found := annotations[gitops.PipelineAsCodePullRequestAnnotation]
+	if !found && !gitops.IsSnapshotCreatedByPACPushEvent(snapshot) {
+		unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("pull-request annotation not found %q", gitops.PipelineAsCodePullRequestAnnotation))
+		r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+		return 0, unRecoverableError
+	}
+
+	if found {
+		r.pullRequest, err = strconv.Atoi(pullRequestStr)
+		if err != nil && !gitops.IsSnapshotCreatedByPACPushEvent(snapshot) {
+			unRecoverableError = helpers.NewUnrecoverableMetadataError(fmt.Sprintf("failed to convert pull request number '%s' to integer: %s", pullRequestStr, err.Error()))
+			r.logger.Error(unRecoverableError, "snapshot.NameSpace", snapshot.Namespace, "snapshot.Name", snapshot.Name)
+			return 0, unRecoverableError
+		}
+	}
+
+	r.snapshot = snapshot
+	return 0, nil
+}
+
+// setCommitStatus sets commit status to be shown as pipeline run in forgejo view
+func (r *ForgejoReporter) setCommitStatus(report TestReport) (int, error) {
+	var statusCode = 0
+	l := loader.NewLoader()
+	scenario, err := l.GetScenario(context.Background(), r.k8sClient, report.ScenarioName, r.snapshot.Namespace)
+
+	if err != nil {
+		r.logger.Error(err, fmt.Sprintf("could not determine whether scenario %s was optional", report.ScenarioName))
+		return statusCode, fmt.Errorf("could not determine whether scenario %s is optional: %w", report.ScenarioName, err)
+	}
+	optional := helpers.IsIntegrationTestScenarioOptional(scenario)
+	fjState, err := GenerateForgejoCommitState(report.Status, optional)
+	if err != nil {
+		return statusCode, fmt.Errorf("failed to generate forgejo state: %w", err)
+	}
+
+	statusOpt := forgejo.CreateStatusOption{
+		State:       forgejo.StatusState(fjState),
+		TargetURL:   "",
+		Description: report.Summary,
+		Context:     report.FullName,
+	}
+
+	if report.TestPipelineRunName != "" {
+		statusOpt.TargetURL = FormatPipelineURL(report.TestPipelineRunName, r.snapshot.Namespace, *r.logger)
+	}
+
+	// Fetch existing commit statuses only if necessary
+	if fjState == "pending" {
+		statuses, resp, err := r.client.ListStatuses(r.owner, r.repo, r.sha, forgejo.ListStatusesOption{})
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		if err != nil {
+			return statusCode, fmt.Errorf("error while getting all commit statuses for sha %s: %w", r.sha, err)
+		}
+		existingStatus := r.GetExistingCommitStatus(statuses, report.FullName)
+
+		// special case, we want to skip updating commit status if the status from pending to pending
+		if existingStatus != nil && string(existingStatus.State) == fjState {
+			r.logger.Info("Skipping commit status update",
+				"scenario.name", report.ScenarioName,
+				"current_status", existingStatus.State,
+				"new_status", fjState)
+			return statusCode, nil
+		}
+	}
+
+	r.logger.Info("creating commit status for scenario test status of snapshot",
+		"scenarioName", report.ScenarioName)
+
+	_, resp, err := r.client.CreateStatus(r.owner, r.repo, r.sha, statusOpt)
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	if err != nil {
+		return statusCode, fmt.Errorf("failed to set commit status to %s: %w", fjState, err)
+	}
+
+	r.logger.Info("Created forgejo commit status", "scenario.name", report.ScenarioName, "TargetURL", statusOpt.TargetURL)
+	return statusCode, nil
+}
+
+// UpdateStatusInComment searches and updates existing comments or creates a new comment in the PR which creates snapshot
+func (r *ForgejoReporter) UpdateStatusInComment(commentPrefix, comment string) (int, error) {
+	var statusCode = 0
+
+	// get all existing integration test comments according to commentPrefix
+	// In Forgejo, PRs are issues, so we use the Issues service
+	allComments, resp, err := r.client.ListIssueComments(r.owner, r.repo, int64(r.pullRequest), forgejo.ListIssueCommentOptions{})
+	if resp != nil {
+		statusCode = resp.StatusCode
+	}
+	if err != nil {
+		r.logger.Error(err, "error while getting all comments for pull-request", "pullRequest", r.pullRequest, "report.SnapshotName", r.snapshot.Name)
+		return statusCode, fmt.Errorf("error while getting all comments for pull-request %d: %w", r.pullRequest, err)
+	}
+
+	commentIDs := r.GetExistingCommentIDs(allComments, commentPrefix)
+
+	if len(commentIDs) > 0 {
+		// update the first existing comment but delete others because sometimes there might be multiple existing comments for the same component due to previous intermittent errors
+		r.logger.Info("found multiple existing comments for the same component, updating the first one but delete others", "commentPrefix", commentPrefix, "count", len(allComments))
+		commentIdToBeUpdated := commentIDs[0]
+
+		if len(commentIDs) > 1 {
+			r.logger.Info("deleting other existing comments since we will update the first one", "commentIDsToBeDeleted", commentIDs[1:])
+			statusCode, err = r.DeleteExistingComments(commentIDs[1:])
+			if err != nil {
+				return statusCode, fmt.Errorf("error while deleting existing comments for pull-request %d: %w", r.pullRequest, err)
+			}
+		}
+
+		// update the first existing comment
+		editOpt := forgejo.EditIssueCommentOption{
+			Body: comment,
+		}
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, resp, err = r.client.EditIssueComment(r.owner, r.repo, commentIdToBeUpdated, editOpt)
+			if resp != nil {
+				statusCode = resp.StatusCode
+			}
+			return err
+		})
+		if err != nil {
+			return statusCode, fmt.Errorf("error while updating comment %d for pull-request %d: %w", commentIdToBeUpdated, r.pullRequest, err)
+		}
+		r.logger.Info("updated existing comment with matching commentPrefix", "commentID", commentIdToBeUpdated, "commentPrefix", commentPrefix)
+	} else {
+		// create a new comment
+		r.logger.Info("no existing comments found with matching commentPrefix, creating a new comment", "commentPrefix", commentPrefix)
+		createOpt := forgejo.CreateIssueCommentOption{
+			Body: comment,
+		}
+		_, resp, err = r.client.CreateIssueComment(r.owner, r.repo, int64(r.pullRequest), createOpt)
+		if resp != nil {
+			statusCode = resp.StatusCode
+		}
+		if err != nil {
+			return statusCode, fmt.Errorf("error while creating comment for pull-request %d: %w", r.pullRequest, err)
+		}
+	}
+
+	return statusCode, nil
+}
+
+// GetExistingCommitStatus returns existing Forgejo commit status that matches the status name
+func (r *ForgejoReporter) GetExistingCommitStatus(statuses []*forgejo.Status, statusName string) *forgejo.Status {
+	for _, status := range statuses {
+		if status.Context == statusName {
+			r.logger.Info("found matching existing commit status",
+				"status.Context", status.Context)
+			return status
+		}
+	}
+	r.logger.Info("found no matching existing commit status", "statusName", statusName)
+	return nil
+}
+
+// GetExistingCommentIDs returns IDs of comments that contain the commentPrefix
+func (r *ForgejoReporter) GetExistingCommentIDs(comments []*forgejo.Comment, commentPrefix string) []int64 {
+	var commentIDs []int64
+	for _, comment := range comments {
+		// get existing comment by searching commentPrefix in comment body
+		if strings.Contains(comment.Body, commentPrefix) {
+			r.logger.Info("found comment ID with a matching commentPrefix", "commentPrefix", commentPrefix, "commentID", comment.ID)
+			commentIDs = append(commentIDs, comment.ID)
+		}
+	}
+
+	if len(commentIDs) == 0 {
+		r.logger.Info("found no comment with a matching commentPrefix", "commentPrefix", commentPrefix)
+	}
+	return commentIDs
+}
+
+// DeleteExistingComments deletes existing Forgejo comments with given commentIDs
+func (r *ForgejoReporter) DeleteExistingComments(commentIDs []int64) (int, error) {
+	var lastStatusCode = 0
+	var errs []error // collect errors during deletion
+
+	for _, commentID := range commentIDs {
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			resp, err := r.client.DeleteIssueComment(r.owner, r.repo, commentID)
+			if resp != nil {
+				lastStatusCode = resp.StatusCode
+			}
+			return err
+		})
+
+		if err != nil {
+			r.logger.Error(err, "failed to delete comment", "commentID", commentID)
+			errs = append(errs, fmt.Errorf("commentID %d: %w", commentID, err))
+			continue // continue to delete next comment
+		}
+		r.logger.Info("existing comment deleted", "commentID", commentID)
+	}
+
+	if len(errs) > 0 {
+		return lastStatusCode, fmt.Errorf("errors occurred during deletion existing comments on pull request %d: %v", r.pullRequest, errs)
+	}
+
+	return lastStatusCode, nil
+}
+
+// ReportStatus reports test result to forgejo
+func (r *ForgejoReporter) ReportStatus(ctx context.Context, report TestReport) (int, error) {
+	var statusCode = 0
+	if r.client == nil {
+		return statusCode, fmt.Errorf("forgejo reporter is not initialized")
+	}
+
+	var err error
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		statusCode, err = r.setCommitStatus(report)
+		return err
+	})
+
+	if err != nil {
+		r.logger.Error(err, "failed to set forgejo commit status, please refer to the comment created on the PR")
+		return statusCode, err
+	}
+	return statusCode, nil
+}
+
+func (r *ForgejoReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest
+}
+
+// GenerateForgejoCommitState transforms internal integration test state into Forgejo state
+func GenerateForgejoCommitState(state intgteststat.IntegrationTestStatus, optional bool) (string, error) {
+	fjState := "error"
+
+	switch state {
+	case intgteststat.IntegrationTestStatusPending, intgteststat.BuildPLRInProgress:
+		fjState = "pending"
+	case intgteststat.IntegrationTestStatusInProgress:
+		fjState = "pending" // Forgejo uses "pending" for in-progress statuses
+	case intgteststat.IntegrationTestStatusEnvironmentProvisionError_Deprecated,
+		intgteststat.IntegrationTestStatusDeploymentError_Deprecated,
+		intgteststat.IntegrationTestStatusTestInvalid:
+		if optional {
+			fjState = "success" // Forgejo doesn't have "skipped"; optional/skipped tests are not a failure
+			break
+		}
+		fjState = "error"
+	case intgteststat.IntegrationTestStatusDeleted,
+		intgteststat.BuildPLRFailed, intgteststat.SnapshotCreationFailed, intgteststat.GroupSnapshotCreationFailed:
+		fjState = "error"
+	case intgteststat.IntegrationTestStatusTestPassed:
+		fjState = "success"
+	case intgteststat.IntegrationTestStatusTestFail:
+		if optional {
+			fjState = "warning" // optional ITS failed: non-blocking but visible
+			break
+		}
+		fjState = "error"
+	default:
+		return fjState, fmt.Errorf("unknown status %s", state)
+	}
+
+	return fjState, nil
+}

--- a/status/reporter_forgejo_test.go
+++ b/status/reporter_forgejo_test.go
@@ -1,0 +1,493 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	forgejo "codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v2"
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	"github.com/tonglil/buflogr"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/konflux-ci/integration-service/gitops"
+	"github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/status"
+)
+
+var _ = Describe("ForgejoReporter", func() {
+
+	const (
+		repoUrl     = "https://codeberg.org/example/example"
+		digest      = "12a4a35ccd08194595179815e4646c3a6c08bb77"
+		pullRequest = "45"
+		owner       = "example"
+		repo        = "example"
+	)
+
+	var (
+		hasSnapshot   *applicationapiv1alpha1.Snapshot
+		mockK8sClient *MockK8sClient
+		buf           bytes.Buffer
+		log           logr.Logger
+	)
+
+	BeforeEach(func() {
+		log = buflogr.NewWithBuffer(&buf)
+
+		hasSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "snapshot-sample",
+				Namespace: "default",
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/type":               "component",
+					"appstudio.openshift.io/component":               "component-sample",
+					"build.appstudio.redhat.com/pipeline":            "enterprise-contract",
+					"pac.test.appstudio.openshift.io/url-org":        owner,
+					"pac.test.appstudio.openshift.io/url-repository": repo,
+					"pac.test.appstudio.openshift.io/sha":            digest,
+					"pac.test.appstudio.openshift.io/event-type":     "Pull Request",
+				},
+				Annotations: map[string]string{
+					"build.appstudio.redhat.com/commit_sha":         digest,
+					"appstudio.redhat.com/updateComponentOnSuccess": "false",
+					"pac.test.appstudio.openshift.io/git-provider":  "forgejo",
+					"pac.test.appstudio.openshift.io/repo-url":      repoUrl,
+					"pac.test.appstudio.openshift.io/pull-request":  pullRequest,
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application: "application-sample",
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "component-sample",
+						ContainerImage: "sample_image",
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									Revision: "sample_revision",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+	})
+
+	It("Reporter can return name uninitialized", func() {
+		reporter := status.NewForgejoReporter(log, mockK8sClient)
+		Expect(reporter.GetReporterName()).To(Equal("ForgejoReporter"))
+	})
+
+	It("can detect if forgejo reporter should be used", func() {
+		reporter := status.NewForgejoReporter(log, mockK8sClient)
+		hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "forgejo"
+		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+
+		hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "not-forgejo"
+		Expect(reporter.Detect(hasSnapshot)).To(BeFalse())
+
+		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "forgejo"
+		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+
+		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "not-forgejo"
+		Expect(reporter.Detect(hasSnapshot)).To(BeFalse())
+	})
+
+	It("can detect when PaC is configured as gitea (workaround for Forgejo)", func() {
+		reporter := status.NewForgejoReporter(log, mockK8sClient)
+		hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "gitea"
+		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+
+		hasSnapshot.Annotations["pac.test.appstudio.openshift.io/git-provider"] = "other"
+		hasSnapshot.Labels["pac.test.appstudio.openshift.io/git-provider"] = "gitea"
+		Expect(reporter.Detect(hasSnapshot)).To(BeTrue())
+	})
+
+	Context("when provided Forgejo webhook integration credentials", func() {
+
+		var (
+			secretData    map[string][]byte
+			repoCR        pacv1alpha1.Repository
+			reporter      *status.ForgejoReporter
+			defaultAPIURL = "/api/v1"
+			mux           *http.ServeMux
+			server        *httptest.Server
+		)
+
+		BeforeEach(func() {
+			mux = http.NewServeMux()
+			apiHandler := http.NewServeMux()
+			apiHandler.Handle(defaultAPIURL+"/", http.StripPrefix(defaultAPIURL, mux))
+
+			// Mock the /version endpoint that the forgejo client calls during initialization
+			mux.HandleFunc("/version", func(rw http.ResponseWriter, r *http.Request) {
+				rw.Header().Set("Content-Type", "application/json")
+				fmt.Fprintf(rw, `{"version": "1.20.0"}`)
+			})
+
+			// server is a test HTTP server used to provide mock API responses
+			server = httptest.NewServer(apiHandler)
+
+			// mock URL with httptest server URL, but include the owner/repo path for parsing
+			mockRepoURL := fmt.Sprintf("%s/%s/%s", server.URL, owner, repo)
+			hasSnapshot.Annotations[gitops.PipelineAsCodeRepoURLAnnotation] = mockRepoURL
+
+			repoCR = pacv1alpha1.Repository{
+				Spec: pacv1alpha1.RepositorySpec{
+					URL: mockRepoURL,
+					GitProvider: &pacv1alpha1.GitProvider{
+						Secret: &pacv1alpha1.Secret{
+							Name: "example-secret-name",
+							Key:  "example-token",
+						},
+					},
+				},
+			}
+
+			mockK8sClient = &MockK8sClient{
+				getInterceptor: func(key client.ObjectKey, obj client.Object) {
+					if secret, ok := obj.(*v1.Secret); ok {
+						secret.Data = secretData
+					}
+				},
+				listInterceptor: func(list client.ObjectList) {
+					if repoList, ok := list.(*pacv1alpha1.RepositoryList); ok {
+						repoList.Items = []pacv1alpha1.Repository{repoCR}
+					}
+				},
+			}
+
+			secretData = map[string][]byte{
+				"example-token": []byte("example-personal-access-token"),
+			}
+
+			reporter = status.NewForgejoReporter(log, mockK8sClient)
+
+			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
+
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		DescribeTable("test handling of missing labels/annotations", func(missingKey string, isLabel bool) {
+			testSnapshot := hasSnapshot.DeepCopy()
+			if isLabel {
+				delete(testSnapshot.Labels, missingKey)
+			} else {
+				delete(testSnapshot.Annotations, missingKey)
+			}
+			testReporter := status.NewForgejoReporter(log, mockK8sClient)
+			statusCode, err := testReporter.Initialize(context.TODO(), testSnapshot)
+			Expect(err).ToNot(Succeed())
+			Expect(statusCode).To(Equal(0))
+		},
+			Entry("Missing repo_url", gitops.PipelineAsCodeRepoURLAnnotation, false),
+			Entry("Missing SHA", gitops.PipelineAsCodeSHALabel, true),
+		)
+
+		It("sends valid success commit status payload to the API", func() {
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 passed"
+			muxForgejoCommitStatusPost(mux, owner, repo, digest, summary, "success")
+
+			statusCode, err := reporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:     "fullname/scenario1",
+					ScenarioName: "scenario1",
+					Status:       integrationteststatus.IntegrationTestStatusTestPassed,
+					Summary:      summary,
+					Text:         "detailed text here",
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(200))
+		})
+
+		It("creates a commit status for push snapshot with correct textual data without comments", func() {
+			pushSnapshot := hasSnapshot.DeepCopy()
+			delete(pushSnapshot.Annotations, gitops.PipelineAsCodePullRequestAnnotation)
+			pushSnapshot.Annotations[gitops.PipelineAsCodeEventTypeLabel] = "Push"
+
+			pushEventReporter := status.NewForgejoReporter(log, mockK8sClient)
+			statusCode, err := pushEventReporter.Initialize(context.TODO(), pushSnapshot)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(0))
+
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 passed"
+			muxForgejoCommitStatusPost(mux, owner, repo, digest, summary, "")
+
+			statusCode, err = pushEventReporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:     "fullname/scenario1",
+					ScenarioName: "scenario1",
+					Status:       integrationteststatus.IntegrationTestStatusTestPassed,
+					Summary:      summary,
+					Text:         "detailed text here",
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(200))
+		})
+
+		It("creates a commit status for snapshot with TargetURL in CommitStatus", func() {
+			PipelineRunName := "TestPipeline"
+			expectedURL := status.FormatPipelineURL(PipelineRunName, hasSnapshot.Namespace, logr.Discard())
+
+			muxForgejoCommitStatusPost(mux, owner, repo, digest, expectedURL, "")
+			muxForgejoCommitStatusesGet(mux, owner, repo, digest, nil)
+
+			statusCode, err := reporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:            "fullname/scenario1",
+					ScenarioName:        "scenario1",
+					TestPipelineRunName: PipelineRunName,
+					Status:              integrationteststatus.IntegrationTestStatusInProgress,
+					Summary:             "summary",
+					Text:                "detailed text here",
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(200))
+		})
+
+		It("sends failure commit status payload and comment text body to the API", func() {
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 failed"
+			muxForgejoCommitStatusPost(mux, owner, repo, digest, summary, "error")
+
+			commentPrefix := status.GenerateTestSummaryPrefixForComponent("component-sample")
+			commentText, err := status.GenerateSummaryForAllScenarios(integrationteststatus.SnapshotCreationFailed, "component-sample")
+			Expect(err).To(Succeed())
+			Expect(commentText).ToNot(BeEmpty())
+			muxForgejoIssueComments(mux, owner, repo, pullRequest, commentText)
+
+			statusCode, err := reporter.ReportStatus(
+				context.TODO(),
+				status.TestReport{
+					FullName:     "fullname/scenario1",
+					ScenarioName: "scenario1",
+					Status:       integrationteststatus.IntegrationTestStatusTestFail,
+					Summary:      summary,
+					Text:         "detailed text here",
+				})
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(200))
+
+			statusCode, err = reporter.UpdateStatusInComment(commentPrefix, commentText)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(201))
+		})
+
+		It("does not create a commit status for snapshot with existing matching status in pending state", func() {
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 is pending"
+			report := status.TestReport{
+				FullName:     "fullname/scenario1",
+				ScenarioName: "scenario1",
+				Status:       integrationteststatus.IntegrationTestStatusPending,
+				Summary:      summary,
+				Text:         "detailed text here",
+			}
+			muxForgejoCommitStatusesGet(mux, owner, repo, digest, &report)
+
+			statusCode, err := reporter.ReportStatus(context.TODO(), report)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(200))
+		})
+
+		It("can get an existing commitStatus that matches the report", func() {
+			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 passed"
+			report := status.TestReport{
+				FullName:     "fullname/scenario1",
+				ScenarioName: "scenario1",
+				Status:       integrationteststatus.IntegrationTestStatusTestPassed,
+				Summary:      summary,
+				Text:         "detailed text here",
+			}
+			commitStatus := forgejo.Status{}
+			commitStatus.ID = 123
+			commitStatus.Context = report.FullName
+			commitStatus.State = forgejo.StatusState("pending")
+			commitStatus.Description = report.Summary
+			commitStatuses := []*forgejo.Status{&commitStatus}
+
+			existingCommitStatus := reporter.GetExistingCommitStatus(commitStatuses, report.FullName)
+			Expect(existingCommitStatus.Context).To(Equal(commitStatus.Context))
+			Expect(existingCommitStatus.ID).To(Equal(commitStatus.ID))
+			Expect(existingCommitStatus.State).To(Equal(commitStatus.State))
+		})
+
+		It("can delete issue comments that match the report then create a new comment", func() {
+			reporter := status.NewForgejoReporter(log, mockK8sClient)
+			_, err := reporter.Initialize(context.TODO(), hasSnapshot)
+			Expect(err).To(Succeed())
+			commentPrefix := status.GenerateTestSummaryPrefixForComponent("component-sample")
+			commentText := "Integration test report for component component-sample: All tests passed"
+			muxForgejoIssueComments(mux, owner, repo, pullRequest, commentText)
+			statusCode, err := reporter.UpdateStatusInComment(commentPrefix, commentText)
+			Expect(err).To(Succeed())
+			Expect(statusCode).To(Equal(201))
+		})
+	})
+
+	Describe("Test helper functions", func() {
+		DescribeTable(
+			"reports correct forgejo statuses from test statuses",
+			func(teststatus integrationteststatus.IntegrationTestStatus, fjState string) {
+				state, err := status.GenerateForgejoCommitState(teststatus, false)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(state).To(Equal(fjState))
+			},
+			Entry("Provision error", integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated, "error"),
+			Entry("Deployment error", integrationteststatus.IntegrationTestStatusDeploymentError_Deprecated, "error"),
+			Entry("Deleted", integrationteststatus.IntegrationTestStatusDeleted, "error"),
+			Entry("Success", integrationteststatus.IntegrationTestStatusTestPassed, "success"),
+			Entry("Test failure", integrationteststatus.IntegrationTestStatusTestFail, "error"),
+			Entry("In progress", integrationteststatus.IntegrationTestStatusInProgress, "pending"),
+			Entry("Pending", integrationteststatus.IntegrationTestStatusPending, "pending"),
+			Entry("Invalid", integrationteststatus.IntegrationTestStatusTestInvalid, "error"),
+			Entry("BuildPLRInProgress", integrationteststatus.BuildPLRInProgress, "pending"),
+			Entry("BuildPLRFailed", integrationteststatus.BuildPLRFailed, "error"),
+			Entry("SnapshotCreationFailed", integrationteststatus.SnapshotCreationFailed, "error"),
+			Entry("GroupSnapshotCreationFailed", integrationteststatus.GroupSnapshotCreationFailed, "error"),
+		)
+
+		It("check if all integration tests statuses are supported", func() {
+			for _, teststatus := range integrationteststatus.IntegrationTestStatusValues() {
+				_, err := status.GenerateForgejoCommitState(teststatus, false)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		})
+		It("check if optional integration test returns warning status for failed test", func() {
+			state, err := status.GenerateForgejoCommitState(integrationteststatus.IntegrationTestStatusTestFail, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal("warning"))
+		})
+		It("check if optional integration test returns success status for invalid test", func() {
+			state, err := status.GenerateForgejoCommitState(integrationteststatus.IntegrationTestStatusTestInvalid, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(state).To(Equal("success"))
+		})
+	})
+})
+
+// muxForgejoCommitStatusPost mocks commit status POST request.
+// If catchStr is non-empty, the POST body must contain it.
+// If expectedState is non-empty (e.g. "success" or "error"), the body must contain that state value.
+func muxForgejoCommitStatusPost(mux *http.ServeMux, owner string, repo string, sha string, catchStr string, expectedState string) {
+	path := fmt.Sprintf("/repos/%s/%s/statuses/%s", owner, repo, sha)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+			return
+		}
+		bit, _ := io.ReadAll(r.Body)
+		s := string(bit)
+		if catchStr != "" {
+			Expect(s).To(ContainSubstring(catchStr))
+		}
+		if expectedState != "" {
+			Expect(s).To(ContainSubstring(expectedState))
+		}
+		rw.WriteHeader(http.StatusOK)
+		rw.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(rw, `{"id": 123, "state": "success", "context": "test"}`)
+	})
+}
+
+// muxForgejoCommitStatusesGet mocks commit statuses GET request
+func muxForgejoCommitStatusesGet(mux *http.ServeMux, owner string, repo string, sha string, report *status.TestReport) {
+	path := fmt.Sprintf("/repos/%s/%s/commits/%s/statuses", owner, repo, sha)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+		output := "[]"
+		if report != nil {
+			commitStatus := forgejo.Status{
+				ID:          123,
+				Context:     report.FullName,
+				State:       forgejo.StatusState("pending"),
+				Description: report.Summary,
+			}
+			jsonStatuses, _ := json.Marshal([]forgejo.Status{commitStatus})
+			output = string(jsonStatuses)
+		}
+		rw.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(rw, output)
+	})
+}
+
+// muxForgejoIssueComments mocks issue comment GET and POST requests
+func muxForgejoIssueComments(mux *http.ServeMux, owner string, repo string, issueNum string, catchStr string) {
+	path := fmt.Sprintf("/repos/%s/%s/issues/%s/comments", owner, repo, issueNum)
+	mux.HandleFunc(path, func(rw http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "POST":
+			bit, _ := io.ReadAll(r.Body)
+			s := string(bit)
+			if catchStr != "" {
+				Expect(s).To(ContainSubstring(catchStr))
+			}
+			rw.WriteHeader(http.StatusCreated)
+			rw.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(rw, `{"id": 1000, "body": "new comment"}`)
+		case "GET":
+			rw.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(rw, `[
+				{"id": 1, "body": "Integration test report for component component-sample"},
+				{"id": 2, "body": "Integration test report for component other-component"}
+			]`)
+		default:
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+
+	deleteEditPathPattern := fmt.Sprintf("/repos/%s/%s/issues/comments/", owner, repo)
+	mux.HandleFunc(deleteEditPathPattern, func(rw http.ResponseWriter, r *http.Request) {
+		switch r.Method {
+		case "DELETE":
+			rw.WriteHeader(http.StatusNoContent)
+			return
+		case "PATCH":
+			bit, _ := io.ReadAll(r.Body)
+			s := string(bit)
+			if catchStr != "" {
+				Expect(s).To(ContainSubstring(catchStr))
+			}
+			rw.WriteHeader(http.StatusOK)
+			rw.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(rw, `{"id": 1000, "body": "updated comment"}`)
+			return
+		default:
+			rw.WriteHeader(http.StatusMethodNotAllowed)
+		}
+	})
+}


### PR DESCRIPTION
- Create reporter_forgejo.go with ReporterInterface.
- Map internal states to Forgejo commit statuses.
- Use Forgejo Issue API for PR comments.
- Add unit tests with coverage in reporter_forgejo_test.go.
- Verify URL parsing and client initialization.
-  Gitea-labeled snapshots until PaaC adds native Forgejo support

Assisted-by: Cursor AI

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
