### PR TITLE
feat(STONEINTG-1548): gate auto-release on build pipeline SHOULD_RELEASE

### DIFF
--- a/gitops/release.go
+++ b/gitops/release.go
@@ -30,7 +30,10 @@ import (
 
 // EvaluateSnapshotAutoReleaseAnnotation evaluates the provided auto-release annotation CEL-like expression
 // against the given Snapshot and returns whether it allows auto-release.
-func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *applicationapiv1alpha1.Snapshot) (bool, error) {
+// The shouldRelease parameter is made available via the shouldRelease() CEL function, which reflects
+// the build PipelineRun's SHOULD_RELEASE result. Note: shouldRelease only gates releases if the CEL
+// expression actually calls shouldRelease(). An expression like "true" will bypass gating entirely.
+func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (bool, error) {
 	// Empty or missing annotation: do not auto-release
 	if len(autoReleaseExpr) == 0 {
 		return false, nil
@@ -46,7 +49,7 @@ func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *app
 
 	// Build a CEL environment
 	// The with a dynamic 'snapshot' variable represents the snapshot object
-	funcs := snapshotCELFunctions{snapshot: objMap}
+	funcs := snapshotCELFunctions{snapshot: objMap, shouldReleaseVal: shouldRelease}
 	env, err := cel.NewEnv(
 		cel.DefaultUTCTimeZone(true),
 		cel.Variable("snapshot", cel.DynType),
@@ -57,6 +60,14 @@ func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *app
 				[]*cel.Type{cel.StringType},
 				cel.BoolType,
 				cel.UnaryBinding(funcs.updatedComponentIs),
+			),
+		),
+		// Register custom function: shouldRelease() -> bool
+		cel.Function("shouldRelease",
+			cel.Overload("shouldRelease_bool",
+				[]*cel.Type{},
+				cel.BoolType,
+				cel.FunctionBinding(funcs.shouldReleaseFn),
 			),
 		),
 	)
@@ -99,7 +110,12 @@ func EvaluateSnapshotAutoReleaseAnnotation(autoReleaseExpr string, snapshot *app
 // This helps avoid global state while keeping a named function.
 
 type snapshotCELFunctions struct {
-	snapshot map[string]any
+	snapshot         map[string]any
+	shouldReleaseVal bool
+}
+
+func (sf snapshotCELFunctions) shouldReleaseFn(args ...ref.Val) ref.Val {
+	return types.Bool(sf.shouldReleaseVal)
 }
 
 func (sf snapshotCELFunctions) updatedComponentIs(arg ref.Val) ref.Val {

--- a/gitops/release_test.go
+++ b/gitops/release_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 	It("returns false when the auto-release annotation is missing", func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
 		autoReleaseAnnotation := ""
-		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(allowed).To(BeFalse())
 	})
@@ -81,7 +81,7 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 	It("returns true when the auto-release annotation is 'true'", func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
 		autoReleaseAnnotation := "true"
-		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(allowed).To(BeTrue())
 	})
@@ -89,7 +89,7 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 	It("returns false when the auto-release annotation is 'false'", func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
 		autoReleaseAnnotation := "false"
-		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(allowed).To(BeFalse())
 	})
@@ -98,15 +98,15 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
 		snapshotCopy.CreationTimestamp = metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
 		autoReleaseAnnotation := "timestamp(snapshot.metadata.creationTimestamp) < (timestamp(now) - duration('168h'))"
-		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(allowed).To(BeTrue())
 	})
 
-	It("returns true  when the updated component is 'component-sample'", func() {
+	It("returns true when the updated component is 'component-sample'", func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
 		autoReleaseAnnotation := "updatedComponentIs('component-sample')"
-		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(allowed).To(BeTrue())
 	})
@@ -114,8 +114,44 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 	It("returns error and false when the auto-release annotation is an invalid CEL expression", func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
 		autoReleaseAnnotation := "invalid expression$" // syntactically invalid
-		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy)
+		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).To(HaveOccurred())
 		Expect(allowed).To(BeFalse())
