### PR TITLE
fix(KONFLUX-12674): include git context for built ss component

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -1062,6 +1062,32 @@ func GetComponentSourceFromComponent(component *applicationapiv1alpha1.Component
 	return componentSource, nil
 }
 
+// EnrichBuiltComponentSourceGitContext sets GitSource.Context on the built component source when it is
+// still empty. When componentVersion is set, matching spec.source.versions[].context takes precedence
+// over spec.source.git.context; otherwise top-level git context is used. This aligns the built row with
+// GetComponentSourceFromComponent for sibling components.
+func EnrichBuiltComponentSourceGitContext(componentSource *applicationapiv1alpha1.ComponentSource, component *applicationapiv1alpha1.Component, componentVersion string) {
+	if componentSource == nil || componentSource.GitSource == nil || component == nil {
+		return
+	}
+	if componentSource.GitSource.Context != "" {
+		return
+	}
+	if componentVersion != "" {
+		for i := range component.Spec.Source.Versions {
+			v := &component.Spec.Source.Versions[i]
+			if v.Name == componentVersion && v.Context != "" {
+				componentSource.GitSource.Context = v.Context
+				return
+			}
+		}
+	}
+	if component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.Context != "" {
+		componentSource.GitSource.Context = component.Spec.Source.GitSource.Context
+		return
+	}
+}
+
 // GetIntegrationTestRunLabelValue returns value of the label responsible for re-running tests
 func GetIntegrationTestRunLabelValue(obj metav1.Object) (string, bool) {
 	labels := obj.GetLabels()

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -1458,3 +1458,121 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		})
 	})
 })
+
+var _ = Describe("EnrichBuiltComponentSourceGitContext", func() {
+	It("copies context from spec.source.git when built source context is empty", func() {
+		src := &applicationapiv1alpha1.ComponentSource{
+			ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+				GitSource: &applicationapiv1alpha1.GitSource{URL: "https://example.com/repo", Revision: "abc"},
+			},
+		}
+		comp := &applicationapiv1alpha1.Component{
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      "https://example.com/repo",
+							Revision: "abc",
+							Context:  "ctx-from-cr",
+						},
+					},
+				},
+			},
+		}
+		gitops.EnrichBuiltComponentSourceGitContext(src, comp, "v1")
+		Expect(src.GitSource.Context).To(Equal("ctx-from-cr"))
+	})
+
+	It("prefers matching spec.source.versions context over top-level git when both are set", func() {
+		src := &applicationapiv1alpha1.ComponentSource{
+			ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+				GitSource: &applicationapiv1alpha1.GitSource{URL: "https://example.com/repo", Revision: "abc"},
+			},
+		}
+		comp := &applicationapiv1alpha1.Component{
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      "https://example.com/repo",
+							Revision: "abc",
+							Context:  "ctx-top-level",
+						},
+						Versions: []applicationapiv1alpha1.ComponentVersion{
+							{Name: "v1", Revision: "main", Context: "ctx-from-version"},
+						},
+					},
+				},
+			},
+		}
+		gitops.EnrichBuiltComponentSourceGitContext(src, comp, "v1")
+		Expect(src.GitSource.Context).To(Equal("ctx-from-version"))
+	})
+
+	It("copies context from matching spec.source.versions entry when top-level git context is empty", func() {
+		src := &applicationapiv1alpha1.ComponentSource{
+			ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+				GitSource: &applicationapiv1alpha1.GitSource{URL: "https://example.com/repo", Revision: "abc"},
+			},
+		}
+		comp := &applicationapiv1alpha1.Component{
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitURL: "https://example.com/repo",
+						Versions: []applicationapiv1alpha1.ComponentVersion{
+							{Name: "v1", Revision: "main", Context: "ctx-from-version"},
+						},
+					},
+				},
+			},
+		}
+		gitops.EnrichBuiltComponentSourceGitContext(src, comp, "v1")
+		Expect(src.GitSource.Context).To(Equal("ctx-from-version"))
+	})
+
+	It("uses top-level spec.source.git when componentVersion is empty", func() {
+		src := &applicationapiv1alpha1.ComponentSource{
+			ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+				GitSource: &applicationapiv1alpha1.GitSource{URL: "https://example.com/repo", Revision: "abc"},
+			},
+		}
+		comp := &applicationapiv1alpha1.Component{
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      "https://example.com/repo",
+							Revision: "abc",
+							Context:  "ctx-from-cr",
+						},
+						Versions: []applicationapiv1alpha1.ComponentVersion{
+							{Name: "v1", Revision: "main", Context: "ctx-from-version"},
+						},
+					},
+				},
+			},
+		}
+		gitops.EnrichBuiltComponentSourceGitContext(src, comp, "")
+		Expect(src.GitSource.Context).To(Equal("ctx-from-cr"))
+	})
+
+	It("does not overwrite non-empty context", func() {
+		src := &applicationapiv1alpha1.ComponentSource{
+			ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+				GitSource: &applicationapiv1alpha1.GitSource{URL: "u", Revision: "r", Context: "already-set"},
+			},
+		}
+		comp := &applicationapiv1alpha1.Component{
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{URL: "u", Revision: "r", Context: "other"},
+					},
+				},
+			},
+		}
+		gitops.EnrichBuiltComponentSourceGitContext(src, comp, "v1")
+		Expect(src.GitSource.Context).To(Equal("already-set"))
+	})
+})

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -694,6 +694,11 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 	if err != nil {
 		return nil, err
 	}
