### PR TITLE
fix(STONEINTG-1558): fix for retry report failure

### DIFF
--- a/status/reporter.go
+++ b/status/reporter.go
@@ -37,9 +37,9 @@ import (
 )
 
 // reporterRetryBackoff defines the retry backoff for transient git provider API errors (GitLab, GitHub, Forgejo).
-// Retries up to 5 times with exponential backoff: ~1s, ~2s, ~4s, ~8s, ~16s.
+// Retries up to 3 times with exponential backoff: ~0s, ~1s, ~2s.
 var reporterRetryBackoff = wait.Backoff{
-	Steps:    5,
+	Steps:    3,
 	Duration: 1 * time.Second,
 	Factor:   2.0,
 	Jitter:   0.1,

--- a/status/reporter_forgejo.go
+++ b/status/reporter_forgejo.go
@@ -145,7 +145,7 @@ func (r *ForgejoReporter) Initialize(ctx context.Context, snapshot *applicationa
 	}
 
 	r.snapshot = snapshot
-	return 0, nil
+	return http.StatusOK, nil
 }
 
 // IsPullRequestOpen returns whether the snapshot's pull request is still open.
@@ -416,7 +416,7 @@ func (r *ForgejoReporter) ReportStatus(ctx context.Context, report TestReport) (
 }
 
 func (r *ForgejoReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound
 }
 
 // GenerateForgejoCommitState transforms internal integration test state into Forgejo state

--- a/status/reporter_forgejo_test.go
+++ b/status/reporter_forgejo_test.go
@@ -197,7 +197,7 @@ var _ = Describe("ForgejoReporter", func() {
 
 			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 		})
 
