### PR TITLE
fix(STONEINTG-1525): on-pull plr should not cancel on-push snapshot

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -592,12 +592,12 @@ func (a *Adapter) EnsureSupercededSnapshotsCanceled() (result controller.Operati
 	// TODO: remove branch after migration to new model
 	var snapshots *[]applicationapiv1alpha1.Snapshot
 	if a.application != nil {
-		snapshots, err = a.loader.GetAllSnapshotsForPR(a.context, a.client, a.application.ObjectMeta, a.component.Name, pr)
+		snapshots, err = a.loader.GetAllPullSnapshotsForPR(a.context, a.client, a.application.ObjectMeta, a.component.Name, pr)
 	} else {
 		// We only have to pass one ComponentGroup here.  The componentGroup is only used to get
 		// the namespace to search. Since all ComponentGroups have to belong to the same NS, we
 		// don't need to search with each ComponentGroup
-		snapshots, err = a.loader.GetAllSnapshotsForPR(a.context, a.client, (*a.componentGroups)[0].ObjectMeta, a.component.Name, pr)
+		snapshots, err = a.loader.GetAllPullSnapshotsForPR(a.context, a.client, (*a.componentGroups)[0].ObjectMeta, a.component.Name, pr)
 	}
 	if err != nil {
 		return controller.RequeueWithError(fmt.Errorf("failed to get running snapshots for PR %s: %w", pr, err))

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -214,6 +214,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeGitProviderAnnotation:    "github",
+					gitops.IntegrationWorkflowAnnotation:          gitops.IntegrationWorkflowPullRequestValue,
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -611,13 +612,17 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				return !result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
 
-			// Get the updated PipelineRun to check the annotation
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), buildPipelineRun)
-			Expect(err).ToNot(HaveOccurred())
-
-			// The PipelineRun should be annotated with the snapshot name
-			snapshotName, found := buildPipelineRun.Annotations[tektonconsts.SnapshotNamesLabel]
-			Expect(found).To(BeTrue(), "PipelineRun should be annotated with snapshot name")
+			// Wait for the cache to reflect the updated PipelineRun annotation
+			var snapshotName string
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), buildPipelineRun)
+				if err != nil {
+					return false
+				}
+				var found bool
+				snapshotName, found = buildPipelineRun.Annotations[tektonconsts.SnapshotNamesLabel]
+				return found
+			}, time.Second*10).Should(BeTrue(), "PipelineRun should be annotated with snapshot name")
 
 			// Verify the snapshot name either has a suffix or is different from colliding one
 			// Format: prefix-YYYYMMDD-HHMMSS-mmm or prefix-YYYYMMDD-HHMMSS-mmm-xx
@@ -873,13 +878,17 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				return !result.CancelRequest && err == nil
 			}, time.Second*10).Should(BeTrue())
 
-			// Get the updated PipelineRun to check the annotation
-			err = k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), buildPipelineRun)
-			Expect(err).ToNot(HaveOccurred())
-
-			// The PipelineRun should be annotated with the snapshot name
-			snapshotName, found := buildPipelineRun.Annotations[tektonconsts.SnapshotNameLabel]
-			Expect(found).To(BeTrue(), "PipelineRun should be annotated with snapshot name")
+			// Wait for the cache to reflect the updated PipelineRun annotation
+			var snapshotName string
+			Eventually(func() bool {
+				err = k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), buildPipelineRun)
+				if err != nil {
+					return false
+				}
+				var found bool
+				snapshotName, found = buildPipelineRun.Annotations[tektonconsts.SnapshotNameLabel]
+				return found
+			}, time.Second*10).Should(BeTrue(), "PipelineRun should be annotated with snapshot name")
 
 			// Verify the snapshot name either has a suffix or is different from colliding one
 			// Format: prefix-YYYYMMDD-HHMMSS-mmm or prefix-YYYYMMDD-HHMMSS-mmm-xx
@@ -1989,7 +1998,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
-						ContextKey: loader.AllSnapshotsForGivenPRContextKey,
+						ContextKey: loader.AllPullSnapshotsForGivenPRContextKey,
 						Resource:   []applicationapiv1alpha1.Snapshot{*duplicateSnapshot},
 					},
 				})
