### PR TITLE
feat(STONEINTG-1349): implement ComponentGroup webhook

### DIFF
--- a/api/v1beta2/componentgroup_types.go
+++ b/api/v1beta2/componentgroup_types.go
@@ -97,12 +97,11 @@ type TestGraphNode struct {
 	// +required
 	Name string `json:"name"`
 
-	// OnFail defines how to behave if this IntegrationTestScenario fails.
-	// Options: "run" (default) - continue running dependent tests, "skip" - skip dependent tests
-	// +kubebuilder:validation:Enum=run;skip
-	// +kubebuilder:default=run
+	// FailFast defines how to behave if this IntegrationTestScenario fails.
+	// If true, skip dependent tests.  If false, continue running dependent tests
+	// +kubebuilder:default=false
 	// +optional
-	OnFail string `json:"onFail,omitempty"`
+	FailFast bool `json:"failFast,omitempty"`
 }
 
 // SnapshotCreatorSpec defines custom logic for creating snapshots.

--- a/api/v1beta2/componentgroup_types_test.go
+++ b/api/v1beta2/componentgroup_types_test.go
@@ -56,11 +56,11 @@ func TestComponentGroupSpec(t *testing.T) {
 			TestGraph: map[string][]TestGraphNode{
 				"verify": {
 					{Name: "clamav-scan"},
-					{Name: "dast-tests", OnFail: "skip"},
+					{Name: "dast-tests", FailFast: true},
 					{Name: "operator-scorecard"},
 				},
 				"e2e-test": {
-					{Name: "clamav-scan", OnFail: "run"},
+					{Name: "clamav-scan", FailFast: false},
 				},
 			},
 		},
