### PR TITLE
fix: handle snapshots without integration status

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -593,6 +593,9 @@ func IsSnapshotError(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	if condition == nil {
 		condition = meta.FindStatusCondition(snapshot.Status.Conditions, LegacyIntegrationStatusCondition)
 	}
+	if condition == nil {
+		return false
+	}
 	if condition.Reason == AppStudioIntegrationStatusErrorOccured {
 		return true
 	}

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -396,6 +396,12 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(gitops.IsSnapshotError(hasSnapshot)).To(BeTrue())
 	})
 
+	It("returns false if the Snapshot has no integration status condition", func() {
+		snapshot := &applicationapiv1alpha1.Snapshot{}
+
+		Expect(gitops.IsSnapshotError(snapshot)).To(BeFalse())
+	})
+
 	It("ensures the Snapshots status can be marked as finished", func() {
 		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary
- return false from IsSnapshotError when neither the current nor legacy integration status condition exists
- add a regression test for snapshots without integration status conditions

## Testing
- KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.23 --bin-dir "$PWD/bin/envtest-binaries" -p path)" go test ./gitops
- KUBEBUILDER_ASSETS="$(./bin/setup-envtest use 1.23 --bin-dir "$PWD/bin/envtest-binaries" -p path)" go test ./...
- go vet ./...

Fixes #1495