@@ -2035,7 +2044,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, log, loader.NewMockLoader(), k8sClient)
 				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
 					{
-						ContextKey: loader.AllSnapshotsForGivenPRContextKey,
+						ContextKey: loader.AllPullSnapshotsForGivenPRContextKey,
 						Resource:   []applicationapiv1alpha1.Snapshot{*finishedSnapshot},
 					},
 				})

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1038,7 +1038,7 @@ func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun(application *application
 	var err error
 	snapshots := &[]applicationapiv1alpha1.Snapshot{}
 	if gitops.IsComponentSnapshot(snapshot) {
-		snapshots, err = a.loader.GetAllSnapshotsForPR(a.context, a.client, application.ObjectMeta, snapshot.GetLabels()[gitops.SnapshotComponentLabel], snapshot.GetLabels()[gitops.PipelineAsCodePullRequestAnnotation])
+		snapshots, err = a.loader.GetAllPullSnapshotsForPR(a.context, a.client, application.ObjectMeta, snapshot.GetLabels()[gitops.SnapshotComponentLabel], snapshot.GetLabels()[gitops.PipelineAsCodePullRequestAnnotation])
 		if err != nil {
 			a.logger.Error(err, "Failed to fetch Snapshots for the application",
 				"application.Name:", application.Name)

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -414,6 +414,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeRepoURLAnnotation:        "repo-url",
+					gitops.IntegrationWorkflowAnnotation:          gitops.IntegrationWorkflowPullRequestValue,
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{
@@ -438,6 +439,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.PipelineAsCodeInstallationIDAnnotation: "123",
 					gitops.PRGroupAnnotation:                      prGroup,
 					gitops.PipelineAsCodeRepoURLAnnotation:        "repo-url",
+					gitops.IntegrationWorkflowAnnotation:          gitops.IntegrationWorkflowPullRequestValue,
 				},
 			},
 			Spec: applicationapiv1alpha1.SnapshotSpec{

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -65,7 +65,7 @@ type ObjectLoader interface {
 	GetComponentGroup(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.ComponentGroup, error)
 	GetAllSnapshotsForBuildPipelineRunApplication(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun, componentGroupNames []string) (*map[string][]applicationapiv1alpha1.Snapshot, error)
-	GetAllSnapshotsForPR(ctx context.Context, c client.Client, object metav1.ObjectMeta, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error)
+	GetAllPullSnapshotsForPR(ctx context.Context, c client.Client, object metav1.ObjectMeta, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetAllTaskRunsWithMatchingPipelineRunLabel(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]tektonv1.TaskRun, error)
 	GetPipelineRun(ctx context.Context, c client.Client, name, namespace string) (*tektonv1.PipelineRun, error)
 	GetComponent(ctx context.Context, c client.Client, name, namespace string) (*applicationapiv1alpha1.Component, error)
@@ -518,11 +518,13 @@ func (l *loader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c clien
 	return &mappedSnapshots, nil
 }
 
-// GetAllSnapshotsForPR returns all Snapshots for the associated Pull Request.
+// GetAllPullSnapshotsForPR returns all pull-request workflow Snapshots for the associated Pull Request.
 // In the case the List operation fails, an error will be returned.
 // PipelineAsCodePullRequestAnnotation is also a label
+// Only snapshots with IntegrationWorkflowAnnotation set to "pull-request" are returned,
+// so on-push snapshots that carry the same PR label are excluded.
 // TODO: make this function take ObjectMeta rather than application
-func (l *loader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, object metav1.ObjectMeta, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
+func (l *loader) GetAllPullSnapshotsForPR(ctx context.Context, c client.Client, object metav1.ObjectMeta, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
 	snapshots := &applicationapiv1alpha1.SnapshotList{}
 	opts := []client.ListOption{
 		client.InNamespace(object.Namespace),
@@ -536,7 +538,14 @@ func (l *loader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, obje
 	if err != nil {
 		return nil, err
 	}
-	return &snapshots.Items, nil
+
+	pullSnapshots := make([]applicationapiv1alpha1.Snapshot, 0, len(snapshots.Items))
+	for _, s := range snapshots.Items {
+		if s.Annotations != nil && s.Annotations[gitops.IntegrationWorkflowAnnotation] == gitops.IntegrationWorkflowPullRequestValue {
+			pullSnapshots = append(pullSnapshots, s)
+		}
+	}
+	return &pullSnapshots, nil
 }
 
 // GetAllTaskRunsWithMatchingPipelineRunLabel finds all Child TaskRuns

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -59,7 +59,7 @@ const (
 	AllEnvironmentsForScenarioContextKey
 	AllSnapshotsForBuildPipelineRunApplicationContextKey
 	AllSnapshotsForBuildPipelineRunContextKey
-	AllSnapshotsForGivenPRContextKey
+	AllPullSnapshotsForGivenPRContextKey
 	AllTaskRunsWithMatchingPipelineRunLabelContextKey
 	GetPipelineRunContextKey
 	GetComponentContextKey
@@ -263,11 +263,11 @@ func (l *mockLoader) GetAllSnapshotsForBuildPipelineRun(ctx context.Context, c c
 	return &snapshots, err
 }
 
-func (l *mockLoader) GetAllSnapshotsForPR(ctx context.Context, c client.Client, object metav1.ObjectMeta, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
-	if ctx.Value(AllSnapshotsForGivenPRContextKey) == nil {
-		return l.loader.GetAllSnapshotsForPR(ctx, c, object, componentName, pullRequest)
+func (l *mockLoader) GetAllPullSnapshotsForPR(ctx context.Context, c client.Client, object metav1.ObjectMeta, componentName, pullRequest string) (*[]applicationapiv1alpha1.Snapshot, error) {
+	if ctx.Value(AllPullSnapshotsForGivenPRContextKey) == nil {
+		return l.loader.GetAllPullSnapshotsForPR(ctx, c, object, componentName, pullRequest)
 	}
-	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllSnapshotsForGivenPRContextKey, []applicationapiv1alpha1.Snapshot{})
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AllPullSnapshotsForGivenPRContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
 


### PR DESCRIPTION
Rename GetAllSnapshotsForPR to GetAllPullSnapshotsForPR and add filtering to exclude snapshots whose integration-workflow annotation is not "pull-request". This prevents a late on-pull build PLR from canceling an in-progress on-push snapshot that carries the same PR label.