+	})
+
+	Context("shouldRelease() CEL function", func() {
+		It("returns true when shouldRelease is true", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("shouldRelease()", snapshotCopy, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+		})
+
+		It("returns false when shouldRelease is false", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("shouldRelease()", snapshotCopy, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeFalse())
+		})
+
+		It("composes with updatedComponentIs", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			expr := "shouldRelease() && updatedComponentIs('component-sample')"
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(expr, snapshotCopy, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+
+			allowed, err = gitops.EvaluateSnapshotAutoReleaseAnnotation(expr, snapshotCopy, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeFalse())
+		})
+
+		It("can be bypassed with a CEL expression that doesn't call it", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			// Even with shouldRelease=false, a "true" expression bypasses gating
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("true", snapshotCopy, false)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+		})
 	})
 })

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -106,6 +106,12 @@ const (
 	// GitReportingFailureAnnotation contains information about git reporting failures
 	GitReportingFailureAnnotation = "test.appstudio.openshift.io/git-reporting-failure"
 
+	// BuildPipelineRunResultAnnotationPrefix is the prefix for annotations derived from build PipelineRun results
+	BuildPipelineRunResultAnnotationPrefix = TestLabelPrefix + "/result-"
+
+	// BuildPipelineRunShouldReleaseAnnotation contains the SHOULD_RELEASE result from the build PipelineRun
+	BuildPipelineRunShouldReleaseAnnotation = BuildPipelineRunResultAnnotationPrefix + "should-release"
+
 	// BuildPipelineRunStartTime contains the start time of build pipelineRun
 	BuildPipelineRunStartTime = "test.appstudio.openshift.io/pipelinerunstarttime"
 
@@ -1197,6 +1203,26 @@ func CopySnapshotLabelsAndAnnotations(object *metav1.ObjectMeta, snapshot *appli
 		_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
 	}
 
+}
+
+// BuildResultAnnotationKey normalizes a PipelineRun result name into a Snapshot annotation key.
+// e.g. "SHOULD_RELEASE" → "test.appstudio.openshift.io/result-should-release"
+func BuildResultAnnotationKey(resultName string) string {
+	normalized := strings.ToLower(strings.ReplaceAll(resultName, "_", "-"))
+	return BuildPipelineRunResultAnnotationPrefix + normalized
+}
+
+// CopyBuildPipelineRunResultsToSnapshot copies all string-typed results from a build PipelineRun
+// into Snapshot annotations so downstream consumers can access them without loading the PLR.
+func CopyBuildPipelineRunResultsToSnapshot(pipelineRun *tektonv1.PipelineRun, snapshot *applicationapiv1alpha1.Snapshot) {
+	if snapshot.Annotations == nil {
+		snapshot.Annotations = map[string]string{}
+	}
+	for _, result := range pipelineRun.Status.Results {
+		if result.Value.StringVal != "" {
+			snapshot.Annotations[BuildResultAnnotationKey(result.Name)] = result.Value.StringVal
+		}
+	}
 }
 
 // CopyTempGroupSnapshotLabelsAndAnnotations coppies labels and annotations from build pipelineRun or tested snapshot

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -1577,3 +1577,77 @@ var _ = Describe("EnrichBuiltComponentSourceGitContext", func() {
 		Expect(src.GitSource.Context).To(Equal("already-set"))
 	})
 })