+	componentVersion := ""
+	if v, verr := tekton.GetComponentVersionFromPipelineRun(pipelineRun); verr == nil {
+		componentVersion = v
+	}
+	gitops.EnrichBuiltComponentSourceGitContext(componentSource, component, componentVersion)
 
 	applicationComponents, err := a.loader.GetAllApplicationComponents(a.context, a.client, application)
 	if err != nil {

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -122,6 +122,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 						GitSource: &applicationapiv1alpha1.GitSource{
 							URL:      SampleRepoLink,
 							Revision: SampleCommit,
+							Context:  "rpms/my-component",
 						},
 					},
 				},
@@ -1108,6 +1109,40 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(found).To(BeTrue())
 			Expect(annotation).To(Equal(gitops.IntegrationWorkflowPushValue))
 			Expect(annotation).To(Equal("push"))
+		})
+
+		It("ensures built component snapshot includes git context from Component spec", func() {
+			snapshot, err := adapter.prepareSnapshotForPipelineRun(buildPipelineRun, hasComp, hasApp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshot).ToNot(BeNil())
+			var built *applicationapiv1alpha1.SnapshotComponent
+			for i := range snapshot.Spec.Components {
+				if snapshot.Spec.Components[i].Name == hasComp.Name {
+					built = &snapshot.Spec.Components[i]
+					break
+				}
+			}
+			Expect(built).NotTo(BeNil())
+			Expect(built.Source.GitSource).NotTo(BeNil())
+			Expect(built.Source.GitSource.Context).To(Equal("rpms/my-component"))
+		})
+
+		It("ensures PipelineRun context annotation overrides Component spec git context", func() {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Annotations[tektonconsts.PipelineRunComponentVersionContextAnnotation] = "annotation-context"
+			snapshot, err := adapter.prepareSnapshotForPipelineRun(plr, hasComp, hasApp)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshot).ToNot(BeNil())
+			var built *applicationapiv1alpha1.SnapshotComponent
+			for i := range snapshot.Spec.Components {
+				if snapshot.Spec.Components[i].Name == hasComp.Name {
+					built = &snapshot.Spec.Components[i]
+					break
+				}
+			}
+			Expect(built).NotTo(BeNil())
+			Expect(built.Source.GitSource).NotTo(BeNil())
+			Expect(built.Source.GitSource.Context).To(Equal("annotation-context"))
 		})
 
 		It("ensure snapshot will not be created in instance when chains is incomplete", func() {

--- a/snapshot/create.go
+++ b/snapshot/create.go
@@ -36,6 +36,11 @@ func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Cli
 		return nil, err
 	}
 
+	var comp applicationapiv1alpha1.Component
+	if err := adapterClient.Get(ctx, client.ObjectKey{Namespace: componentGroup.Namespace, Name: componentName}, &comp); err == nil {
+		gitops.EnrichBuiltComponentSourceGitContext(&newSnapshotComponent.Source, &comp, newSnapshotComponent.Version)
+	}
+
 	snapshot, err := PrepareSnapshot(ctx, adapterClient, componentGroup, newSnapshotComponent, log)
 	if err != nil {
 		return nil, err

--- a/snapshot/create_test.go
+++ b/snapshot/create_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
@@ -28,6 +29,8 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		buildPipelineRun  *tektonv1.PipelineRun
 		successfulTaskRun *tektonv1.TaskRun
 		hasCompGroup      *v1beta2.ComponentGroup
+		hasAppSample      *applicationapiv1alpha1.Application
+		hasCompSample     *applicationapiv1alpha1.Component
 		logger            logr.Logger
 	)
 	const (
@@ -41,6 +44,40 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 	)
 
 	BeforeAll(func() {
+		hasAppSample = &applicationapiv1alpha1.Application{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "application-sample",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ApplicationSpec{
+				DisplayName: "application-sample",
+				Description: "This is an example application",
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasAppSample)).Should(Succeed())
+
+		hasCompSample = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      componentName,
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName:  componentName,
+				Application:    "application-sample",
+				ContainerImage: "invalidImage",
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      SampleRepoLink,
+							Revision: SampleCommit,
+							Context:  "rpms/my-component",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, hasCompSample)).Should(Succeed())
+
 		buildPipelineRun = &tektonv1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "pipelinerun-build-sample",
@@ -227,9 +264,29 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasCompGroup)
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasCompSample)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasAppSample)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 	})
 
 	Context("Testing PrepareSnapshotForPipelineRun()", func() {
+		It("ensures built component includes git context from Component CR", func() {
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(expectedSnapshot).NotTo(BeNil())
+			var built *applicationapiv1alpha1.SnapshotComponent
+			for i := range expectedSnapshot.Spec.Components {
+				if expectedSnapshot.Spec.Components[i].Name == componentName {
+					built = &expectedSnapshot.Spec.Components[i]
+					break
+				}
+			}
+			Expect(built).NotTo(BeNil())
+			Expect(built.Source.GitSource).NotTo(BeNil())
+			Expect(built.Source.GitSource.Context).To(Equal("rpms/my-component"))
+		})
+
 		It("ensures that snapshot has label pointing to build pipelinerun", func() {
 			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
 			Expect(err).ToNot(HaveOccurred())

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -206,6 +206,9 @@ func GetComponentSourceFromPipelineRun(pipelineRun *tektonv1.PipelineRun) (*appl
 			},
 		},
 	}
+	if ctx, ok := pipelineRun.Annotations[consts.PipelineRunComponentVersionContextAnnotation]; ok && ctx != "" {
+		componentSource.GitSource.Context = ctx
+	}
 
 	return &componentSource, nil
 }

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -308,6 +308,14 @@ var _ = Describe("build pipeline", Ordered, func() {
 			Expect(componentSource).NotTo(BeNil())
 		})
 
+		It("sets git context from PipelineRun annotation when present", func() {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Annotations[tektonconsts.PipelineRunComponentVersionContextAnnotation] = "monorepo/subdir"
+			componentSource, err := tekton.GetComponentSourceFromPipelineRun(plr)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(componentSource.GitSource.Context).To(Equal("monorepo/subdir"))
+		})
+
 		It("ensures the component version can be accessed", func() {
 			version, err := tekton.GetComponentVersionFromPipelineRun(buildPipelineRun)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
- Built snapshot row gets git.context like other components
- Read context from PLR appstudio.openshift.io/context when set
- Else copy from Component spec.source.git or matching versions
- Application and ComponentGroup snapshot paths both enriched
- PLR annotation overrides Component when both exist
- Tests added for the above

Assisted by AI: Cursor AI

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
