### PR TITLE
fix(STONEINTG-1472): disable autorelease ss on component del

### DIFF
--- a/internal/controller/component/component_adapter.go
+++ b/internal/controller/component/component_adapter.go
@@ -139,6 +139,8 @@ func (a *Adapter) createUpdatedSnapshot(snapshotComponents *[]applicationapiv1al
 		snapshot.Labels = map[string]string{}
 	}
 
+	snapshot.Labels[gitops.AutoReleaseLabel] = "false"
+
 	err := ctrl.SetControllerReference(a.application, snapshot, a.client.Scheme())
 	if err != nil {
 		a.logger.Error(err, "Failed to set controller reference")

--- a/internal/controller/component/component_adapter_test.go
+++ b/internal/controller/component/component_adapter_test.go
@@ -11,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/loader"
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
 
@@ -140,6 +141,10 @@ var _ = Describe("Component Adapter", Ordered, func() {
 
 		Eventually(func() bool {
 			Expect(k8sClient.List(ctx, snapshots, &client.ListOptions{Namespace: hasApp.Namespace})).To(Succeed())
+
+			// check if the snapshot is labeled with auto-release=false
+			Expect(snapshots.Items[0].Labels[gitops.AutoReleaseLabel]).To(Equal("false"))
+
 			return !result.CancelRequest && len(snapshots.Items) == 1 && err == nil
 		}, time.Second*20).Should(BeTrue())
 	})


### PR DESCRIPTION
- set the auto-release label to false for Snapshots that were created upon component deletion
- improved unit test with coverage for this

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