@@ -235,7 +235,7 @@ var _ = Describe("ForgejoReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		It("creates a commit status for push snapshot with correct textual data without comments", func() {
@@ -246,7 +246,7 @@ var _ = Describe("ForgejoReporter", func() {
 			pushEventReporter := status.NewForgejoReporter(log, mockK8sClient)
 			statusCode, err := pushEventReporter.Initialize(context.TODO(), pushSnapshot)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 passed"
 			muxForgejoCommitStatusPost(mux, owner, repo, digest, summary, "")
@@ -261,7 +261,7 @@ var _ = Describe("ForgejoReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		It("creates a commit status for snapshot with TargetURL in CommitStatus", func() {
@@ -282,7 +282,7 @@ var _ = Describe("ForgejoReporter", func() {
 					Text:                "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		It("sends failure commit status payload and comment text body to the API", func() {
@@ -305,11 +305,11 @@ var _ = Describe("ForgejoReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 			statusCode, err = reporter.UpdateStatusInComment(commentPrefix, commentText, true)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(201))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 		})
 
 		It("does not create a commit status for snapshot with existing matching status in pending state", func() {
@@ -325,7 +325,7 @@ var _ = Describe("ForgejoReporter", func() {
 
 			statusCode, err := reporter.ReportStatus(context.TODO(), report)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		It("can get an existing commitStatus that matches the report", func() {
@@ -359,7 +359,7 @@ var _ = Describe("ForgejoReporter", func() {
 			muxForgejoIssueComments(mux, owner, repo, pullRequest, commentText)
 			statusCode, err := reporter.UpdateStatusInComment(commentPrefix, commentText, true)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(201))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 		})
 	})
 
@@ -431,7 +431,7 @@ var _ = Describe("ForgejoReporter", func() {
 			reporter = status.NewForgejoReporter(log, mockK8sClient)
 			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		AfterEach(func() {

--- a/status/reporter_github.go
+++ b/status/reporter_github.go
@@ -357,7 +357,7 @@ func (csu *CommitStatusUpdater) Authenticate(ctx context.Context, snapshot *appl
 	}
 
 	csu.ghClient.SetOAuthToken(ctx, token)
-	return 0, nil
+	return http.StatusOK, nil
 }
 
 // createCommitStatusAdapterForSnapshot create a commitStatusAdapter used to create commitStatus on GitHub
@@ -490,7 +490,7 @@ func (csu *CommitStatusUpdater) UpdateStatus(ctx context.Context, report TestRep
 		}
 	}
 
-	return 0, nil
+	return http.StatusOK, nil
 }
 
 // GitHubReporter reports status back to GitHub for a Snapshot.
@@ -631,7 +631,7 @@ func (r *GitHubReporter) Detect(snapshot *applicationapiv1alpha1.Snapshot) bool 
 
 // blank implementation to satisfy ReporterInterface
 func (r *GitHubReporter) UpdateStatusInComment(arg0, arg1 string, arg2 bool) (int, error) {
-	return 0, nil
+	return http.StatusCreated, nil
 }
 
 // Initialize github reporter. Must be called before updating status
@@ -714,5 +714,5 @@ func (r *GitHubReporter) ReportStatus(ctx context.Context, report TestReport) (i
 }
 
 func (r *GitHubReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound
 }

--- a/status/reporter_github_test.go
+++ b/status/reporter_github_test.go
@@ -371,7 +371,7 @@ var _ = Describe("GitHubReporter", func() {
 					})
 
 				Expect(err).To(Succeed(), "ReportStatus should succeed")
-				Expect(statusCode).To(Equal(200))
+				Expect(statusCode).To(Equal(http.StatusOK))
 				Expect(mockGitHubClient.CreateCheckRunResult.cra).NotTo(BeNil())
 				Expect(mockGitHubClient.CreateCheckRunResult.cra.Title).To(Equal(title))
 				Expect(mockGitHubClient.CreateCheckRunResult.cra.Conclusion).To(Equal(conclusion))
@@ -402,7 +402,7 @@ var _ = Describe("GitHubReporter", func() {
 					})
 
 				Expect(err).To(Succeed(), "ReportStatus should succeed")
-				Expect(statusCode).To(Equal(200))
+				Expect(statusCode).To(Equal(http.StatusOK))
 			}
 		})
 
@@ -423,7 +423,7 @@ var _ = Describe("GitHubReporter", func() {
 				})
 
 			Expect(err).To(Succeed(), "ReportStatus should succeed")
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra).NotTo(BeNil())
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
@@ -452,7 +452,7 @@ var _ = Describe("GitHubReporter", func() {
 				})
 
 			Expect(err).To(Succeed(), "ReportStatus should succeed")
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra).NotTo(BeNil())
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Summary).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 experienced an error when provisioning environment"))
 			Expect(mockGitHubClient.CreateCheckRunResult.cra.Conclusion).To(Equal(gitops.IntegrationTestStatusFailureGithub))
@@ -524,7 +524,7 @@ var _ = Describe("GitHubReporter", func() {
 					StartTime:     &now,
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 			expectedLogEntry = "found existing checkrun"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
@@ -602,7 +602,7 @@ var _ = Describe("GitHubReporter", func() {
 				})
 
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal(gitops.IntegrationTestStatusErrorGithub))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 failed"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("fullname/scenario1"))
@@ -625,7 +625,7 @@ var _ = Describe("GitHubReporter", func() {
 				})
 
 			Expect(err).To(Succeed(), "ReportStatus should succeed")
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 			Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal(gitops.IntegrationTestStatusErrorGithub))
 			Expect(mockGitHubClient.CreateCommitStatusResult.description).To(Equal("Integration test for snapshot snapshot-sample and scenario scenario1 failed"))
 			Expect(mockGitHubClient.CreateCommitStatusResult.statusContext).To(Equal("fullname/scenario1"))
@@ -643,7 +643,7 @@ var _ = Describe("GitHubReporter", func() {
 						Status:       teststatus,
 					})
 				Expect(err).To(Succeed(), "ReportStatus should succeed")
-				Expect(statusCode).To(Equal(0))
+				Expect(statusCode).To(Equal(http.StatusOK))
 				Expect(mockGitHubClient.CreateCommitStatusResult.state).To(Equal(ghstatus))
 			},
 			Entry("Provision error", integrationteststatus.IntegrationTestStatusEnvironmentProvisionError_Deprecated, gitops.IntegrationTestStatusErrorGithub),
@@ -671,7 +671,7 @@ var _ = Describe("GitHubReporter", func() {
 					})
 
 				Expect(err).To(Succeed(), "ReportStatus should succeed")
-				Expect(statusCode).To(Equal(0))
+				Expect(statusCode).To(Equal(http.StatusOK))
 			}
 		})
 
@@ -684,7 +684,7 @@ var _ = Describe("GitHubReporter", func() {
 			}
 			statusCode, err := reporter.ReportStatus(context.TODO(), testReport)
 			Expect(err).To(Succeed(), "ReportStatus should succeed")
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 			expectedLogEntry := "found existing commitStatus for scenario test status of snapshot, no need to create new commit status"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 		})
@@ -699,7 +699,7 @@ var _ = Describe("GitHubReporter", func() {
 			}
 			statusCode, err := reporter.ReportStatus(context.TODO(), testReport)
 			Expect(err).To(Succeed(), "ReportStatus should succeed")
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 			expectedLogEntry := "Won't create/update commitStatus since there is access limitation for different source and target Repo Owner"
 			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -160,7 +160,7 @@ func (r *GitLabReporter) Initialize(ctx context.Context, snapshot *applicationap
 	}
 
 	r.snapshot = snapshot
-	return 0, nil
+	return http.StatusOK, nil
 }
 
 // setCommitStatus sets commit status to be shown as pipeline run in gitlab view
