### PR TITLE
feat(STONEINTG-1488): reduce git api call in snapshot/build plr controller

### DIFF
--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -1343,4 +1343,31 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 			Expect(isCommentDisabled).To(BeFalse())
 		})
 	})
+
+	Context("Can check if two snapshot have the same git source and mr/pr", func() {
+		BeforeEach(func() {
+			hasSnapshot.Labels[gitops.PipelineAsCodePullRequestAnnotation] = "1"
+			hasSnapshot.Annotations[gitops.PipelineAsCodeRepoUrlAnnotation] = "https://example.com/repo"
+			hasComSnapshot1.Labels[gitops.PipelineAsCodePullRequestAnnotation] = "1"
+			hasComSnapshot1.Annotations[gitops.PipelineAsCodeRepoUrlAnnotation] = "https://example.com/repo"
+		})
+
+		It("when the same snapshot are compared", func() {
+			Expect(gitops.HasSameGitSourceAndPRWithProcessedSnapshot(hasSnapshot, hasSnapshot)).To(BeTrue())
+		})
+
+		It("When two snapshots have the same git url and pull request number", func() {
+			Expect(gitops.HasSameGitSourceAndPRWithProcessedSnapshot(hasSnapshot, hasComSnapshot1)).To(BeTrue())
+		})
+
+		It("when the snapshot have different git source repo url", func() {
+			hasComSnapshot1.Annotations[gitops.PipelineAsCodeRepoUrlAnnotation] = "https://github.com/different/repo"
+			Expect(gitops.HasSameGitSourceAndPRWithProcessedSnapshot(hasSnapshot, hasComSnapshot1)).To(BeFalse())
+		})
+
+		It("when the snapshot have different pull request number", func() {
+			hasComSnapshot1.Labels[gitops.PipelineAsCodePullRequestAnnotation] = "3"
+			Expect(gitops.HasSameGitSourceAndPRWithProcessedSnapshot(hasSnapshot, hasComSnapshot1)).To(BeFalse())
+		})
+	})
 })

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -355,7 +355,7 @@ func (a *Adapter) EnsureIntegrationTestReportedToGitProvider() (controller.Opera
 	}
 
 	a.logger.Info("try to check if group snapshot is expected for build PLR")
