### PR TITLE
fix(KONFLUX-13098): honour auto-release=false

### DIFF
--- a/gitops/release.go
+++ b/gitops/release.go
@@ -39,6 +39,10 @@ func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *app
 		return false, nil
 	}
 
+	if IsSnapshotAutoReleaseDisabled(snapshot) {
+		return false, nil
+	}
+
 	// Convert snapshot to a JSON-like map so field selections like
 	// snapshot.metadata.creationTimestamp work naturally with CEL and
 	// to allow custom functions to access the snapshot contents.

--- a/gitops/release_test.go
+++ b/gitops/release_test.go
@@ -119,6 +119,17 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 		Expect(allowed).To(BeFalse())
 	})
 
+	It("returns false when the snapshot has auto-release label false even if the expression is true", func() {
+		snapshotCopy := hasSnapshot.DeepCopy()
+		if snapshotCopy.Labels == nil {
+			snapshotCopy.Labels = make(map[string]string)
+		}
+		snapshotCopy.Labels[gitops.AutoReleaseLabel] = "false"
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("true", snapshotCopy, true)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(allowed).To(BeFalse())
+	})
+
 	Context("shouldRelease() CEL function", func() {
 		It("returns true when shouldRelease is true", func() {
 			snapshotCopy := hasSnapshot.DeepCopy()

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -771,6 +771,7 @@ func CanSnapshotBePromoted(snapshot *applicationapiv1alpha1.Snapshot) (bool, []s
 			reasons = append(reasons, "the Snapshot was created for a PaC pull request event")
 		}
 		if IsSnapshotAutoReleaseDisabled(snapshot) {
+			canBePromoted = false
 			reasons = append(reasons, fmt.Sprintf("the Snapshot '%s' label is 'false'", AutoReleaseLabel))
 		}
 		if IsGroupSnapshot(snapshot) {

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -769,7 +769,35 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		canBePromoted, reasons = gitops.CanSnapshotBePromoted(hasSnapshot)
 		Expect(canBePromoted).To(BeFalse())
 		Expect(reasons).To(HaveLen(3))
+	})
 
+	It("promotes the Snapshot when auto-release label is true", func() {
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
+		Expect(err).ToNot(HaveOccurred())
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "Test message")
+		Expect(err).ToNot(HaveOccurred())
+
+		snapshotCopy := hasSnapshot.DeepCopy()
+		snapshotCopy.Labels[gitops.AutoReleaseLabel] = "true"
+		canBePromoted, reasons := gitops.CanSnapshotBePromoted(snapshotCopy)
+
+		Expect(canBePromoted).To(BeTrue())
+		Expect(reasons).To(BeEmpty())
+	})
+
+	It("does not promote the Snapshot when auto-release label is false even if otherwise eligible", func() {
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
+		Expect(err).ToNot(HaveOccurred())
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "Test message")
+		Expect(err).ToNot(HaveOccurred())
+
+		snapshotCopy := hasSnapshot.DeepCopy()
+		snapshotCopy.Labels[gitops.AutoReleaseLabel] = "false"
+		canBePromoted, reasons := gitops.CanSnapshotBePromoted(snapshotCopy)
+
+		Expect(canBePromoted).To(BeFalse())
+		Expect(reasons).To(HaveLen(1))
+		Expect(reasons[0]).To(Equal("the Snapshot '" + gitops.AutoReleaseLabel + "' label is 'false'"))
 	})
 
 	It("Return false when the image url contains invalid digest", func() {


### PR DESCRIPTION
 - set canBePromoted = false when release.appstudio.openshift.io/auto-release is false in CanSnapshotBePromoted()
 - Fix GetAutoReleasePlansForApplication() so CEL results append release plans when err == nil && canRelease
 - improve EvaluateSnapshotAutoReleaseAnnotation() 
 - unit tests added

asisted by AI - Cursor IDE ask mode

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
