### PR TITLE
fix(buildpipeline): prevent panic when component groups are empty

### DIFF
--- a/helpers/component_group_test.go
+++ b/helpers/component_group_test.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2026 Red Hat Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers_test
+
+import (
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ComponentGroup helpers", func() {
+	It("returns empty names for nil component groups", func() {
+		names := helpers.GetComponentGroupNames(nil)
+		Expect(names).To(BeEmpty())
+	})
+
+	It("returns names for non-empty component groups", func() {
+		componentGroups := []v1beta2.ComponentGroup{
+			{ObjectMeta: metav1.ObjectMeta{Name: "group-a"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "group-b"}},
+		}
+
+		names := helpers.GetComponentGroupNames(&componentGroups)
+		Expect(names).To(ConsistOf("group-a", "group-b"))
+	})
+})

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -81,6 +81,11 @@ func NewAdapterWithApplication(context context.Context, pipelineRun *tektonv1.Pi
 func NewAdapter(context context.Context, pipelineRun *tektonv1.PipelineRun, component *applicationapiv1alpha1.Component, componentGroups *[]v1beta2.ComponentGroup,
 	logger h.IntegrationLogger, loader loader.ObjectLoader, client client.Client,
 ) *Adapter {
+	if componentGroups == nil {
+		emptyComponentGroups := []v1beta2.ComponentGroup{}
+		componentGroups = &emptyComponentGroups
+	}
+
 	return &Adapter{
 		pipelineRun:     pipelineRun,
 		component:       component,
@@ -203,6 +208,15 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 	if _, found := a.pipelineRun.Annotations[tektonconsts.SnapshotNamesLabel]; found {
 		a.logger.Info("The build pipelineRun is already associated with existing Snapshot via annotation",
 			"snapshot.Name", a.pipelineRun.Annotations[tektonconsts.SnapshotNamesLabel])
+		canRemoveFinalizer = true
+		return controller.ContinueProcessing()
+	}
+
+	if a.componentGroups == nil || len(*a.componentGroups) == 0 {
+		a.logger.Info("no ComponentGroups found for component version; skipping Snapshot creation",
+			"pipelineRun.Namespace", a.pipelineRun.Namespace,
+			"pipelineRun.Name", a.pipelineRun.Name,
+			"component.Name", a.component.Name)
 		canRemoveFinalizer = true
 		return controller.ContinueProcessing()
 	}
@@ -480,6 +494,14 @@ func (a *Adapter) EnsureIntegrationTestReportedToGitProvider() (controller.Opera
 		return controller.ContinueProcessing()
 	}
 
+	if a.application == nil && (a.componentGroups == nil || len(*a.componentGroups) == 0) {
+		a.logger.Info("no ComponentGroups found for component version; skipping integration test status reporting",
+			"pipelineRun.Namespace", a.pipelineRun.Namespace,
+			"pipelineRun.Name", a.pipelineRun.Name,
+			"component.Name", a.component.Name)
+		return controller.ContinueProcessing()
+	}
+
 	integrationTestStatus := getIntegrationTestStatusFromBuildPLR(a.pipelineRun)
 
 	if integrationTestStatus == intgteststat.IntegrationTestStatus(0) {
@@ -562,6 +584,14 @@ func (a *Adapter) EnsurePRSnapshotAnnotatedForMergedPR() (controller.OperationRe
 
 	if metadata.HasAnnotationWithValue(a.pipelineRun, gitops.PRStatusAnnotation, gitops.PRStatusMerged) {
 		a.logger.Info("build pipelineRun PR status is annotated as merged, we consider component snapshots have been annotated as well")
+		return controller.ContinueProcessing()
+	}
+
+	if a.application == nil && (a.componentGroups == nil || len(*a.componentGroups) == 0) {
+		a.logger.Info("no ComponentGroups found for component version; skipping PR snapshot annotation",
+			"pipelineRun.Namespace", a.pipelineRun.Namespace,
+			"pipelineRun.Name", a.pipelineRun.Name,
+			"component.Name", a.component.Name)
 		return controller.ContinueProcessing()
 	}
 

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -634,6 +634,13 @@ func (a *Adapter) EnsureSupercededSnapshotsCanceled() (result controller.Operati
 	if a.application != nil {
 		snapshots, err = a.loader.GetAllPullSnapshotsForPR(a.context, a.client, a.application.ObjectMeta, a.component.Name, pr)
 	} else {
+		if a.componentGroups == nil || len(*a.componentGroups) == 0 {
+			a.logger.Info("no ComponentGroups found for component version; skipping superseded Snapshot cancellation",
+				"pipelineRun.Namespace", a.pipelineRun.Namespace,
+				"pipelineRun.Name", a.pipelineRun.Name,
+				"component.Name", a.component.Name)
+			return controller.ContinueProcessing()
+		}
 		// We only have to pass one ComponentGroup here.  The componentGroup is only used to get
 		// the namespace to search. Since all ComponentGroups have to belong to the same NS, we
 		// don't need to search with each ComponentGroup

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -2071,6 +2071,22 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		})
 
 		When("There is a snapshot currently being tested for that build pipeline", func() {
+			It("skips superseded snapshot cancellation when component groups are nil", func() {
+				buildPipelineRun.Status.SetCondition(&apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: "Unknown",
+				})
+				var buf bytes.Buffer
+				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, nil, log, loader.NewMockLoader(), k8sClient)
+
+				result, err := adapter.EnsureSupercededSnapshotsCanceled()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.CancelRequest).To(BeFalse())
+				Expect(result.RequeueRequest).To(BeFalse())
+				Expect(buf.String()).Should(ContainSubstring("no ComponentGroups found for component version; skipping superseded Snapshot cancellation"))
+			})
+
 			It("skips superseded snapshot cancellation when there are no component groups", func() {
 				buildPipelineRun.Status.SetCondition(&apis.Condition{
 					Type:   apis.ConditionSucceeded,

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -2071,6 +2071,23 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		})
 
 		When("There is a snapshot currently being tested for that build pipeline", func() {
+			It("skips superseded snapshot cancellation when there are no component groups", func() {
+				buildPipelineRun.Status.SetCondition(&apis.Condition{
+					Type:   apis.ConditionSucceeded,
+					Status: "Unknown",
+				})
+				emptyComponentGroups := []v1beta2.ComponentGroup{}
+				var buf bytes.Buffer
+				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+				adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &emptyComponentGroups, log, loader.NewMockLoader(), k8sClient)
+
+				result, err := adapter.EnsureSupercededSnapshotsCanceled()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.CancelRequest).To(BeFalse())
+				Expect(result.RequeueRequest).To(BeFalse())
+				Expect(buf.String()).Should(ContainSubstring("no ComponentGroups found for component version; skipping superseded Snapshot cancellation"))
+			})
+
 			It("Can cancel the snapshot", func() {
 				duplicateSnapshot := hasSnapshot.DeepCopy()
 				duplicateSnapshot.Name = "duplicate-snapshot"

--- a/loader/component_group_test.go
+++ b/loader/component_group_test.go
@@ -12,18 +12,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package helpers
 
-import "github.com/konflux-ci/integration-service/api/v1beta2"
+package loader
 
-func GetComponentGroupNames(componentGroups *[]v1beta2.ComponentGroup) []string {
-	if componentGroups == nil {
-		return []string{}
-	}
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
 
-	names := []string{}
-	for _, componentGroup := range *componentGroups {
-		names = append(names, componentGroup.Name)
-	}
-	return names
-}
+var _ = Describe("ComponentGroup loading", func() {
+	It("returns an empty scenario list for nil component groups", func() {
+		l := &loader{}
+		scenarios, err := l.GetAllIntegrationTestScenariosForComponentGroups(ctx, k8sClient, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(scenarios).NotTo(BeNil())
+		Expect(*scenarios).To(BeEmpty())
+	})
+})

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -295,6 +295,10 @@ func (l *loader) GetAllIntegrationTestScenariosForComponentGroup(ctx context.Con
 // GetAllIntegrationTestScenariosForComponentGroup returns all IntegrationTestScenarios used by all ComponentGroups in the list. No deduplication is required since an ITS can only belong to one ComponentGroup
 func (l *loader) GetAllIntegrationTestScenariosForComponentGroups(ctx context.Context, c client.Client, componentGroups *[]v1beta2.ComponentGroup) (*[]v1beta2.IntegrationTestScenario, error) {
 	scenarios := []v1beta2.IntegrationTestScenario{}
+	if componentGroups == nil {
+		return &scenarios, nil
+	}
+
 	for _, componentGroup := range *componentGroups {
 		items, err := l.GetAllIntegrationTestScenariosForComponentGroup(ctx, c, &componentGroup)
 		if err != nil {

--- a/snapshot/gcl.go
+++ b/snapshot/gcl.go
@@ -15,6 +15,10 @@ import (
 
 // updateGCLForBuildPLR updates global candidate list for component snapshots
 func UpdateGCLForBuildPLR(ctx context.Context, client client.Client, componentGroups *[]v1beta2.ComponentGroup, pipelineRun *tektonv1.PipelineRun, componentName string) error {
+	if componentGroups == nil {
+		return nil
+	}
+
 	containerImage, err := tekton.GetImagePullSpecFromPipelineRun(pipelineRun)
 	if err != nil {
 		return nil

--- a/snapshot/gcl_test.go
+++ b/snapshot/gcl_test.go
@@ -186,6 +186,11 @@ var _ = Describe("GCL manipulation functions", Ordered, func() {
 	})
 
 	Context("testing GCL entry update", func() {
+		It("handles nil component groups in build pipeline GCL update", func() {
+			err := UpdateGCLForBuildPLR(ctx, k8sClient, nil, buildPipelineRun, componentName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
 		When("an entry matching a componentVersion is added", func() {
 			BeforeAll(func() {
 				updatedComponentGroup = hasCompGroup.DeepCopy()


### PR DESCRIPTION
## Summary
- prevent panic in EnsureSupercededSnapshotsCanceled when componentGroups is nil or empty
- normalize nil componentGroups in NewAdapter and add no-group safeguards in:
  - EnsureSnapshotExists
  - EnsureIntegrationTestReportedToGitProvider
  - EnsurePRSnapshotAnnotatedForMergedPR
- make shared helpers nil-safe to eliminate downstream dereference risks:
  - helpers.GetComponentGroupNames
  - loader.GetAllIntegrationTestScenariosForComponentGroups
  - snapshot.UpdateGCLForBuildPLR
- add regression tests for nil and empty componentGroups paths

## Security Impact
This addresses the controller panic DoS vector and hardens related code paths to prevent similar nil dereference panics during reconciliation.

## Validation
- go test ./internal/controller/buildpipeline -run "Pipeline Adapter" -count=1 (package compile check; ginkgo selection does not run individual specs by name)
- full envtest suites could not run here due missing /usr/local/kubebuilder/bin/etcd

## Notes
- change remains scoped to panic-safety and no-group guardrails
- unrelated local documentation changes were not included in this PR