@@ -132,8 +132,8 @@ func TestComponentGroupSpec(t *testing.T) {
 	if len(cg.Spec.TestGraph["verify"]) != 3 {
 		t.Errorf("Expected 3 nodes in 'verify' graph, got %d", len(cg.Spec.TestGraph["verify"]))
 	}
-	if cg.Spec.TestGraph["verify"][1].OnFail != "skip" {
-		t.Errorf("Expected OnFail 'skip', got '%s'", cg.Spec.TestGraph["verify"][1].OnFail)
+	if cg.Spec.TestGraph["verify"][1].FailFast != true {
+		t.Errorf("Expected FailFast 'true', got '%t'", cg.Spec.TestGraph["verify"][1].FailFast)
 	}
 
 	if len(cg.Status.GlobalCandidateList) != 2 {
@@ -321,21 +321,21 @@ func TestComponentGroupListDeepCopy(t *testing.T) {
 	}
 }
 
-func TestTestGraphNodeOnFailDefault(t *testing.T) {
+func TestTestGraphNodeFailFastDefault(t *testing.T) {
 	node := TestGraphNode{
 		Name: "test-scenario",
 	}
-	// OnFail should be empty string when not set (default in CRD is "run")
-	if node.OnFail != "" {
-		t.Errorf("Expected empty OnFail, got '%s'", node.OnFail)
+	// FailFast should be false when not set
+	if node.FailFast != false {
+		t.Errorf("Expected false FailFast, got '%t'", node.FailFast)
 	}
 
-	nodeWithOnFail := TestGraphNode{
-		Name:   "test-scenario",
-		OnFail: "skip",
+	nodeWithFailFast := TestGraphNode{
+		Name:     "test-scenario",
+		FailFast: true,
 	}
-	if nodeWithOnFail.OnFail != "skip" {
-		t.Errorf("Expected OnFail 'skip', got '%s'", nodeWithOnFail.OnFail)
+	if nodeWithFailFast.FailFast != true {
+		t.Errorf("Expected FailFast 'true', got '%t'", nodeWithFailFast.FailFast)
 	}
 }
 
@@ -362,7 +362,7 @@ func TestComponentGroupSpecDeepCopy(t *testing.T) {
 		},
 		Dependents: []string{"dep-1"},
 		TestGraph: map[string][]TestGraphNode{
-			"test-1": {{Name: "node-1", OnFail: "skip"}},
+			"test-1": {{Name: "node-1", FailFast: true}},
 		},
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,6 +174,10 @@ func main() {
 		setupLog.Error(err, "unable to setup controllers")
 		os.Exit(1)
 	}
+	if err = iswebhook.SetupComponentGroupWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "ComponentGroup")
+		os.Exit(1)
+	}
 	if err = iswebhook.SetupIntegrationTestScenarioWebhookWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "IntegrationTestScenario")
 		os.Exit(1)

--- a/config/crd/bases/appstudio.redhat.com_componentgroups.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentgroups.yaml
@@ -139,17 +139,14 @@ spec:
                     description: TestGraphNode represents a node in the test serialization
                       graph
                     properties:
+                      failFast:
+                        default: false
+                        description: |-
+                          FailFast defines how to behave if this IntegrationTestScenario fails.
+                          If true, skip dependent tests.  If false, continue running dependent tests
+                        type: boolean
                       name:
                         description: Name is the name of the IntegrationTestScenario
-                        type: string
-                      onFail:
-                        default: run
-                        description: |-
-                          OnFail defines how to behave if this IntegrationTestScenario fails.
-                          Options: "run" (default) - continue running dependent tests, "skip" - skip dependent tests
-                        enum:
-                        - run
-                        - skip
                         type: string
                     required:
                     - name

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -31,6 +31,7 @@ rules:
   - appstudio.redhat.com
   resources:
   - applications/finalizers
+  - componentgroups/finalizers
   - components/finalizers
   - snapshots/finalizers
   verbs:
@@ -39,22 +40,12 @@ rules:
   - appstudio.redhat.com
   resources:
   - applications/status
-  - componentgroups/status
   verbs:
   - get
 - apiGroups:
   - appstudio.redhat.com
   resources:
   - componentgroups
-  - environments
-  - releaseplans
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - appstudio.redhat.com
-  resources:
   - components
   verbs:
   - get
@@ -65,6 +56,7 @@ rules:
 - apiGroups:
   - appstudio.redhat.com
   resources:
+  - componentgroups/status
   - components/status
   - environments/status
   - integrationtestscenarios/status
@@ -75,6 +67,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - environments
+  - releaseplans
+  verbs:
+  - get
+  - list
+  - watch
 - apiGroups:
   - pipelinesascode.tekton.dev
   resources:

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -56,6 +56,27 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-appstudio-redhat-com-v1beta2-componentgroup
+  failurePolicy: Fail
+  name: vcomponentgroup.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    - DELETE
+    resources:
+    - componentgroups
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-appstudio-redhat-com-v1beta2-integrationtestscenario
   failurePolicy: Fail
   name: vintegrationtestscenario.kb.io

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -47,6 +47,27 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 webhooks:
+  - name: vcomponentgroup.kb.io
+    clientConfig:
+      service:
+        name: integration-service-webhook-service
+        namespace: {{ .Values.namespace | default .Release.Namespace }}
+        path: /validate-appstudio-redhat-com-v1beta2-componentgroup
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+          - DELETE
+        apiGroups:
+          - appstudio.redhat.com
+        apiVersions:
+          - v1beta2
+        resources:
+          - componentgroups
   - name: vintegrationtestscenario.kb.io
     clientConfig:
       service:

--- a/helpers/component_group.go
+++ b/helpers/component_group.go
@@ -14,7 +14,11 @@ limitations under the License.
 */
 package helpers
 
-import "github.com/konflux-ci/integration-service/api/v1beta2"
+import (
+	"fmt"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+)
 
 func GetComponentGroupNames(componentGroups *[]v1beta2.ComponentGroup) []string {
 	names := []string{}
@@ -22,4 +26,12 @@ func GetComponentGroupNames(componentGroups *[]v1beta2.ComponentGroup) []string 
 		names = append(names, componentGroup.Name)
 	}
 	return names
+}
+
+func GetComponentVersionLogString(name, version string) string {
+	return fmt.Sprintf("%s (version %s)", name, version)
+}
+
+func GetComponentVersionString(name, version string) string {
+	return fmt.Sprintf("%s/%s", name, version)
 }

--- a/helpers/component_group_test.go
+++ b/helpers/component_group_test.go
@@ -14,23 +14,32 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package snapshot
+package helpers
 
 import (
-	"unicode"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
+const (
+	name    = "component"
+	version = "v1"
+)
+
 var _ = Describe("Utility functions", Ordered, func() {
-	Context("Validating generateRandomSuffix", func() {
-		It("Can generate a suffix", func() {
-			suffix, err := generateRandomSuffix()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(suffix).To(HaveLen(2))
-			Expect(unicode.IsDigit(rune(suffix[0])) || unicode.IsLower(rune(suffix[0]))).To(BeTrue())
-			Expect(unicode.IsDigit(rune(suffix[1])) || unicode.IsLower(rune(suffix[1]))).To(BeTrue())
+	Context("Validating component version strings", func() {
+		It("Can generate a valid component version string", func() {
+			expectedResult := fmt.Sprintf("%s/%s", name, version)
+			result := GetComponentVersionString(name, version)
+			Expect(result).To(Equal(expectedResult))
+		})
+
+		It("Can generate a valid component version log string", func() {
+			expectedResult := fmt.Sprintf("%s (version %s)", name, version)
+			result := GetComponentVersionLogString(name, version)
+			Expect(result).To(Equal(expectedResult))
 		})
 	})
 })

--- a/internal/controller/componentgroup/componentgroup_adapter.go
+++ b/internal/controller/componentgroup/componentgroup_adapter.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentgroup
+
+import (
+	"context"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	h "github.com/konflux-ci/integration-service/helpers"
+	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/operator-toolkit/controller"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// Adapter holds the objects needed to reconcile a ComponentGroup.
+type Adapter struct {
+	componentGroup *v1beta2.ComponentGroup
+	logger         h.IntegrationLogger
+	loader         loader.ObjectLoader
+	client         client.Client
+	context        context.Context
+}
+
+// NewAdapter creates and returns an Adapter instance.
+func NewAdapter(
+	ctx context.Context,
+	componentGroup *v1beta2.ComponentGroup,
+	logger h.IntegrationLogger,
+	loader loader.ObjectLoader,
+	client client.Client,
+) *Adapter {
+	return &Adapter{
+		componentGroup: componentGroup,
+		logger:         logger,
+		loader:         loader,
+		client:         client,
+		context:        ctx,
+	}
+}
+
+// EnsureGCLAlignedWithSpecComponents ensures the GlobalCandidateList in the ComponentGroup status
+// reflects the components declared in spec.components.
+func (a *Adapter) EnsureGCLAlignedWithSpecComponents() (controller.OperationResult, error) {
+	retryError := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		cg, err := a.loader.GetComponentGroup(a.context, a.client, a.componentGroup.Name, a.componentGroup.Namespace)
+		if err != nil {
+			return err
+		}
+		err = a.alignGCLWithSpecComponents(cg)
+		return err
+	})
+	if retryError != nil {
+		return controller.OperationResult{}, retryError
+	}
+	return controller.ContinueProcessing()
+}
+
+// alignGCLWithSpecComponents aligns the GCL with the spec.components for the given componentGroup.  Uses optimistic locking
+// to avoid conflicts.
+// If items are added to spec.Components their ComponentVersion will be added to the GCL. Image, commit, and build time will be
+// gathered from the build pipeline the next time an on-push pipeline for this componentversion completes. If items are removed from
+// spec.Components their ComponentVersion will be removed from the GCL.
+func (a *Adapter) alignGCLWithSpecComponents(mostRecentComponentGroup *v1beta2.ComponentGroup) error {
+	a.logger.Info("Aligning GCL with spec.components")
+
+	patch := client.MergeFromWithOptions(mostRecentComponentGroup.DeepCopy(), client.MergeFromWithOptimisticLock{})
+	gclComponents := make(map[string]v1beta2.ComponentState)
+
+	// Add existing components to GCL
+	for _, component := range mostRecentComponentGroup.Status.GlobalCandidateList {
+		componentVersion := h.GetComponentVersionString(component.Name, component.Version)
+		gclComponents[componentVersion] = component
+	}
+
+	var newGCL []v1beta2.ComponentState
+
+	for _, component := range mostRecentComponentGroup.Spec.Components {
+		componentVersion := h.GetComponentVersionString(component.Name, component.ComponentVersion.Name)
+		if existingComponent, ok := gclComponents[componentVersion]; ok {
+			newGCL = append(newGCL, existingComponent)
+		} else {
+			// Create a new ComponentState for the componentVersion
+			// All other fields are gathered from build pipeline the next time
+			// an on-push pipeline for this componentversion completes
+			newComponentState := v1beta2.ComponentState{
+				Name:    component.Name,
+				Version: component.ComponentVersion.Name,
+			}
+			newGCL = append(newGCL, newComponentState)
+		}
+	}
+
+	mostRecentComponentGroup.Status.GlobalCandidateList = newGCL
+	err := a.client.Status().Patch(a.context, mostRecentComponentGroup, patch)
+	return err
+}

--- a/internal/controller/componentgroup/componentgroup_adapter_test.go
+++ b/internal/controller/componentgroup/componentgroup_adapter_test.go
@@ -1,0 +1,203 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentgroup
+
+import (
+	"bytes"
+	"reflect"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tonglil/buflogr"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/helpers"
+	"github.com/konflux-ci/integration-service/loader"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("ComponentGroup Adapter", Ordered, func() {
+	var (
+		adapter        *Adapter
+		logger         helpers.IntegrationLogger
+		componentGroup *v1beta2.ComponentGroup
+	)
+
+	const (
+		SampleImage = "quay.io/example/image@sha256:abc123def456"
+	)
+
+	// fetchFreshCG retrieves the latest version of componentGroup from the cluster,
+	// which is required to have a correct ResourceVersion for optimistic-lock patches.
+	fetchFreshCG := func() *v1beta2.ComponentGroup {
+		fresh := &v1beta2.ComponentGroup{}
+		Eventually(func() error {
+			return k8sClient.Get(ctx, client.ObjectKeyFromObject(componentGroup), fresh)
+		}, time.Second*10).Should(Succeed())
+		return fresh
+	}
+
+	// setGCL overwrites the GCL status on the cluster and waits for it to be visible.
+	setGCL := func(entries []v1beta2.ComponentState) {
+		cg := fetchFreshCG()
+		cg.Status.GlobalCandidateList = entries
+		Expect(k8sClient.Status().Update(ctx, cg)).To(Succeed())
+		newRV := cg.ResourceVersion // Updated in-place by the client after a successful write
+
+		// Wait for the informer cache to reflect the exact ResourceVersion written above.
+		// Checking only HaveLen is insufficient when entries is empty, because the cache
+		// may satisfy HaveLen(0) with a stale pre-update entry, causing fetchFreshCG() to
+		// return a stale ResourceVersion and triggering a 409 conflict on the subsequent patch.
+		Eventually(func(g Gomega) {
+			updated := &v1beta2.ComponentGroup{}
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(componentGroup), updated)).To(Succeed())
+			g.Expect(updated.ResourceVersion).To(Equal(newRV))
+			g.Expect(updated.Status.GlobalCandidateList).To(HaveLen(len(entries)))
+		}, time.Second*10).Should(Succeed())
+	}
+
+	BeforeAll(func() {
+		logger = helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&bytes.Buffer{})}
+
+		componentGroup = &v1beta2.ComponentGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-component-group",
+				Namespace: "default",
+			},
+			Spec: v1beta2.ComponentGroupSpec{
+				Components: []v1beta2.ComponentReference{
+					{
+						Name: "comp-a",
+						ComponentVersion: v1beta2.ComponentVersionReference{
+							Name: "main",
+						},
+					},
+					{
+						Name: "comp-b",
+						ComponentVersion: v1beta2.ComponentVersionReference{
+							Name: "v1",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, componentGroup)).Should(Succeed())
+	})
+
+	AfterAll(func() {
+		err := k8sClient.Delete(ctx, componentGroup)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("can create a new Adapter instance", func() {
+		Expect(reflect.TypeOf(NewAdapter(ctx, componentGroup, logger, loader.NewMockLoader(), k8sClient))).
+			To(Equal(reflect.TypeOf(&Adapter{})))
+	})
+
+	When("alignGCLWithSpecComponents is called with an empty GCL", func() {
+		BeforeEach(func() {
+			setGCL([]v1beta2.ComponentState{})
+			adapter = NewAdapter(ctx, componentGroup, logger, loader.NewMockLoader(), k8sClient)
+		})
+
+		It("adds a GCL entry for every component in spec.components", func() {
+			Expect(adapter.alignGCLWithSpecComponents(fetchFreshCG())).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &v1beta2.ComponentGroup{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(componentGroup), updated)).To(Succeed())
+				g.Expect(updated.Status.GlobalCandidateList).To(HaveLen(2))
+				g.Expect(updated.Status.GlobalCandidateList[0].Name).To(Equal("comp-a"))
+				g.Expect(updated.Status.GlobalCandidateList[0].Version).To(Equal("main"))
+				g.Expect(updated.Status.GlobalCandidateList[0].LastPromotedImage).To(BeEmpty())
+				g.Expect(updated.Status.GlobalCandidateList[1].Name).To(Equal("comp-b"))
+				g.Expect(updated.Status.GlobalCandidateList[1].Version).To(Equal("v1"))
+				g.Expect(updated.Status.GlobalCandidateList[1].LastPromotedImage).To(BeEmpty())
+			}, time.Second*10).Should(Succeed())
+		})
+	})
+
+	When("alignGCLWithSpecComponents is called with a GCL entry that matches a spec component", func() {
+		BeforeEach(func() {
+			setGCL([]v1beta2.ComponentState{
+				{Name: "comp-a", Version: "main", LastPromotedImage: SampleImage},
+			})
+			adapter = NewAdapter(ctx, componentGroup, logger, loader.NewMockLoader(), k8sClient)
+		})
+
+		It("preserves the existing image data for the matching entry", func() {
+			Expect(adapter.alignGCLWithSpecComponents(fetchFreshCG())).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &v1beta2.ComponentGroup{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(componentGroup), updated)).To(Succeed())
+				g.Expect(updated.Status.GlobalCandidateList).To(HaveLen(2))
+
+				compA := updated.Status.GlobalCandidateList[0]
+				g.Expect(compA.Name).To(Equal("comp-a"))
+				g.Expect(compA.LastPromotedImage).To(Equal(SampleImage))
+
+				compB := updated.Status.GlobalCandidateList[1]
+				g.Expect(compB.Name).To(Equal("comp-b"))
+				g.Expect(compB.LastPromotedImage).To(BeEmpty())
+			}, time.Second*10).Should(Succeed())
+		})
+	})
+
+	When("alignGCLWithSpecComponents is called with a GCL entry for a component no longer in spec", func() {
+		BeforeEach(func() {
+			setGCL([]v1beta2.ComponentState{
+				{Name: "comp-a", Version: "main", LastPromotedImage: SampleImage},
+				{Name: "comp-b", Version: "v1"},
+				{Name: "comp-c", Version: "main"}, // not in spec.components
+			})
+			adapter = NewAdapter(ctx, componentGroup, logger, loader.NewMockLoader(), k8sClient)
+		})
+
+		It("removes the stale entry from the GCL", func() {
+			Expect(adapter.alignGCLWithSpecComponents(fetchFreshCG())).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &v1beta2.ComponentGroup{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(componentGroup), updated)).To(Succeed())
+				g.Expect(updated.Status.GlobalCandidateList).To(HaveLen(2))
+				names := []string{
+					updated.Status.GlobalCandidateList[0].Name,
+					updated.Status.GlobalCandidateList[1].Name,
+				}
+				g.Expect(names).NotTo(ContainElement("comp-c"))
+			}, time.Second*10).Should(Succeed())
+		})
+	})
+
+	When("EnsureGCLAlignedWithSpecComponents is called", func() {
+		BeforeEach(func() {
+			adapter = NewAdapter(ctx, componentGroup, logger, loader.NewLoader(), k8sClient)
+		})
+
+		It("returns ContinueProcessing without error", func() {
+			result, err := adapter.EnsureGCLAlignedWithSpecComponents()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+		})
+	})
+})