-	isGroupSnapshotExpected, err := a.isGroupSnapshotExpectedForBuildPLR(a.pipelineRun)
+	isGroupSnapshotExpected, err := a.isGroupSnapshotExpectedForBuildPLR(a.pipelineRun, tempComponentSnapshot)
 	if err != nil {
 		a.logger.Error(err, "failed to check if group snapshot is expected")
 		return controller.RequeueWithError(err)
@@ -1027,7 +1027,7 @@ func (a *Adapter) getComponentsFromLatestFlightBuildPLR(prGroup, prGroupHash str
 }
 
 // isGroupSnapshotExpectedForBuildPLR return group context ITS if group snapshot is expected for the same pr group with the given build PLR
-func (a *Adapter) isGroupSnapshotExpectedForBuildPLR(pipelineRun *tektonv1.PipelineRun) (bool, error) {
+func (a *Adapter) isGroupSnapshotExpectedForBuildPLR(pipelineRun *tektonv1.PipelineRun, tempComponentSnapshot *applicationapiv1alpha1.Snapshot) (bool, error) {
 	prGroupHash, prGroup := gitops.GetPRGroup(pipelineRun)
 	if prGroupHash == "" || prGroup == "" {
 		a.logger.Error(fmt.Errorf("NotFound"), fmt.Sprintf("Failed to get PR group label/annotation from pipelineRun %s/%s", pipelineRun.Namespace, pipelineRun.Name))
@@ -1062,7 +1062,7 @@ func (a *Adapter) isGroupSnapshotExpectedForBuildPLR(pipelineRun *tektonv1.Pipel
 			return false, err
 		}
 
-		foundSnapshotWithOpenedPR, statusCode, err := a.status.FindSnapshotWithOpenedPR(a.context, snapshots)
+		foundSnapshotWithOpenedPR, statusCode, err := a.status.FindSnapshotWithOpenedPR(a.context, snapshots, tempComponentSnapshot)
 		if err != nil {
 			a.logger.Error(err, "failed to find snapshot with open PR or MR", "statusCode", statusCode)
 			return false, err

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -2106,7 +2106,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			mockStatus = status.NewMockStatusInterface(ctrl)
 			mockReporter.EXPECT().GetReporterName().Return("mocked-reporter").AnyTimes()
 			mockStatus.EXPECT().GetReporter(gomock.Any()).Return(mockReporter).AnyTimes()
-			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasSnapshot, 0, nil).AnyTimes()
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(hasSnapshot, 0, nil).AnyTimes()
 			mockReporter.EXPECT().GetReporterName().AnyTimes()
 			mockReporter.EXPECT().Initialize(gomock.Any(), gomock.Any()).AnyTimes()
 			mockReporter.EXPECT().ReportStatus(gomock.Any(), gomock.Any()).AnyTimes()

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -2682,8 +2682,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			ctrl := gomock.NewController(GinkgoT())
 			mockStatus := status.NewMockStatusInterface(ctrl)
-			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot2, 0, nil)
-			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any()).Return(hasComSnapshot3, 0, nil)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(hasComSnapshot2, 0, nil)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(hasComSnapshot3, 0, nil)
 			// mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).Return(true, nil)
 			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
 

--- a/status/mock_status.go
+++ b/status/mock_status.go
@@ -40,9 +40,9 @@ func (m *MockStatusInterface) EXPECT() *MockStatusInterfaceMockRecorder {
 }
 
 // FindSnapshotWithOpenedPR mocks base method.
-func (m *MockStatusInterface) FindSnapshotWithOpenedPR(arg0 context.Context, arg1 *[]v1alpha1.Snapshot) (*v1alpha1.Snapshot, int, error) {
+func (m *MockStatusInterface) FindSnapshotWithOpenedPR(arg0 context.Context, arg1 *[]v1alpha1.Snapshot, arg2 *v1alpha1.Snapshot) (*v1alpha1.Snapshot, int, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindSnapshotWithOpenedPR", arg0, arg1)
+	ret := m.ctrl.Call(m, "FindSnapshotWithOpenedPR", arg0, arg1, arg2)
 	ret0, _ := ret[0].(*v1alpha1.Snapshot)
 	ret1, _ := ret[1].(int)
 	ret2, _ := ret[2].(error)
@@ -50,9 +50,9 @@ func (m *MockStatusInterface) FindSnapshotWithOpenedPR(arg0 context.Context, arg
 }
 
 // FindSnapshotWithOpenedPR indicates an expected call of FindSnapshotWithOpenedPR.
-func (mr *MockStatusInterfaceMockRecorder) FindSnapshotWithOpenedPR(arg0, arg1 interface{}) *gomock.Call {
+func (mr *MockStatusInterfaceMockRecorder) FindSnapshotWithOpenedPR(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSnapshotWithOpenedPR", reflect.TypeOf((*MockStatusInterface)(nil).FindSnapshotWithOpenedPR), arg0, arg1)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSnapshotWithOpenedPR", reflect.TypeOf((*MockStatusInterface)(nil).FindSnapshotWithOpenedPR), arg0, arg1, arg2)
 }
 
 // GetReporter mocks base method.


### PR DESCRIPTION
* reduce git provier api call when preparing group snapshot in build plr and snapshot controller since component snapshot and build plr is created for open PR/MR, so we can consider its PR is opened, and also, monorepo components snapshot are created for the same PR/MR, so we can skip check PR/MR checking if the component snapshots from different components have the same git url and PR/MR number

Assisted-by: Claude Code AI
Signed-off-by: Hongwei Liu hongliu@redhat.com

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