+
+var _ = Describe("BuildResultAnnotationKey", func() {
+	It("lowercases and replaces underscores with hyphens", func() {
+		Expect(gitops.BuildResultAnnotationKey("SHOULD_RELEASE")).To(Equal("test.appstudio.openshift.io/result-should-release"))
+	})
+
+	It("handles result names with hyphens", func() {
+		Expect(gitops.BuildResultAnnotationKey("CHAINS-GIT_URL")).To(Equal("test.appstudio.openshift.io/result-chains-git-url"))
+	})
+})
+
+var _ = Describe("CopyBuildPipelineRunResultsToSnapshot", func() {
+	var (
+		pipelineRun *tektonv1.PipelineRun
+		snapshot    *applicationapiv1alpha1.Snapshot
+	)
+
+	BeforeEach(func() {
+		pipelineRun = &tektonv1.PipelineRun{
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					Results: []tektonv1.PipelineRunResult{
+						{
+							Name:  "IMAGE_URL",
+							Value: *tektonv1.NewStructuredValues("quay.io/test/image"),
+						},
+						{
+							Name:  "IMAGE_DIGEST",
+							Value: *tektonv1.NewStructuredValues("sha256:abc123"),
+						},
+						{
+							Name:  "CHAINS-GIT_URL",
+							Value: *tektonv1.NewStructuredValues("https://github.com/org/repo"),
+						},
+						{
+							Name:  "SHOULD_RELEASE",
+							Value: *tektonv1.NewStructuredValues("false"),
+						},
+					},
+				},
+			},
+		}
+		snapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-snapshot",
+				Namespace: "default",
+			},
+		}
+	})
+
+	It("copies all string results as annotations", func() {
+		gitops.CopyBuildPipelineRunResultsToSnapshot(pipelineRun, snapshot)
+		Expect(snapshot.Annotations).To(HaveKeyWithValue("test.appstudio.openshift.io/result-image-url", "quay.io/test/image"))
+		Expect(snapshot.Annotations).To(HaveKeyWithValue("test.appstudio.openshift.io/result-image-digest", "sha256:abc123"))
+		Expect(snapshot.Annotations).To(HaveKeyWithValue("test.appstudio.openshift.io/result-chains-git-url", "https://github.com/org/repo"))
+		Expect(snapshot.Annotations).To(HaveKeyWithValue("test.appstudio.openshift.io/result-should-release", "false"))
+	})
+
+	It("skips results with empty StringVal", func() {
+		pipelineRun.Status.Results = append(pipelineRun.Status.Results, tektonv1.PipelineRunResult{
+			Name:  "EMPTY_RESULT",
+			Value: *tektonv1.NewStructuredValues(""),
+		})
+		gitops.CopyBuildPipelineRunResultsToSnapshot(pipelineRun, snapshot)
+		Expect(snapshot.Annotations).NotTo(HaveKey("test.appstudio.openshift.io/result-empty-result"))
+	})
+
+	It("preserves existing annotations", func() {
+		snapshot.Annotations = map[string]string{"existing-key": "existing-value"}
+		gitops.CopyBuildPipelineRunResultsToSnapshot(pipelineRun, snapshot)
+		Expect(snapshot.Annotations).To(HaveKeyWithValue("existing-key", "existing-value"))
+		Expect(snapshot.Annotations).To(HaveKey("test.appstudio.openshift.io/result-image-url"))
+	})
+})

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -780,6 +780,9 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 	snapshot.Annotations[gitops.BuildPipelineRunStartTime] = strconv.FormatInt(timestampMillis, 10)
 	snapshot.Name = gitops.GenerateSnapshotNameWithTimestamp(application.Name, timestampMillis)
 
+	// Copy all build PipelineRun results as Snapshot annotations
+	gitops.CopyBuildPipelineRunResultsToSnapshot(pipelineRun, snapshot)
+
 	// Set the integration workflow annotation based on the PipelineRun type
 	if tekton.IsPLRCreatedByPACPushEvent(pipelineRun) {
 		snapshot.Annotations[gitops.IntegrationWorkflowAnnotation] = gitops.IntegrationWorkflowPushValue

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -573,7 +573,9 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 		return controller.ContinueProcessing()
 	}
 
-	releasePlans, err := a.getAutoReleasePlans()
+	shouldRelease := a.getShouldRelease()
+
+	releasePlans, err := a.getAutoReleasePlans(shouldRelease)
 	if err != nil {
 		return a.handleReleaseError(err, "Failed to get all ReleasePlans")
 	}
