### PR TITLE
chore: disable scenario controller

### DIFF
--- a/internal/controller/controllers.go
+++ b/internal/controller/controllers.go
@@ -21,7 +21,6 @@ import (
 	"github.com/konflux-ci/integration-service/internal/controller/buildpipeline"
 	"github.com/konflux-ci/integration-service/internal/controller/component"
 	"github.com/konflux-ci/integration-service/internal/controller/integrationpipeline"
-	"github.com/konflux-ci/integration-service/internal/controller/scenario"
 	"github.com/konflux-ci/integration-service/internal/controller/snapshot"
 	"github.com/konflux-ci/integration-service/internal/controller/statusreport"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,7 +32,7 @@ var setupFunctions = []func(manager.Manager, *logr.Logger) error{
 	integrationpipeline.SetupController,
 	buildpipeline.SetupController,
 	snapshot.SetupController,
-	scenario.SetupController,
+	//scenario.SetupController,
 	statusreport.SetupController,
 	component.SetupController,
 }

--- a/internal/controller/scenario/scenario_adapter.go
+++ b/internal/controller/scenario/scenario_adapter.go
@@ -47,20 +47,6 @@ func NewAdapter(context context.Context, scenario *v1beta2.IntegrationTestScenar
 	}
 }
 
-// TODO: Remove after a couple weeks. This is just to add new field to existing scenarios
-// Adds ResourceKind field to existing IntegrationTestScenarios
-func (a *Adapter) EnsureScenarioContainsResourceKind() (controller.OperationResult, error) {
-	a.logger.Info("Adding ResourceKind to ITS if it does not exist", "scenario", a.scenario)
-	if a.scenario.Spec.ResolverRef.ResourceKind == "" {
-		// set ResourceKind to 'pipeline'
-		patch := client.MergeFrom(a.scenario.DeepCopy())
-		a.scenario.Spec.ResolverRef.ResourceKind = "pipeline"
-		err := a.client.Patch(a.context, a.scenario, patch)
-		if err != nil {
-			a.logger.Error(err, "Failed to add ResourceKind to Scenario")
-			return controller.RequeueWithError(err)
-		}
-	}
-
+func (a *Adapter) EnsurePlaceholder() (controller.OperationResult, error) {
 	return controller.ContinueProcessing()
 }

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -78,7 +78,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(ctx, scenario, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
-		adapter.EnsureScenarioContainsResourceKind,
+		adapter.EnsurePlaceholder,
 	})
 }
 
@@ -100,7 +100,7 @@ func (r *Reconciler) getApplicationFromScenario(context context.Context, scenari
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
-	EnsureScenarioContainsResourceKind() (controller.OperationResult, error)
+	EnsurePlaceholder() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.


### PR DESCRIPTION
The only function in the scenario controller was EnsureScenarioContainsResourceKind, a function whose purpose was to add the `resourceKind` field  to all IntegrationTestScenarios. Now that the field exists for all scenarios on the cluster the function can be removed.  With that, we can also disable the scenario controller since it does not do any work. This PR disables the controller rather than deletes it entirely in case the controller is needed in the future.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