@@ -233,7 +233,7 @@ func (r *GitLabReporter) setCommitStatus(report TestReport) (int, error) {
 			"sourceProjectID", r.sourceProjectID,
 			"targetProjectID", r.targetProjectID,
 		}
-		if err != nil && statusCode != 200 {
+		if err != nil && statusCode != http.StatusOK {
 			r.logger.Error(joinedError, "API error while searching for Merge Request pipeline, proceeding without association", logFields...)
 		} else {
 			r.logger.Info("no existing merge request pipeline found after retries, creating commit status without pipeline association", logFields...)
@@ -265,41 +265,48 @@ func (r *GitLabReporter) setCommitStatus(report TestReport) (int, error) {
 	r.logger.Info("creating commit status for scenario test status of snapshot",
 		"scenarioName", report.ScenarioName)
 
-	sourceProjectCommitStatus, sourceProjectResponse, sourceProjectErr := r.client.Commits.SetCommitStatus(r.sourceProjectID, r.sha, &opt)
-	if sourceProjectResponse != nil {
-		statusCode = sourceProjectResponse.StatusCode
-	}
-	if sourceProjectErr == nil {
-		r.logger.Info("Created gitlab commit status", "scenario.name", report.ScenarioName, "commitStatus.ID", sourceProjectCommitStatus.ID, "TargetURL", opt.TargetURL)
-		return statusCode, nil
-	} else if strings.Contains(sourceProjectErr.Error(), "Cannot transition status via :enqueue from :pending") {
-		r.logger.Info("Ignoring the error when transition from pending to pending when the commitStatus might be created/updated in multiple threads at the same time occasionally")
-		return statusCode, nil
-	} else {
-		r.logger.Error(sourceProjectErr, "failed to set commit status to gitlab source project, try to set commit status to gitlab target project",
-			"sourceProjectID", r.sourceProjectID, "targetProjectID", r.targetProjectID, "sha", r.sha,
-			"scenario.name", report.ScenarioName, "statusCode", statusCode, "targetState", string(glState))
-	}
-
+	var targetProjectStatusCode, sourceProjectStatusCode int
 	targetProjectCommitStatus, targetProjectResponse, targetProjectErr := r.client.Commits.SetCommitStatus(r.targetProjectID, r.sha, &opt)
 	if targetProjectResponse != nil {
-		statusCode = targetProjectResponse.StatusCode
+		targetProjectStatusCode = targetProjectResponse.StatusCode
 	}
 	if targetProjectErr == nil {
 		r.logger.Info("Created gitlab commit status", "scenario.name", report.ScenarioName, "commitStatus2.ID", targetProjectCommitStatus.ID, "TargetURL", opt.TargetURL)
-		return statusCode, nil
-	}
-	// this code will only be reached if both source project and target project cannot be updated
-	// when commitStatus is created in multiple thread occasionally, we can still see the transition error, so let's ignore it as a workaround
-	if strings.Contains(targetProjectErr.Error(), "Cannot transition status via :enqueue from :pending") {
+		return targetProjectStatusCode, nil
+	} else if strings.Contains(targetProjectErr.Error(), "Cannot transition status via :enqueue from :pending") {
 		r.logger.Info("Ignoring the error when transition from pending to pending when the commitStatus might be created/updated in multiple threads at the same time occasionally")
-		return statusCode, nil
+		return http.StatusOK, nil
+	} else {
+		r.logger.Error(targetProjectErr, "failed to set commit status to gitlab target project, will try to set commit status to gitlab source project",
+			"sourceProjectID", r.sourceProjectID, "targetProjectID", r.targetProjectID, "sha", r.sha,
+			"scenario.name", report.ScenarioName, "target project statusCode", targetProjectStatusCode, "targetState", string(glState))
 	}
 
-	r.logger.Error(errors.Join(targetProjectErr, sourceProjectErr), "failed to set commit status to gitlab source project and target project",
+	sourceProjectCommitStatus, sourceProjectResponse, sourceProjectErr := r.client.Commits.SetCommitStatus(r.sourceProjectID, r.sha, &opt)
+	if sourceProjectResponse != nil {
+		sourceProjectStatusCode = sourceProjectResponse.StatusCode
+	}
+	if sourceProjectErr == nil {
+		r.logger.Info("Created gitlab commit status", "scenario.name", report.ScenarioName, "commitStatus.ID", sourceProjectCommitStatus.ID, "TargetURL", opt.TargetURL)
+		return sourceProjectStatusCode, nil
+	}
+	if strings.Contains(sourceProjectErr.Error(), "Cannot transition status via :enqueue from :pending") {
+		r.logger.Info("Ignoring the error when transition from pending to pending when the commitStatus might be created/updated in multiple threads at the same time occasionally")
+		return http.StatusOK, nil
+	}
+
+	r.logger.Error(errors.Join(targetProjectErr, sourceProjectErr), "failed to set commit status to gitlab source project and target project, retry",
 		"sourceProjectID", r.sourceProjectID, "targetProjectID", r.targetProjectID, "sha", r.sha,
-		"scenario.name", report.ScenarioName, "statusCode", statusCode, "targetState", string(glState))
-	return statusCode, fmt.Errorf("failed to set commit status to %s with returned statusCode %d: %w", string(glState), statusCode, errors.Join(targetProjectErr, sourceProjectErr))
+		"scenario.name", report.ScenarioName, "source project statusCode", sourceProjectStatusCode, "target project statusCode", targetProjectStatusCode, "targetState", string(glState))
+	// return targetProjectStatusCode to retry in ReportStatus function if the error is recoverable since the commit status in target project is the one shown in MR view, otherwise return sourceProjectStatusCode to avoid retry in ReportStatus function because the error is unrecoverable for both target and source project
+	if !r.ReturnCodeIsUnrecoverable(targetProjectStatusCode) {
+		return targetProjectStatusCode, targetProjectErr
+	}
+	if !r.ReturnCodeIsUnrecoverable(sourceProjectStatusCode) {
+		return sourceProjectStatusCode, sourceProjectErr
+	}
+	// by default return target project error and status code to have retry in ReportStatus since the commit status in target project is the one shown in MR view
+	return targetProjectStatusCode, targetProjectErr
 }
 
 // UpdateStatusInComment searches and deletes existing comments according to commentPrefix and create a new comment in the MR which creates snapshot
@@ -502,7 +509,7 @@ func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) (i
 }
 
 func (r *GitLabReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound
 }
 
 // GenerateGitlabCommitState transforms internal integration test state into Gitlab state

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -184,7 +184,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 		})
 