@@ -589,7 +591,11 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 			autoReleaseMessage = "The Snapshot was auto-released"
 		}
 	} else {
-		autoReleaseMessage = "Skipping auto-release of the Snapshot because no ReleasePlans have the 'auto-release' label set to 'true'"
+		if !shouldRelease {
+			autoReleaseMessage = "Skipping auto-release because the build pipeline's SHOULD_RELEASE result is 'false'"
+		} else {
+			autoReleaseMessage = "Skipping auto-release of the Snapshot because no ReleasePlans have the 'auto-release' label set to 'true'"
+		}
 	}
 
 	err = gitops.MarkSnapshotAsAutoReleased(a.context, a.client, a.snapshot, autoReleaseMessage)
@@ -617,15 +623,27 @@ func (a *Adapter) shouldProcessReleases() bool {
 	return true
 }
 
+// getShouldRelease checks the Snapshot's annotation for the SHOULD_RELEASE
+// value that was persisted by the build pipeline adapter at Snapshot creation time.
+// Returns false only when the annotation is explicitly "false"; absence means release normally.
+func (a *Adapter) getShouldRelease() bool {
+	val, ok := a.snapshot.Annotations[gitops.BuildPipelineRunShouldReleaseAnnotation]
+	if ok && val == "false" {
+		a.logger.Info("Snapshot SHOULD_RELEASE annotation is false, releases will be gated")
+		return false
+	}
+	return true
+}
+
 // getAutoReleasePlans fetch release plans
-func (a *Adapter) getAutoReleasePlans() (*[]releasev1alpha1.ReleasePlan, error) {
+func (a *Adapter) getAutoReleasePlans(shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error) {
 	// TODO: remove application-specific branch
 	var releasePlans *[]releasev1alpha1.ReleasePlan
 	var err error
 	if a.application != nil {
-		releasePlans, err = a.loader.GetAutoReleasePlansForApplication(a.context, a.client, a.application, a.snapshot)
+		releasePlans, err = a.loader.GetAutoReleasePlansForApplication(a.context, a.client, a.application, a.snapshot, shouldRelease)
 	} else {
-		releasePlans, err = a.loader.GetAutoReleasePlansForComponentGroup(a.context, a.client, a.componentGroup, a.snapshot)
+		releasePlans, err = a.loader.GetAutoReleasePlansForComponentGroup(a.context, a.client, a.componentGroup, a.snapshot, shouldRelease)
 	}
 	if err != nil {
 		a.logger.Error(err, "Failed to get all ReleasePlans")

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -61,8 +61,8 @@ type ObjectLoader interface {
 	GetAllIntegrationTestScenariosForSnapshot(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot) (*[]v1beta2.IntegrationTestScenario, error)
 	GetAllPipelineRunsForSnapshotAndScenario(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot, integrationTestScenario *v1beta2.IntegrationTestScenario) (*[]tektonv1.PipelineRun, error)
 	GetAllSnapshots(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Snapshot, error)
-	GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error)
-	GetAutoReleasePlansForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error)
+	GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error)
+	GetAutoReleasePlansForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error)
 	GetScenario(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.IntegrationTestScenario, error)
 	GetComponentGroup(ctx context.Context, c client.Client, name, namespace string) (*v1beta2.ComponentGroup, error)
 	GetAllSnapshotsForBuildPipelineRunApplication(ctx context.Context, c client.Client, pipelineRun *tektonv1.PipelineRun) (*[]applicationapiv1alpha1.Snapshot, error)