--- a/internal/controller/componentgroup/componentgroup_controller.go
+++ b/internal/controller/componentgroup/componentgroup_controller.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentgroup
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/go-logr/logr"
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/helpers"
+	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/operator-toolkit/controller"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// Reconciler reconciles a ComponentGroup object.
+type Reconciler struct {
+	client.Client
+	Log    logr.Logger
+	Scheme *runtime.Scheme
+}
+
+// NewComponentGroupReconciler creates and returns a Reconciler.
+func NewComponentGroupReconciler(client client.Client, logger *logr.Logger, scheme *runtime.Scheme) *Reconciler {
+	return &Reconciler{
+		Client: client,
+		Log:    logger.WithName("componentgroup"),
+		Scheme: scheme,
+	}
+}
+
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups,verbs=get;list;watch;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups/finalizers,verbs=update
+
+// Reconcile is part of the main kubernetes reconciliation loop which aims to
+// move the current state of the cluster closer to the desired state.
+func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	logger := helpers.IntegrationLogger{Logger: r.Log.WithValues("componentgroup", req.NamespacedName)}
+	loader := loader.NewLoader()
+
+	componentGroup := &v1beta2.ComponentGroup{}
+	err := r.Get(ctx, req.NamespacedName, componentGroup)
+	if err != nil {
+		logger.Error(err, "Failed to get ComponentGroup for", "req", req.NamespacedName)
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, err
+	}
+
+	adapter := NewAdapter(ctx, componentGroup, logger, loader, r.Client)
+
+	return controller.ReconcileHandler([]controller.Operation{
+		adapter.EnsureGCLAlignedWithSpecComponents,
+	})
+}
+
+// AdapterInterface is an interface defining all the operations that should be defined in a ComponentGroup adapter.
+type AdapterInterface interface {
+	EnsureGCLAlignedWithSpecComponents() (controller.OperationResult, error)
+}
+
+// SetupController creates a new ComponentGroup controller and adds it to the Manager.
+func SetupController(manager ctrl.Manager, log *logr.Logger) error {
+	return setupControllerWithManager(manager, NewComponentGroupReconciler(manager.GetClient(), log, manager.GetScheme()))
+}
+
+// setupControllerWithManager sets up the controller with the Manager which monitors ComponentGroups
+// and filters events to only create events and spec.components updates.
+func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) error {
+	return ctrl.NewControllerManagedBy(manager).
+		For(&v1beta2.ComponentGroup{}).
+		Named("componentgroup").
+		WithEventFilter(predicate.Or(
+			componentGroupCreatedPredicate(),
+			componentGroupSpecComponentsChangedPredicate(),
+		)).
+		Complete(controller)
+}
+
+// componentGroupCreatedPredicate returns a predicate that passes only for ComponentGroup create events.
+func componentGroupCreatedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return true
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+	}
+}
+
+// componentGroupSpecComponentsChangedPredicate returns a predicate that passes only when
+// spec.components has changed on an update event.
+func componentGroupSpecComponentsChangedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldCG, ok1 := e.ObjectOld.(*v1beta2.ComponentGroup)
+			newCG, ok2 := e.ObjectNew.(*v1beta2.ComponentGroup)
+			if !ok1 || !ok2 {
+				return false
+			}
+			return !reflect.DeepEqual(oldCG.Spec.Components, newCG.Spec.Components)
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+	}
+}

