### PR TITLE
chore(STONEINTG-1427): forgejo connect reporter, constants and tests

### DIFF
--- a/status/status.go
+++ b/status/status.go
@@ -227,6 +227,11 @@ func (s *Status) GetReporter(snapshot *applicationapiv1alpha1.Snapshot) Reporter
 		return gitlabReporter
 	}
 
+	forgejoReporter := NewForgejoReporter(s.logger, s.client)
+	if forgejoReporter.Detect(snapshot) {
+		return forgejoReporter
+	}
+
 	return nil
 }
 
@@ -464,7 +469,16 @@ func (s Status) IsPRMRInSnapshotOpened(ctx context.Context, snapshot *applicatio
 		return s.IsMRInSnapshotOpened(ctx, gitlabReporter, snapshot)
 	}
 
-	return false, 0, fmt.Errorf("invalid git provider, valid git provider must be one of github and gitlab")
+	forgejoReporter := NewForgejoReporter(s.logger, s.client)
+	if forgejoReporter.Detect(snapshot) {
+		statusCode, err := forgejoReporter.Initialize(ctx, snapshot)
+		if err != nil {
+			return false, statusCode, err
+		}
+		return forgejoReporter.IsPullRequestOpen(ctx)
+	}
+
+	return false, 0, fmt.Errorf("invalid git provider, valid git provider must be one of github, gitlab, forgejo and gitea")
 }
 
 // IsMRInSnapshotOpened check if the gitlab merge request triggering snapshot is opened

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -512,6 +512,38 @@ var _ = Describe("Status Adapter", func() {
 		Expect(reporter.GetReporterName()).To(Equal("GithubReporter"))
 	})
 
+	It("returns ForgejoReporter when snapshot has gitea provider label", func() {
+		giteaSnapshot := &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					gitops.PipelineAsCodeGitProviderLabel: gitops.PipelineAsCodeGiteaProviderType,
+				},
+			},
+		}
+		st := status.NewStatus(logr.Discard(), nil)
+		reporter := st.GetReporter(giteaSnapshot)
+		Expect(reporter).ToNot(BeNil())
+		Expect(reporter.GetReporterName()).To(Equal(status.ForgejoProvider))
+		_, ok := reporter.(*status.ForgejoReporter)
+		Expect(ok).To(BeTrue())
+	})
+
+	It("returns ForgejoReporter when snapshot has forgejo provider label", func() {
+		forgejoSnapshot := &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					gitops.PipelineAsCodeGitProviderLabel: gitops.PipelineAsCodeForgejoProviderType,
+				},
+			},
+		}
+		st := status.NewStatus(logr.Discard(), nil)
+		reporter := st.GetReporter(forgejoSnapshot)
+		Expect(reporter).ToNot(BeNil())
+		Expect(reporter.GetReporterName()).To(Equal(status.ForgejoProvider))
+		_, ok := reporter.(*status.ForgejoReporter)
+		Expect(ok).To(BeTrue())
+	})
+
 	It("can migrate snapshot to reportStatus in old way - migration test)", func() {
 		hasSnapshot.Annotations["test.appstudio.openshift.io/status"] = "[{\"scenario\":\"scenario1\",\"status\":\"InProgress\",\"startTime\":\"2023-07-26T16:57:49+02:00\",\"lastUpdateTime\":\"2023-08-26T17:57:50+02:00\",\"details\":\"Test in progress\"}]"
 		hasSnapshot.Annotations["test.appstudio.openshift.io/pr-last-update"] = "2023-08-26T17:57:50+02:00"


### PR DESCRIPTION
Assisted-by: Cursor AI

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
