### PR TITLE
fix(renovate): remove renovate major group

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -29,20 +29,6 @@
       "groupName": "github action dependencies"
     },
     {
-      "description": "Go major updates (excluding go language version)",
-      "matchManagers": [
-        "gomod"
-      ],
-      "matchUpdateTypes": [
-        "major"
-      ],
-      "groupName": "go major dependencies",
-      "matchPackageNames": [
-        "!go",
-        "!toolchain"
-      ]
-    },
-    {
       "description": "Go minor updates",
       "matchManagers": [
         "gomod"


### PR DESCRIPTION
* remove major group from renovate config file because some change is too big

Signed-off-by: Hongwei Liu <hongliu@redhat.com>  
## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