--- a/internal/controller/componentgroup/componentgroup_suite_test.go
+++ b/internal/controller/componentgroup/componentgroup_suite_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2024 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package componentgroup
+
+import (
+	"context"
+	"go/build"
+	"path/filepath"
+	"testing"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	toolkit "github.com/konflux-ci/operator-toolkit/test"
+	releasev1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
+)
+
+var (
+	cfg       *rest.Config
+	k8sClient client.Client
+	testEnv   *envtest.Environment
+	ctx       context.Context
+	cancel    context.CancelFunc
+)
+
+func TestControllerComponentGroup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "ComponentGroup Controller Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+	ctx, cancel = context.WithCancel(context.TODO())
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths: []string{
+			filepath.Join("..", "..", "..", "config", "crd", "bases"),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("tektoncd/pipeline"), "config",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("tektoncd/pipeline"), "config", "300-crds",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("application-api"),
+				"config", "crd", "bases",
+			),
+			filepath.Join(
+				build.Default.GOPATH,
+				"pkg", "mod", toolkit.GetRelativeDependencyPath("release-service"), "config", "crd", "bases",
+			),
+		},
+		ErrorIfCRDPathMissing: true,
+	}
+
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+
+	Expect(applicationapiv1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(tektonv1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(releasev1alpha1.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+	Expect(v1beta2.AddToScheme(clientsetscheme.Scheme)).To(Succeed())
+
+	k8sManager, _ := ctrl.NewManager(cfg, ctrl.Options{
+		Scheme: clientsetscheme.Scheme,
+		Metrics: server.Options{
+			BindAddress: "0",
+		},
+		LeaderElection: false,
+	})
+
+	k8sClient = k8sManager.GetClient()
+	go func() {
+		defer GinkgoRecover()
+		Expect(k8sManager.Start(ctx)).To(Succeed())
+	}()
+})
+
+var _ = AfterSuite(func() {
+	cancel()
+	By("tearing down the test environment")
+	err := testEnv.Stop()
+	Expect(err).NotTo(HaveOccurred())
+})

--- a/internal/controller/controllers.go
+++ b/internal/controller/controllers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/konflux-ci/integration-service/internal/controller/buildpipeline"
 	"github.com/konflux-ci/integration-service/internal/controller/component"
+	"github.com/konflux-ci/integration-service/internal/controller/componentgroup"
 	"github.com/konflux-ci/integration-service/internal/controller/integrationpipeline"
 	"github.com/konflux-ci/integration-service/internal/controller/snapshot"
 	"github.com/konflux-ci/integration-service/internal/controller/statusreport"
@@ -35,6 +36,7 @@ var setupFunctions = []func(manager.Manager, *logr.Logger) error{
 	//scenario.SetupController,
 	statusreport.SetupController,
 	component.SetupController,
+	componentgroup.SetupController,
 }
 
 // SetupControllers invoke all SetupController functions defined in setupFunctions, setting all controllers up and

--- a/internal/webhook/v1beta2/componentgroup_webhook.go
+++ b/internal/webhook/v1beta2/componentgroup_webhook.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"reflect"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/pkg/dag"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	"context"
+	"fmt"
+)
+
+// nolint:unused
+// log is for logging in this package.
+var componentgrouplog = logf.Log.WithName("componentgroup-webhook")
+
+func SetupComponentGroupWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1beta2.ComponentGroup{}).
+		WithValidator(&ComponentGroupCustomValidator{Client: mgr.GetClient()}).
+		Complete()
+}
+
+// ComponentGroupCustomValidator is a webhook handler and does not need deepcopy methods. (validator = validating webhook)
+// +k8s:deepcopy-gen=false
+type ComponentGroupCustomValidator struct {
+	Client client.Client
+	// TODO(user): Add more fields as needed for validation
+}
+
+// +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1beta2-componentgroup,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=componentgroups,verbs=create;update;delete,versions=v1beta2,name=vcomponentgroup.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomValidator = &ComponentGroupCustomValidator{}
+
+// ValidateCreate implements webhook.Validator so a webhook will be registered for the type
+func (v *ComponentGroupCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (warnings admission.Warnings, err error) {
+	// Validate testGraph
+	componentGroup, ok := obj.(*v1beta2.ComponentGroup)
+	if !ok {
+		return nil, fmt.Errorf("expected a ComponentGroup object but got %T", obj)
+	}
+
+	componentgrouplog.Info("Validating created component")
+	if componentGroup.Spec.TestGraph != nil {
+		err := dag.ValidateTestGraph(componentGroup.Spec.TestGraph)
+		if err != nil {
+			return nil, fmt.Errorf("error validating test graph: %v", err)
+		}
+	}
+	return nil, nil
+}
+
+// ValidateUpdate implements webhook.Validator so a webhook will be registered for the type
+func (v *ComponentGroupCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (warnings admission.Warnings, err error) {
+	// If testGraph is updated, validate testGraph
+	oldComponentGroup, ok := oldObj.(*v1beta2.ComponentGroup)
+	if !ok {
+		return nil, fmt.Errorf("expected a ComponentGroup for oldObj but got %T", oldObj)
+	}
+	newComponentGroup, ok := newObj.(*v1beta2.ComponentGroup)
+	if !ok {
+		return nil, fmt.Errorf("expected a ComponentGroup for newObj but got %T", newObj)
+	}
+
+	componentgrouplog.Info("Validating updated component")
+	if !reflect.DeepEqual(oldComponentGroup.Spec.TestGraph, newComponentGroup.Spec.TestGraph) {
+		componentgrouplog.Info("Validating updated test graph")
+		err := dag.ValidateTestGraph(newComponentGroup.Spec.TestGraph)
+		if err != nil {
+			return nil, fmt.Errorf("error validating test graph: %v", err)
+		}
+	}
+
+	return nil, nil
+}
+
+// ValidateDelete implements webhook.Validator so a webhook will be registered for the type
+func (v *ComponentGroupCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhook/v1beta2/componentgroup_webhook_test.go
+++ b/internal/webhook/v1beta2/componentgroup_webhook_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	appstudiov1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("ComponentGroup webhook", Ordered, func() {
+	var (
+		validator        *ComponentGroupCustomValidator
+		componentGroup   *appstudiov1beta2.ComponentGroup
+		validTestGraph   map[string][]appstudiov1beta2.TestGraphNode
+		invalidTestGraph map[string][]appstudiov1beta2.TestGraphNode
+	)
+
+	BeforeAll(func() {
+		// A   E
+		//  \ / \
+		//   C   B
+		//       |
+		//       D
+		validTestGraph = map[string][]appstudiov1beta2.TestGraphNode{
+			"scenarioA": {},
+			"scenarioE": {},
+			"scenarioB": {{Name: "scenarioE"}},
+			"scenarioC": {{Name: "scenarioA"}, {Name: "scenarioE"}},
+			"scenarioD": {{Name: "scenarioB"}},
+		}
+
+		// Cycle: scenarioC -> scenarioE -> scenarioC
+		invalidTestGraph = map[string][]appstudiov1beta2.TestGraphNode{
+			"scenarioA": {},
+			"scenarioB": {{Name: "scenarioA"}},
+			"scenarioC": {{Name: "scenarioA"}, {Name: "scenarioE"}},
+			"scenarioD": {{Name: "scenarioB"}},
+			"scenarioE": {{Name: "scenarioC"}},
+		}
+	})
+
+	BeforeEach(func() {
+		validator = &ComponentGroupCustomValidator{Client: k8sClient}
+		componentGroup = &appstudiov1beta2.ComponentGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-component-group",
+				Namespace: "default",
+			},
+			Spec: appstudiov1beta2.ComponentGroupSpec{
+				Components: []appstudiov1beta2.ComponentReference{
+					{
+						Name: "component-a",
+						ComponentVersion: appstudiov1beta2.ComponentVersionReference{
+							Name:     "main",
+							Revision: "abc123",
+						},
+					},
+					{
+						Name: "component-b",
+						ComponentVersion: appstudiov1beta2.ComponentVersionReference{
+							Name:     "v1",
+							Revision: "def456",
+						},
+					},
+				},
+			},
+		}
+	})
+
+	When("a new component is created", func() {
+		It("Does not return an error for a valid test graph", func() {
+			componentGroup.Spec.TestGraph = validTestGraph
+			warnings, err := validator.ValidateCreate(ctx, componentGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("Returns an error for an invalid test graph", func() {
+			componentGroup.Spec.TestGraph = invalidTestGraph
+			_, err := validator.ValidateCreate(ctx, componentGroup)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error validating test graph: invalid TestGraph - cycle detected"))
+		})
+	})
+
+	When("a component is updated", func() {
+		It("Does not return an error for a valid test graph", func() {
+
+			componentGroup.Spec.TestGraph = validTestGraph
+			warnings, err := validator.ValidateCreate(ctx, componentGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+
+			// make valid testGraph update
+			newComponentGroup := componentGroup.DeepCopy()
+			newComponentGroup.Spec.TestGraph["scenarioD"] = []appstudiov1beta2.TestGraphNode{{Name: "scenarioC"}}
+			warnings, err = validator.ValidateUpdate(ctx, componentGroup, newComponentGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+
+		})
+
+		It("Returns an error for an invalid test graph", func() {
+			warnings, err := validator.ValidateCreate(ctx, componentGroup)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+
+			newComponentGroup := componentGroup.DeepCopy()
+			newComponentGroup.Spec.TestGraph = invalidTestGraph
+			_, err = validator.ValidateUpdate(ctx, componentGroup, newComponentGroup)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("error validating test graph: invalid TestGraph - cycle detected"))
+		})
+	})
+})

--- a/internal/webhook/v1beta2/webhook_suite_test.go
+++ b/internal/webhook/v1beta2/webhook_suite_test.go
@@ -140,6 +140,9 @@ var _ = BeforeSuite(func() {
 	err = SetupIntegrationTestScenarioWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = SetupComponentGroupWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = SetupSnapshotWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/dag/dag_suite_test.go
+++ b/pkg/dag/dag_suite_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 Red Hat Inc.
+Copyright 2023 Red Hat Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -14,23 +14,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package snapshot
+package dag
 
 import (
-	"unicode"
+	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Utility functions", Ordered, func() {
-	Context("Validating generateRandomSuffix", func() {
-		It("Can generate a suffix", func() {
-			suffix, err := generateRandomSuffix()
-			Expect(err).NotTo(HaveOccurred())
-			Expect(suffix).To(HaveLen(2))
-			Expect(unicode.IsDigit(rune(suffix[0])) || unicode.IsLower(rune(suffix[0]))).To(BeTrue())
-			Expect(unicode.IsDigit(rune(suffix[1])) || unicode.IsLower(rune(suffix[1]))).To(BeTrue())
-		})
-	})
-})
+func TestIntegrationteststatus(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "DAG Suite")
+}

--- a/pkg/dag/verify.go
+++ b/pkg/dag/verify.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dag
+
+import (
+	"fmt"
+	"maps"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+)
+
+// Node represents a Task in a pipeline.
+type Node struct {
+	// Key represent a unique name of the node in a graph
+	Key string
+	// Prev represent all the Previous task Nodes for the current Task
+	Prev []*Node
+	// Next represent all the Next task Nodes for the current Task
+	Next []*Node
+	// FailFastMap maps next node names to their FailFast behavior
+	FailFastMap map[string]bool
+}
+
+// Graph represents the Pipeline Graph
+type Graph struct {
+	// Nodes represent map of PipelineTask name to Node in Pipeline Graph
+	Nodes map[string]*Node
+}
+
+func newGraph() *Graph {
+	return &Graph{Nodes: map[string]*Node{}}
+}
+
+func (g *Graph) addScenarioToGraph(scenarioName string) {
+	newNode := &Node{
+		Key: scenarioName,
+	}
+	g.Nodes[scenarioName] = newNode
+}
+
+// ValidateTestGraph checks that all scenarios are representable as a DAG within
+// the provided testGraph (i.e. the graph contains no cycles).
+// TODO: when we validate test graph during testing time, we'll wan to expand the
+// for loop in this function to also remove nodes from graphCopy that are not going
+// to be run based on the contexts
+func ValidateTestGraph(testGraph map[string][]v1beta2.TestGraphNode, scenarios ...v1beta2.IntegrationTestScenario) error {
+	dag := newGraph()
+	graphCopy := maps.Clone(testGraph)
+
+	for _, scenario := range scenarios {
+		dag.addScenarioToGraph(scenario.Name)
+
+		// Ensure every scenario appears in testGraph even if it has no declared
+		// parents, so that checkGraphForCycles sees the full node set.
+		// This isn't technically necessary (every node in a cycle has a parent)
+		// but it creates some peace of mind
+		if _, ok := graphCopy[scenario.Name]; !ok {
+			graphCopy[scenario.Name] = []v1beta2.TestGraphNode{}
+		}
+	}
+
+	// We're technically checking a reversed version of the graph. Reversing
+	// the graph preserves all cycles so this is acceptable
+	if err := checkGraphForCycles(graphCopy); err != nil {
+		return fmt.Errorf("invalid TestGraph - cycle detected: %w", err)
+	}
+	return nil
+}
+
+// checkGraphForCycles uses Kahn's algorithm on the reversed dependency graph to
+// detect cycles.  The testGraph maps each scenario name to the list of parent
+// scenarios it depends on (parents must finish before the keyed scenario starts).
+func checkGraphForCycles(testGraph map[string][]v1beta2.TestGraphNode) error {
+	// indegrees[x] = number of nodes that list x as a parent (i.e. x's child count).
+	indegrees := make(map[string]int)
+	var res []string
+
+	for _, parentNodes := range testGraph {
+		for _, parentNode := range parentNodes {
+			indegrees[parentNode.Name]++
+		}
+	}
+
+	// Seed the queue with nodes that have no children (nobody depends on them).
+	var queue []string
+	for node := range testGraph {
+		if indegrees[node] == 0 {
+			queue = append(queue, node)
+			res = append(res, node)
+		}
+	}
+
+	// BFS: for each childless node, decrement its parents' child-counts; enqueue
+	// any parent that reaches zero.
+	for len(queue) > 0 {
+		node := queue[0]
+		queue = queue[1:]
+		for _, parentNode := range testGraph[node] {
+			indegrees[parentNode.Name]--
+			if indegrees[parentNode.Name] == 0 {
+				queue = append(queue, parentNode.Name)
+				res = append(res, parentNode.Name)
+			}
+		}
+	}
+
+	switch {
+	case len(res) < len(testGraph):
+		return fmt.Errorf("cycles found in graph; remaining indegrees: %+v", indegrees)
+	default:
+		return nil
+	}
+}

--- a/pkg/dag/verify_test.go
+++ b/pkg/dag/verify_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dag
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+)
+
+var _ = Describe("DAG library unittests", Ordered, func() {
+	var (
+		//integrationTestScenario *v1beta2.IntegrationTestScenario
+		testGraphWithoutCycles map[string][]v1beta2.TestGraphNode
+		testGraphWithCycles    map[string][]v1beta2.TestGraphNode
+	)
+	Context("Checking graph for cycles", func() {
+		BeforeAll(func() {
+			// Create testGraph with no cycles
+			//    A   E
+			//   / \ /
+			//  B   C
+			//  |
+			//  D
+			testGraphWithoutCycles = make(map[string][]v1beta2.TestGraphNode)
+			testGraphWithoutCycles["scenarioA"] = createTestGraphNodesForScenarios(nil)
+			testGraphWithoutCycles["scenarioB"] = createTestGraphNodesForScenarios([]string{"scenarioA"})
+			testGraphWithoutCycles["scenarioC"] = createTestGraphNodesForScenarios([]string{"scenarioA", "scenarioE"})
+			testGraphWithoutCycles["scenarioD"] = createTestGraphNodesForScenarios([]string{"scenarioB"})
+			testGraphWithoutCycles["scenarioE"] = createTestGraphNodesForScenarios(nil)
+
+			// Create testGraph with cycles. 'E' is repeated
+			//    A   E
+			//   / \ /
+			//  B   C
+			//  |   |
+			//  D   E
+			testGraphWithCycles = make(map[string][]v1beta2.TestGraphNode)
+			testGraphWithCycles["scenarioA"] = createTestGraphNodesForScenarios([]string{})
+			testGraphWithCycles["scenarioB"] = createTestGraphNodesForScenarios([]string{"scenarioA"})
+			testGraphWithCycles["scenarioC"] = createTestGraphNodesForScenarios([]string{"scenarioA", "scenarioE"})
+			testGraphWithCycles["scenarioD"] = createTestGraphNodesForScenarios([]string{"scenarioB"})
+			testGraphWithCycles["scenarioE"] = createTestGraphNodesForScenarios([]string{"scenarioC"})
+		})
+
+		When("A Graph without cycles is checked", func() {
+			It("Returns no error", func() {
+				err := checkGraphForCycles(testGraphWithoutCycles)
+				Expect(err).NotTo(HaveOccurred())
+			})
+		})
+
+		When("A Graph with cycles is checked", func() {
+			It("Returns no error", func() {
+				err := checkGraphForCycles(testGraphWithCycles)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("cycles found in graph"))
+			})
+		})
+	})
+})
+
+func createTestGraphNodesForScenarios(scenarioNames []string) (nodes []v1beta2.TestGraphNode) {
+	for _, name := range scenarioNames {
+		nodes = append(nodes, v1beta2.TestGraphNode{Name: name, FailFast: false})
+	}
+	return
+}

--- a/snapshot/create.go
+++ b/snapshot/create.go
@@ -180,13 +180,24 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, component
 	return snapshot, nil
 }
 
+// This prevents race conditions if EnsureGCLAlignedWithSpecComponents runs late
 func getSnapshotComponentsFromGCL(componentGroup *v1beta2.ComponentGroup, log logr.Logger) ([]applicationapiv1alpha1.SnapshotComponent, []v1beta2.ComponentState) {
 	var snapshotComponents []applicationapiv1alpha1.SnapshotComponent
 	var invalidComponents []v1beta2.ComponentState
+
+	specComponents := getSpecComponentsAndVersionsMap(componentGroup)
 	for _, gclComponent := range componentGroup.Status.GlobalCandidateList {
 		name := gclComponent.Name
 		version := gclComponent.Version
 		image := gclComponent.LastPromotedImage
+
+		// Necessary to prevent race condition if reconciler function has not
+		// cleaned up GCL by the time snapshot is created
+		specVersions, ok := specComponents[name]
+		if !ok || !slices.Contains(specVersions, version) {
+			log.Info("componentVersion was deleted from spec.Components. Will not add to snapshot", "componentGroup", componentGroup.Name, "component.Name", name, "component.Version", version)
+			continue
+		}
 
 		// If containerImage is empty, we have run into a race condition in
 		// which multiple components are being built in close succession.
@@ -217,6 +228,14 @@ func getSnapshotComponentsFromGCL(componentGroup *v1beta2.ComponentGroup, log lo
 		)
 	}
 	return snapshotComponents, invalidComponents
+}
+
+func getSpecComponentsAndVersionsMap(componentGroup *v1beta2.ComponentGroup) map[string][]string {
+	componentVersions := make(map[string][]string)
+	for _, component := range componentGroup.Spec.Components {
+		componentVersions[component.Name] = append(componentVersions[component.Name], component.ComponentVersion.Name)
+	}
+	return componentVersions
 }
 
 // Adds the updated Component to the list of snapshotComponents that will be added to the snapshot.  If a SnapshotComponent with

--- a/snapshot/create_test.go
+++ b/snapshot/create_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package snapshot
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strconv"
@@ -33,6 +34,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"github.com/tonglil/buflogr"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
@@ -223,6 +225,10 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 					Name:    componentName2,
 					Version: "v1",
 					URL:     "",
+				},
+				v1beta2.ComponentState{
+					Name:    "deleted-component",
+					Version: "v1",
 				},
 			},
 		}
