### PR TITLE
fix(STONEINTG-1481): keep comp snapshot in 1 day for group snapshot

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -124,6 +124,9 @@ const (
 	// GroupSnapshotInfoAnnotation contains the component snapshot info included in group snapshot
 	GroupSnapshotInfoAnnotation = "test.appstudio.openshift.io/group-test-info"
 
+	// PRStatusAnnotation contains the status of the PR
+	PRStatusAnnotation = "test.appstudio.openshift.io/pr-status"
+
 	// BuildPipelineRunNameLabel contains the build PipelineRun name
 	BuildPipelineRunNameLabel = AppstudioLabelPrefix + "/build-pipelinerun"
 
@@ -192,6 +195,12 @@ const (
 
 	// PipelineAsCodeMergeRequestType is the type of merge request event which triggered the pipelinerun in build service
 	PipelineAsCodeMergeRequestType = "merge request"
+
+	// PipelineAsCodeGLMergeRequestType is the type of gitlab merge request event marked in label which triggered the pipelinerun in build service
+	PipelineAsCodeMergeUnderscoreRequestType = "Merge_Request"
+
+	// PipelineAsCodeRetestType is the type of retest event which triggered the pipelinerun in build service by commenting /retest
+	PipelineAsCodeRetestType = "retest-all-comment"
 
 	// IntegrationWorkflowPushValue is the value for push workflow snapshots
 	IntegrationWorkflowPushValue = "push"
@@ -287,6 +296,9 @@ const (
 	FailedToCreateGroupSnapshotMsg = "Failed to create group snapshot for pr group"
 
 	GroupSnapshotCreationFailureReported = "group snapshot creation failure is reported to git provider"
+
+	// PRStatusMerged indicates that the PR has been merged
+	PRStatusMerged = "merged"
 
 	Success = "Success"
 	// AddedToGlobalCandidateListAnnotation is the annotation for marking if Snapshot/build PLR's component was added to

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -625,7 +625,7 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 
 	It("ensures the different Snapshots can be successfully compared if they have different event-type", func() {
 		expectedSnapshot := hasSnapshot.DeepCopy()
-		expectedSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodeMergeRequestType
+		expectedSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = gitops.PipelineAsCodeMergeUnderscoreRequestType
 		comparisonResult := gitops.CompareSnapshots(hasSnapshot, expectedSnapshot)
 		Expect(comparisonResult).To(BeFalse())
 	})

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -137,6 +137,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	return controller.ReconcileHandler([]controller.Operation{
 		adapter.EnsurePipelineIsFinalized,
+		adapter.EnsurePRSnapshotAnnotatedForMergedPR,
 		adapter.EnsurePRGroupAnnotated,
 		adapter.EnsureIntegrationTestReportedToGitProvider,
 		adapter.EnsureGlobalCandidateImageUpdated,
@@ -147,6 +148,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
+	EnsurePRSnapshotAnnotatedForMergedPR() (controller.OperationResult, error)
 	EnsurePipelineIsFinalized() (controller.OperationResult, error)
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureIntegrationTestReportedToGitProvider() (controller.OperationResult, error)

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1048,6 +1048,7 @@ func (a *Adapter) haveAllPipelineRunProcessedForPrGroup(prGroup, prGroupHash str
 		// check if build PLR finishes
 		if !h.HasPipelineRunFinished(&pipelineRun) {
 			a.logger.Info(fmt.Sprintf("The build pipelineRun %s/%s with pr group %s is still running, won't create group snapshot", pipelineRun.Namespace, pipelineRun.Name, prGroup))
+			// snapshot Gabage Collector will also check this annotation to decide whether to delete the snapshot or not when it is waiting for group snapshot creation
 			err := gitops.AnnotateSnapshot(a.context, a.snapshot, gitops.PRGroupCreationAnnotation, fmt.Sprintf("The build pipelineRun %s/%s with pr group %s is still running, won't create group snapshot", pipelineRun.Namespace, pipelineRun.Name, prGroup), a.client)
 			if err != nil {
 				return false, err

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -67,6 +67,7 @@ const (
 	GetComponentsFromSnapshotForPRGroupKey
 	GetGroupSnapshotsKey
 	ResolutionRequestContextKey
+	GetPRComponentSnapshotsForComponentContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -318,4 +319,12 @@ func (l *mockLoader) GetResolutionRequest(ctx context.Context, c client.Client, 
 	}
 	resolutionRequest, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ResolutionRequestContextKey, resolutionv1beta1.ResolutionRequest{})
 	return resolutionRequest, err
+}
+
+func (l *mockLoader) GetPRComponentSnapshotsForComponent(ctx context.Context, c client.Client, namespace, applicationName, componentName, prNumber string) (*[]applicationapiv1alpha1.Snapshot, error) {
+	if ctx.Value(GetPRComponentSnapshotsForComponentContextKey) == nil {
+		return l.loader.GetPRComponentSnapshotsForComponent(ctx, c, namespace, applicationName, componentName, prNumber)
+	}
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPRComponentSnapshotsForComponentContextKey, []applicationapiv1alpha1.Snapshot{})
+	return &snapshots, err
 }

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -417,4 +417,19 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("When calling GetPRComponentSnapshotsForComponent", func() {
+		It("returns resource and error from the context", func() {
+			snapshots := []applicationapiv1alpha1.Snapshot{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: GetPRComponentSnapshotsForComponentContextKey,
+					Resource:   snapshots,
+				},
+			})
+			resource, err := loader.GetPRComponentSnapshotsForComponent(mockContext, nil, "", "", "", "")
+			Expect(resource).To(Equal(&snapshots))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 })

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -977,5 +977,15 @@ var _ = Describe("Loader", Ordered, func() {
 			Expect(request).NotTo(BeNil())
 			Expect(request.Name).To(Equal(reqName))
 		})
+
+		It("can get pull request component snapshot for specific compoent and PR number", func() {
+			prNumber := "1"
+			snapshots, err := loader.GetPRComponentSnapshotsForComponent(ctx, k8sClient, hasSnapshot.Namespace, hasApp.Name, hasComp.Name, prNumber)
+			Expect(err).To(Succeed())
+			Expect(*snapshots).To(HaveLen(1))
+			Expect((*snapshots)[0].Name).To(Equal(hasSnapshot.Name))
+			Expect((*snapshots)[0].Namespace).To(Equal(hasSnapshot.Namespace))
+			Expect((*snapshots)[0].Spec).To(Equal(hasSnapshot.Spec))
+		})
 	})
 })

--- a/status/status.go
+++ b/status/status.go
@@ -652,19 +652,20 @@ func (s Status) FindSnapshotWithOpenedPR(ctx context.Context, snapshots *[]appli
 	log := log.FromContext(ctx)
 	sortedSnapshots := gitops.SortSnapshots(*snapshots)
 	// find the latest component snapshot created for open PR/MR
-	for _, snapshot := range sortedSnapshots {
-		snapshot := snapshot
-		// find the built image for pull/merge request build PLR from the latest opened pull request component snapshot
-		isPRMROpened, statusCode, err := s.IsPRMRInSnapshotOpened(ctx, &snapshot)
-		if err != nil {
-			log.Error(err, "Failed to fetch PR/MR status for component snapshot", "snapshot.Name", snapshot.Name)
-			return nil, statusCode, err
-		}
-		if isPRMROpened {
-			log.Info("PR/MR in snapshot is opened, will find snapshotComponent and add to groupSnapshot")
-			return &snapshot, statusCode, nil
-		}
+	// find the built image for pull/merge request build PLR from the latest opened pull request component snapshot
+	latestSnapshot := sortedSnapshots[0]
+
+	log.Info("Try to find if the latest snapshot has opened PR/MR", "snapshot.Name", sortedSnapshots[0].Name)
+	isPRMROpened, statusCode, err := s.IsPRMRInSnapshotOpened(ctx, &latestSnapshot)
+	if err != nil {
+		log.Error(err, "Failed to fetch PR/MR status for component snapshot", "snapshot.Name", latestSnapshot.Name)
+		return nil, statusCode, err
 	}
+	if isPRMROpened {
+		log.Info("PR/MR in snapshot is opened, will find snapshotComponent and add to groupSnapshot")
+		return &latestSnapshot, statusCode, nil
+	}
+
 	return nil, 0, nil
 }
 


### PR DESCRIPTION
* add EnsurePRSnapshotAnnotatedForMergedPR to mark component snapshot when PR/MR is merged
* still keep component snapshot when it is created in 1 day and has no annotation test.appstudio.openshift.io/pr-status:merged and waiting for other inprogress buid PLR to create even if the `pr-snapshots-to-keep` has been reached. 

Assisted-by: Claude Code AI
Signed-off-by: Hongwei Liu <hongliu@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