@@ -440,7 +440,7 @@ func (l *loader) GetAllSnapshots(ctx context.Context, c client.Client, applicati
 // ReleasePlans are not found, an error will be returned. A ReleasePlan will only be returned if it has the
 // release.appstudio.openshift.io/auto-release label set to true or if it is missing the label entirely.
 // TODO: delete function when we remove support for old application model
-func (l *loader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *loader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error) {
 	allReleasePlans := &releasev1alpha1.ReleasePlanList{}
 	filteredReleasePlans := &releasev1alpha1.ReleasePlanList{}
 
@@ -455,15 +455,21 @@ func (l *loader) GetAutoReleasePlansForApplication(ctx context.Context, c client
 	}
 
 	for _, rp := range allReleasePlans.Items {
-		annotationValue, ok := rp.GetAnnotations()[gitops.AutoReleaseLabel] // label and annotation have same value
-		if ok || annotationValue != "" {
-			// If the annotation exists we evaluate the expression and return that
-			canRelease, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(annotationValue, snapshot)
-			if err != nil || !canRelease {
+		annotationValue := rp.GetAnnotations()[gitops.AutoReleaseLabel] // label and annotation have same value
+		if annotationValue != "" {
+			// If the annotation exists we evaluate the CEL expression and include the plan when it allows release
+			canRelease, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(annotationValue, snapshot, shouldRelease)
+			if err != nil {
+				return nil, fmt.Errorf("failed to evaluate auto-release CEL expression for ReleasePlan %s: %w", rp.Name, err)
+			}
+			if canRelease {
 				filteredReleasePlans.Items = append(filteredReleasePlans.Items, rp)
 			}
 		} else if !metadata.HasLabelWithValue(&rp, gitops.AutoReleaseLabel, "false") {
-			filteredReleasePlans.Items = append(filteredReleasePlans.Items, rp)
+			// Label-based plan: apply default SHOULD_RELEASE gating
+			if shouldRelease {
+				filteredReleasePlans.Items = append(filteredReleasePlans.Items, rp)
+			}
 		}
 	}
 
@@ -473,7 +479,7 @@ func (l *loader) GetAutoReleasePlansForApplication(ctx context.Context, c client
 // GetAutoReleasePlansForComponentGroup returns the ReleasePlans used by the component group being processed. If matching
 // ReleasePlans are not found, an error will be returned. A ReleasePlan will only be returned if it has the
 // release.appstudio.openshift.io/auto-release label set to true or if it is missing the label entirely.
-func (l *loader) GetAutoReleasePlansForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *loader) GetAutoReleasePlansForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error) {
 	allReleasePlans := &releasev1alpha1.ReleasePlanList{}
 	filteredReleasePlans := &releasev1alpha1.ReleasePlanList{}
 
@@ -490,13 +496,19 @@ func (l *loader) GetAutoReleasePlansForComponentGroup(ctx context.Context, c cli
 	for _, rp := range allReleasePlans.Items {
 		annotationValue := rp.GetAnnotations()[gitops.AutoReleaseLabel] // label and annotation have same value
 		if annotationValue != "" {
-			// If the annotation exists we evaluate the expression and return that
-			canRelease, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(annotationValue, snapshot)
-			if err != nil || !canRelease {
+			// If the annotation exists we evaluate the CEL expression and include the plan when it allows release
+			canRelease, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(annotationValue, snapshot, shouldRelease)
+			if err != nil {
+				return nil, fmt.Errorf("failed to evaluate auto-release CEL expression for ReleasePlan %s: %w", rp.Name, err)
+			}
+			if canRelease {
 				filteredReleasePlans.Items = append(filteredReleasePlans.Items, rp)
 			}
 		} else if !metadata.HasLabelWithValue(&rp, gitops.AutoReleaseLabel, "false") {
-			filteredReleasePlans.Items = append(filteredReleasePlans.Items, rp)
+			// Label-based plan: apply default SHOULD_RELEASE gating
+			if shouldRelease {
+				filteredReleasePlans.Items = append(filteredReleasePlans.Items, rp)
+			}
 		}
 	}
 

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -230,18 +230,18 @@ func (l *mockLoader) GetAllSnapshots(ctx context.Context, c client.Client, appli
 }
 
 // GetAutoReleasePlansForApplication returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *mockLoader) GetAutoReleasePlansForApplication(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error) {
 	if ctx.Value(AutoReleasePlansContextKey) == nil {
-		return l.loader.GetAutoReleasePlansForApplication(ctx, c, application, snapshot)
+		return l.loader.GetAutoReleasePlansForApplication(ctx, c, application, snapshot, shouldRelease)
 	}
 	autoReleasePlans, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AutoReleasePlansContextKey, []releasev1alpha1.ReleasePlan{})
 	return &autoReleasePlans, err
 }
 
 // GetAutoReleasePlansForComponentGroup returns the resource and error passed as values of the context.
-func (l *mockLoader) GetAutoReleasePlansForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.ReleasePlan, error) {
+func (l *mockLoader) GetAutoReleasePlansForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot, shouldRelease bool) (*[]releasev1alpha1.ReleasePlan, error) {
 	if ctx.Value(AutoReleasePlansContextKey) == nil {
-		return l.loader.GetAutoReleasePlansForComponentGroup(ctx, c, componentGroup, snapshot)
+		return l.loader.GetAutoReleasePlansForComponentGroup(ctx, c, componentGroup, snapshot, shouldRelease)
 	}
 	autoReleasePlans, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, AutoReleasePlansContextKey, []releasev1alpha1.ReleasePlan{})
 	return &autoReleasePlans, err

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -286,7 +286,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   releasePlans,
 				},
 			})