@@ -529,13 +535,18 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 	Context("testing creation of snapshotComponentsList", func() {
 		It("Ensures valid and invalid snapshotComponents can be gathered from the GCL", func() {
-			snapshotComponents, invalidComponents := getSnapshotComponentsFromGCL(hasCompGroup, logger)
+			var buf bytes.Buffer
+			readableLog := buflogr.NewWithBuffer(&buf)
+			snapshotComponents, invalidComponents := getSnapshotComponentsFromGCL(hasCompGroup, readableLog)
 
 			Expect(snapshotComponents).To(HaveLen(1))
 			Expect(snapshotComponents[0].Name).To(Equal(componentName))
 
 			Expect(invalidComponents).To(HaveLen(1))
 			Expect(invalidComponents[0].Name).To(Equal(componentName2))
+
+			Expect(buf.String()).To(ContainSubstring("componentVersion was deleted from spec.Components"))
+
 		})
 
 		It("Ensures built component can replace existing snapshotComponent", func() {

--- a/snapshot/gcl.go
+++ b/snapshot/gcl.go
@@ -119,7 +119,7 @@ func UpdateGCLEntry(ctx context.Context, adapterClient client.Client, componentG
 func UpdateMultipleGCLEntries(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, componentsToUpdate map[string]v1beta2.ComponentState, logger helpers.IntegrationLogger) error {
 	patch := client.MergeFromWithOptions(componentGroup.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	for i, entry := range componentGroup.Status.GlobalCandidateList {
-		entryKey := getComponentVersionString(entry.Name, entry.Version)
+		entryKey := helpers.GetComponentVersionString(entry.Name, entry.Version)
 		newEntry, ok := componentsToUpdate[entryKey]
 		if !ok {
 			// if key doesn't exist then we want to retain the original GCL entry
@@ -145,7 +145,7 @@ func UpdateGCLForOverrideSnapshot(ctx context.Context, adapterClient client.Clie
 		component := component //G601
 
 		// Create ComponentState object
-		key := getComponentVersionString(component.Name, component.Version)
+		key := helpers.GetComponentVersionString(component.Name, component.Version)
 		componentsToAdd[key] = snapshotComponentToComponentState(component)
 	}
 

--- a/snapshot/utils.go
+++ b/snapshot/utils.go
@@ -18,13 +18,13 @@ package snapshot
 
 import (
 	"crypto/rand"
-	"fmt"
 	"math/big"
 	"strings"
 	"time"
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/helpers"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
@@ -43,18 +43,10 @@ func generateRandomSuffix() (string, error) {
 	return string(suffix), nil
 }
 
-func getComponentVersionString(name, version string) string {
-	return fmt.Sprintf("%s/%s", name, version)
-}
-
-func getComponentVersionLogString(name, version string) string {
-	return fmt.Sprintf("%s (version %s)", name, version)
-}
-
 func joinInvalidComponentNamesAndVersions(invalidComponents []v1beta2.ComponentState) string {
 	var sb strings.Builder
 	for _, component := range invalidComponents {
-		sb.WriteString(getComponentVersionLogString(component.Name, component.Version))
+		sb.WriteString(helpers.GetComponentVersionLogString(component.Name, component.Version))
 	}
 	return sb.String()
 }

--- a/snapshot/validation.go
+++ b/snapshot/validation.go
@@ -24,6 +24,7 @@ import (
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
+	"github.com/konflux-ci/integration-service/helpers"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -37,16 +38,16 @@ func ValidateOverrideSnapshotComponents(ctx context.Context, snapshot *applicati
 	// Build a set of known (name, version) pairs from the ComponentGroup spec in O(n)
 	knownComponents := make(map[string]bool, len(componentGroup.Spec.Components))
 	for _, component := range componentGroup.Spec.Components {
-		knownComponents[getComponentVersionString(component.Name, component.ComponentVersion.Name)] = true
+		knownComponents[helpers.GetComponentVersionString(component.Name, component.ComponentVersion.Name)] = true
 	}
 
 	var errsForSnapshot error
 	for _, snapshotComponent := range snapshot.Spec.Components {
 		snapshotComponent := snapshotComponent //G601
 
-		key := getComponentVersionString(snapshotComponent.Name, snapshotComponent.Version)
+		key := helpers.GetComponentVersionString(snapshotComponent.Name, snapshotComponent.Version)
 		if _, found := knownComponents[key]; !found {
-			errsForSnapshot = errors.Join(errsForSnapshot, fmt.Errorf("snapshotComponent %s defined in snapshot %s doesn't exist in componentGroup %s/%s", getComponentVersionLogString(snapshotComponent.Name, snapshotComponent.Version), snapshot.Name, componentGroup.Namespace, componentGroup.Name))
+			errsForSnapshot = errors.Join(errsForSnapshot, fmt.Errorf("snapshotComponent %s defined in snapshot %s doesn't exist in componentGroup %s/%s", helpers.GetComponentVersionLogString(snapshotComponent.Name, snapshotComponent.Version), snapshot.Name, componentGroup.Namespace, componentGroup.Name))
 		}
 
 		if err := gitops.ValidateImageDigest(snapshotComponent.ContainerImage); err != nil {


### PR DESCRIPTION
the ComponentGroup webhook ensures that the TestGraph defined in the ComponentGroup contains no cycles and modifies the status.globalCandidateList field to ensure its items match the items in spec.components

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