@@ -226,7 +226,7 @@ var _ = Describe("GitLabReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 		})
 
 		It("creates a commit status for push snapshot with correct textual data without comments", func() {
@@ -240,7 +240,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			statusCode, err := pushEventReporter.Initialize(context.TODO(), pushSnapshot)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 
 			summary := "Integration test for component component-sample snapshot snapshot-sample and scenario scenario1 failed"
 
@@ -258,7 +258,7 @@ var _ = Describe("GitLabReporter", func() {
 					Text:         "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 		})
 
 		It("creates a commit status and comment for snapshot with TargetURL in CommitStatus", func() {
@@ -285,7 +285,7 @@ var _ = Describe("GitLabReporter", func() {
 					Text:                "detailed text here",
 				})
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 		})
 
 		It("does not create a commit status or comment for snapshot with existing matching checkRun in running state", func() {
@@ -306,7 +306,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			statusCode, err := reporter.ReportStatus(context.TODO(), report)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		It("can get an existing commitStatus that matches the report", func() {
@@ -346,7 +346,7 @@ var _ = Describe("GitLabReporter", func() {
 			muxMergeNotesForListingNotes(mux, targetProjectID, mergeRequest)
 			statusCode, err := reporter.UpdateStatusInComment(commentPrefix, commentText, true)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(200))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		It("can create a new mergeRequest notes when there is no existing comment", func() {
@@ -358,7 +358,7 @@ var _ = Describe("GitLabReporter", func() {
 			muxMergeNotesForCreatingNote(mux, targetProjectID, mergeRequest, commentPrefix)
 			statusCode, err := reporter.UpdateStatusInComment(commentPrefix, commentText, true)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(201))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 		})
 	})
 	Context("when testing retry behavior", func() {
@@ -377,7 +377,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			savedBackoff = status.GetReporterRetryBackoff()
 			status.SetReporterRetryBackoff(wait.Backoff{
-				Steps:    5,
+				Steps:    3,
 				Duration: 1 * time.Millisecond,
 				Factor:   1.0,
 				Jitter:   0.0,
@@ -422,7 +422,7 @@ var _ = Describe("GitLabReporter", func() {
 			reporter = status.NewGitLabReporter(log, mockK8sClient)
 			statusCode, err := reporter.Initialize(context.TODO(), hasSnapshot)
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(0))
+			Expect(statusCode).To(Equal(http.StatusOK))
 		})
 
 		AfterEach(func() {
@@ -447,7 +447,7 @@ var _ = Describe("GitLabReporter", func() {
 					fmt.Fprintf(rw, `{"error": "unprocessable"}`)
 					return
 				}
-				rw.WriteHeader(http.StatusOK)
+				rw.WriteHeader(http.StatusCreated)
 				fmt.Fprintf(rw, `{"id": 1, "status": "success"}`)
 			})
 
@@ -465,7 +465,7 @@ var _ = Describe("GitLabReporter", func() {
 			})
 
 			Expect(err).To(Succeed())
-			Expect(statusCode).To(Equal(http.StatusOK))
+			Expect(statusCode).To(Equal(http.StatusCreated))
 			Expect(atomic.LoadInt32(&sourceCallCount)).To(BeNumerically("==", 2))
 			Expect(buf.String()).To(ContainSubstring("retrying to set gitlab commit status after transient error"))
 		})
@@ -560,7 +560,7 @@ var _ = Describe("GitLabReporter", func() {
 
 			Expect(err).To(HaveOccurred())
 			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
-			Expect(atomic.LoadInt32(&sourceCallCount)).To(BeNumerically("==", 5))
+			Expect(atomic.LoadInt32(&sourceCallCount)).To(BeNumerically("==", 3))
 			Expect(buf.String()).To(ContainSubstring("failed to set gitlab commit status after all retries"))
 		})
 	})
@@ -618,6 +618,7 @@ func muxCommitStatusPost(mux *http.ServeMux, pid string, sha string, catchStr st
 		if catchStr != "" {
 			Expect(s).To(ContainSubstring(catchStr))
 		}
+		rw.WriteHeader(http.StatusCreated)
 		fmt.Fprintf(rw, "{}")
 	})
 }


### PR DESCRIPTION
* retry 3 times in reporterRetryBackoff by default
* consider NotFound as unrecoverable error
* fix for incorrect return 200, nil when function succeeds
* try to set commitStatus to target project first since the commitStatus is shown on target project MR, if it fails, then   try to set commitStatus on source project
* handle the status status returned from setting commit status on target project and source project separately 

Assisted-by: Claude Code AI
Signed-off-by: Hongwei Liu hongliu@redhat.com

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
