### PR TITLE
DNM: test: running TPA scan for integration service

### DIFF
--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -373,7 +373,12 @@ spec:
           value: task
         resolver: bundles
       timeout: 20m
-    - name: tpa-scan
+    - matrix:
+        params:
+          - name: image-platform
+            value:
+              - $(params.build-platforms)
+      name: tpa-scan
       params:
         - name: image-digest
           value: $(tasks.build-image-index.results.IMAGE_DIGEST)

--- a/.tekton/integration-service-pull-request.yaml
+++ b/.tekton/integration-service-pull-request.yaml
@@ -373,6 +373,24 @@ spec:
           value: task
         resolver: bundles
       timeout: 20m
+    - name: tpa-scan
+      params:
+        - name: image-digest
+          value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+        - name: image-url
+          value: $(tasks.build-image-index.results.IMAGE_URL)
+      runAfter:
+        - build-image-index
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/dirgim/konflux-test-tasks
+          - name: revision
+            value: STONEINTG-1505
+          - name: pathInRepo
+            value: task/tpa-scan/0.1/tpa-scan.yaml
+      timeout: 1h
     - name: sast-snyk-check
       params:
       - name: image-digest


### PR DESCRIPTION
* Test running the TPA scan on the multi arch build of the integration service
* Do Not Merge

Signed-off-by: dirgim <kpavic@redhat.com>


## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