-			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil, nil)
+			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil, nil, true)
 			Expect(resource).To(Equal(&releasePlans))
 			Expect(err).ToNot(HaveOccurred())
 		})
@@ -301,7 +301,7 @@ var _ = Describe("Release Adapter", Ordered, func() {
 					Resource:   releasePlans,
 				},
 			})
-			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil, nil)
+			resource, err := loader.GetAutoReleasePlansForApplication(mockContext, nil, nil, nil, true)
 			Expect(resource).To(Equal(&releasePlans))
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -816,14 +816,14 @@ var _ = Describe("Loader", Ordered, func() {
 	})
 
 	It("ensures the ReleasePlan can be gotten for Application [APPLICATION]", func() {
-		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
+		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot, true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(gottenReleasePlanItems).NotTo(BeNil())
 
 	})
 
 	It("ensures the ReleasePlan can be gotten for ComponentGroup", func() {
-		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForComponentGroup(ctx, k8sClient, hasComponentGroup1, hasSnapshot)
+		gottenReleasePlanItems, err := loader.GetAutoReleasePlansForComponentGroup(ctx, k8sClient, hasComponentGroup1, hasSnapshot, true)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(gottenReleasePlanItems).NotTo(BeNil())
 
@@ -870,7 +870,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is set to true", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(HaveLen(1))
@@ -910,7 +910,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is missing", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(HaveLen(1))
@@ -1188,7 +1188,7 @@ var _ = Describe("Loader", Ordered, func() {
 
 		It("ensures the auto-release plans for application are returned correctly when the auto-release label is set to false", func() {
 			// Get auto-release plans for application
-			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot)
+			autoReleasePlans, err := loader.GetAutoReleasePlansForApplication(ctx, k8sClient, hasApp, hasSnapshot, true)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(autoReleasePlans).ToNot(BeNil())
 			Expect(*autoReleasePlans).To(BeEmpty())

--- a/snapshot/create.go
+++ b/snapshot/create.go
@@ -83,6 +83,10 @@ func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Cli
 	snapshot.Annotations[gitops.BuildPipelineRunStartTime] = strconv.FormatInt(timestampMillis, 10)
 	snapshot.Name = gitops.GenerateSnapshotNameWithTimestamp(componentGroup.Name, timestampMillis)
 
+	// Copy all build PipelineRun results as Snapshot annotations so downstream
+	// consumers can access them without loading the PLR (which may be pruned).
+	gitops.CopyBuildPipelineRunResultsToSnapshot(pipelineRun, snapshot)
+
 	// Set the integration workflow annotation based on the PipelineRun type
 	if tekton.IsPLRCreatedByPACPushEvent(pipelineRun) {
 		snapshot.Annotations[gitops.IntegrationWorkflowAnnotation] = gitops.IntegrationWorkflowPushValue

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -131,6 +131,9 @@ const (
 
 	// PipelineRunChainsGitCommitParamName name of param repo chains commit
 	PipelineRunChainsGitCommitParamName = "CHAINS-GIT_COMMIT"
+
+	// PipelineRunShouldReleaseResultName is the name of the SHOULD_RELEASE result in build PipelineRuns
+	PipelineRunShouldReleaseResultName = "SHOULD_RELEASE"
 )
 
 var (

--- a/tekton/utils.go
+++ b/tekton/utils.go
@@ -168,3 +168,23 @@ func GetComponentSourceGitCommit(object client.Object) (string, error) {
 	}
 	return "", h.MissingInfoInPipelineRunError(pipelineRun.Name, consts.PipelineRunChainsGitCommitParamName)
 }
+
+// GetShouldRelease extracts the SHOULD_RELEASE result from a build PipelineRun.
+// Returns false only when the result is explicitly set to "false".
+// Returns true when the result is unset, empty, "true", or when the PipelineRun is nil.
+// This default-true behavior ensures releases aren't blocked for pipelines that don't
+// produce a SHOULD_RELEASE result. The resolved bool is propagated to the shouldRelease()
+// CEL function in ReleasePlan auto-release expressions.
+func GetShouldRelease(pipelineRun *tektonv1.PipelineRun) bool {
+	// A nil PipelineRun means the snapshot has no build PLR label (e.g. override snapshot)
+	// or the PLR was garbage collected. Default to true so releases aren't blocked.
+	if pipelineRun == nil {
+		return true
+	}
+	for _, pipelineResult := range pipelineRun.Status.Results {
+		if pipelineResult.Name == consts.PipelineRunShouldReleaseResultName {
+			return pipelineResult.Value.StringVal != "false"
+		}
+	}
+	return true
+}

--- a/tekton/utils_test.go
+++ b/tekton/utils_test.go
@@ -113,4 +113,39 @@ var _ = Describe("Utils", func() {
 		_, err := tekton.GetComponentSourceGitCommit(pipelineRun)
 		Expect(err).To(HaveOccurred())
 	})
+
+	Context("GetShouldRelease", func() {
+		It("returns true when PipelineRun is nil", func() {
+			Expect(tekton.GetShouldRelease(nil)).To(BeTrue())
+		})
+
+		It("returns true when SHOULD_RELEASE result is not present", func() {
+			Expect(tekton.GetShouldRelease(pipelineRun)).To(BeTrue())
+		})
+
+		It("returns true when SHOULD_RELEASE is set to 'true'", func() {
+			pipelineRun.Status.Results = append(pipelineRun.Status.Results, tektonv1.PipelineRunResult{
+				Name:  "SHOULD_RELEASE",
+				Value: *tektonv1.NewStructuredValues("true"),
+			})
+			Expect(tekton.GetShouldRelease(pipelineRun)).To(BeTrue())
+		})
+
+		It("returns true when SHOULD_RELEASE is empty", func() {
+			pipelineRun.Status.Results = append(pipelineRun.Status.Results, tektonv1.PipelineRunResult{
+				Name:  "SHOULD_RELEASE",
+				Value: *tektonv1.NewStructuredValues(""),
+			})
+			Expect(tekton.GetShouldRelease(pipelineRun)).To(BeTrue())
+		})
+
+		It("returns false when SHOULD_RELEASE is set to 'false'", func() {
+			pipelineRun.Status.Results = append(pipelineRun.Status.Results, tektonv1.PipelineRunResult{
+				Name:  "SHOULD_RELEASE",
+				Value: *tektonv1.NewStructuredValues("false"),
+			})
+			Expect(tekton.GetShouldRelease(pipelineRun)).To(BeFalse())
+		})
+
+	})
 })


### PR DESCRIPTION
When a build plr sets its SHOULD_RELEASE result to false integration service now skips Release CR creation. A new shouldRelease() CEL function is available in ReleasePlan auto-release annotations.
