### PR TITLE
feat: add distributed tracing with timing spans and trace context propagation

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -25,6 +26,7 @@ import (
 	controllers "github.com/konflux-ci/integration-service/internal/controller"
 	iswebhook "github.com/konflux-ci/integration-service/internal/webhook/v1beta2"
 	imetrics "github.com/konflux-ci/integration-service/pkg/metrics"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -109,6 +111,18 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Initialize tracing
+	ctx := context.Background()
+	tracerProvider, err := tracing.New(ctx)
+	if err != nil {
+		setupLog.Error(err, "failed to initialize tracing")
+	}
+	defer func() {
+		if err := tracerProvider.Shutdown(ctx); err != nil {
+			setupLog.Error(err, "failed to shutdown tracer provider")
+		}
+	}()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will
@@ -197,7 +211,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := ctrl.SetupSignalHandler()
+	ctx = ctrl.SetupSignalHandler()
 	integrationMetrics := imetrics.NewIntegrationMetrics([]imetrics.AvailabilityProbe{imetrics.NewGithubAppAvailabilityProbe(mgr.GetClient())})
 	if err := integrationMetrics.InitMetrics(metrics.Registry); err != nil {
 		setupLog.Error(err, "unable to initialize metrics")

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"os"
@@ -25,6 +26,7 @@ import (
 	controllers "github.com/konflux-ci/integration-service/internal/controller"
 	iswebhook "github.com/konflux-ci/integration-service/internal/webhook/v1beta2"
 	imetrics "github.com/konflux-ci/integration-service/pkg/metrics"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
@@ -109,6 +111,16 @@ func main() {
 	flag.Parse()
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	// Initialize tracing
+	tracerProvider := tracing.New()
+	defer func() {
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := tracerProvider.Shutdown(shutdownCtx); err != nil {
+			setupLog.Error(err, "failed to shutdown tracer provider")
+		}
+	}()
 
 	// if the enable-http2 flag is false (the default), http/2 should be disabled
 	// due to its vulnerabilities. More specifically, disabling http/2 will

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,6 +5,9 @@
 - [build-pipeline-controller](https://github.com/konflux-ci/integration-service/blob/main/docs/build_pipeline_controller.md)
 - [integration-pipeline-controller](https://github.com/konflux-ci/integration-service/blob/main/docs/integration_pipeline_controller.md)
 
+## Operational docs
+- [Distributed tracing](https://github.com/konflux-ci/integration-service/blob/main/docs/tracing.md)
+
 ## Creating or editing Mermaid diagrams
 
 Mermaid is a JS based diagramming tool that renders markdown style syntax to create/modify diagrams. Mermaid has [native support in Github](https://github.com/github/roadmap/issues/372)

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,49 @@
+<div align="center"><h1>Distributed tracing</h1></div>
+
+The operator emits OpenTelemetry spans for build and integration-test PipelineRuns it reconciles, and propagates the trace context forward onto Snapshots and downstream Release CRs so a single trace can span the build → test → release lifecycle.
+
+## Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/gRPC collector URL. Unset disables tracing (noop provider). | *(unset)* |
+| `OTEL_TRACES_SAMPLER` | `always_on`, `always_off`, `traceidratio`, `parentbased_always_off`, `parentbased_traceidratio`. | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Ratio for ratio-based samplers (e.g. `0.1`). | *(unused unless a ratio sampler is selected)* |
+| `TRACING_LABEL_ACTION` | PipelineRun label read to populate `cicd.pipeline.action.name`. Empty string disables the attribute. | `delivery.tekton.dev/action` |
+| `TRACING_LABEL_APPLICATION` | PipelineRun label read to populate `delivery.tekton.dev.application`. Empty string disables the attribute. | `delivery.tekton.dev/application` |
+| `TRACING_LABEL_COMPONENT` | PipelineRun label read to populate `delivery.tekton.dev.component`. Empty string disables the attribute. | `delivery.tekton.dev/component` |
+
+## Emitted spans
+
+Two spans are emitted per PipelineRun when it completes:
+
+- `waitDuration` — `pr.CreationTimestamp` → `pr.Status.StartTime`
+- `executeDuration` — `pr.Status.StartTime` → `pr.Status.CompletionTime`
+
+The build-pipeline and integration-pipeline controllers each emit for their respective PipelineRun types. The `tekton.dev/timingEmitted` annotation guards against re-emission on subsequent reconciles.
+
+## Trace-context propagation
+
+Parenting follows the W3C Trace Context in the `tekton.dev/pipelinerunSpanContext` annotation. The annotation is propagated across resource boundaries so a single trace covers the full delivery flow:
+
+```
+build PipelineRun (annotation set by upstream)
+   └── Snapshot (annotation copied from the build PipelineRun)
+         ├── integration-test PipelineRun (annotation copied from the Snapshot)
+         └── Release CR (annotation copied from the Snapshot)
+```
+
+When the annotation is absent, spans are still emitted but without a parent.
+
+## Span attributes
+
+| Attribute | Span | Source |
+|---|---|---|
+| `namespace` | both | `pr.GetNamespace()` |
+| `pipelinerun` | both | `pr.GetName()` |
+| `delivery.tekton.dev.pipelinerun_uid` | both | `pr.GetUID()` |
+| `cicd.pipeline.action.name` | both | PipelineRun label (name configurable via `TRACING_LABEL_ACTION`) |
+| `delivery.tekton.dev.application` | both | PipelineRun label (name configurable via `TRACING_LABEL_APPLICATION`) |
+| `delivery.tekton.dev.component` | both | PipelineRun label (name configurable via `TRACING_LABEL_COMPONENT`) |
+| `cicd.pipeline.result` | execute | `Succeeded` condition mapped to the semconv `cicd.pipeline.result` enum (`success` / `failure` / `timeout` / `cancellation` / `error`) |
+| `delivery.tekton.dev.result_message` | execute | Earliest failing TaskRun's `Succeeded` condition message, falling back to the PipelineRun's own condition message. Omitted on success; truncated to 1024 bytes (UTF-8 safe). |

--- a/docs/tracing.md
+++ b/docs/tracing.md
@@ -1,0 +1,53 @@
+<div align="center"><h1>Distributed tracing</h1></div>
+
+The operator emits OpenTelemetry spans for build and integration-test PipelineRuns it reconciles, and propagates the trace context forward onto Snapshots and downstream Release CRs so a single trace can span the build, test, and release lifecycle.
+
+## Configuration
+
+| Env var | Purpose | Default |
+|---|---|---|
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OTLP/gRPC collector URL. Unset disables tracing (noop provider). | *(unset)* |
+| `OTEL_TRACES_SAMPLER` | `always_on`, `always_off`, `traceidratio`, `parentbased_always_off`, `parentbased_traceidratio`. | `parentbased_always_on` |
+| `OTEL_TRACES_SAMPLER_ARG` | Ratio for ratio-based samplers (e.g. `0.1`). | *(unused unless a ratio sampler is selected)* |
+| `TRACING_LABEL_ACTION` | PipelineRun label read to populate `cicd.pipeline.action.name`. Empty string disables the attribute. | `delivery.tekton.dev/action` |
+| `TRACING_LABEL_APPLICATION` | PipelineRun label read to populate `delivery.tekton.dev.application`. Empty string disables the attribute. | `delivery.tekton.dev/application` |
+| `TRACING_LABEL_COMPONENT` | PipelineRun label read to populate `delivery.tekton.dev.component`. Empty string disables the attribute. | `delivery.tekton.dev/component` |
+
+## Emitted spans
+
+Two spans are emitted per PipelineRun when it completes:
+
+- `waitDuration`: `pr.CreationTimestamp` to `pr.Status.StartTime`
+- `executeDuration`: `pr.Status.StartTime` to `pr.Status.CompletionTime`
+
+The build-pipeline and integration-pipeline controllers each emit for their respective PipelineRun types. The `delivery.tekton.dev/timingEmitted` annotation guards against re-emission on subsequent reconciles.
+
+## Trace-context propagation
+
+Parenting follows the W3C Trace Context in the `tekton.dev/pipelinerunSpanContext` annotation. The annotation is propagated across resource boundaries so a single trace covers the full delivery flow:
+
+```
+build PipelineRun (annotation set by upstream)
+   └── Snapshot (annotation copied from the build PipelineRun)
+         ├── integration-test PipelineRun (annotation copied from the Snapshot)
+         └── Release CR (annotation copied from the Snapshot)
+```
+
+When the annotation is absent, spans are still emitted but without a parent.
+
+## Span attributes
+
+| Attribute | Span | Source |
+|---|---|---|
+| `namespace` | both | `pr.GetNamespace()` |
+| `pipelinerun` | both | `pr.GetName()` |
+| `delivery.tekton.dev.pipelinerun_uid` | both | `pr.GetUID()` |
+| `cicd.pipeline.action.name` | both | PipelineRun label (name configurable via `TRACING_LABEL_ACTION`) |
+| `delivery.tekton.dev.application` | both | PipelineRun label (name configurable via `TRACING_LABEL_APPLICATION`) |
+| `delivery.tekton.dev.component` | both | PipelineRun label (name configurable via `TRACING_LABEL_COMPONENT`) |
+| `cicd.pipeline.result` | execute | `Succeeded` condition mapped to the semconv `cicd.pipeline.result` enum (`success` / `failure` / `timeout` / `cancellation` / `error`) |
+| `delivery.tekton.dev.result_message` | execute | PipelineRun's `Succeeded` condition message on failure. Omitted on success; truncated to 1024 bytes (UTF-8 safe). |
+
+## Superseded Snapshot dedup
+
+When the snapshot controller skips auto-release because a newer Snapshot for the same Application has already been released, a single `waitDuration` span is emitted on the superseded Snapshot's trace context, anchored at the Snapshot's `CreationTimestamp` and ending at the `AutoReleased` condition's `LastTransitionTime`. It carries `cicd.pipeline.result=skip` and `delivery.tekton.dev.result_message="Released in newer Snapshot"` so the trace distinguishes the deliberate dedup from a broken chain.

--- a/e2e-tests/pkg/clients/gitlab/git.go
+++ b/e2e-tests/pkg/clients/gitlab/git.go
@@ -10,6 +10,40 @@ import (
 	"gitlab.com/gitlab-org/api/client-go/v2"
 )
 
+// GitLab pre-receive hooks surface 5xx wrapped in a 4xx; RetryTransport's status-code check misses it.
+func isGitlabTransientError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "Internal API error") ||
+		strings.Contains(msg, "504 Gateway Timeout")
+}
+
+func (gc *GitlabClient) createBranchWithRetry(projectID string, opt *gitlab.CreateBranchOptions) (*gitlab.Response, error) {
+	const maxAttempts = 5
+	const baseDelay = 2 * time.Second
+	var resp *gitlab.Response
+	var err error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		_, resp, err = gc.client.Branches.CreateBranch(projectID, opt)
+		if err == nil {
+			return resp, nil
+		}
+		if resp != nil && resp.StatusCode == http.StatusConflict {
+			return resp, err
+		}
+		if !isGitlabTransientError(err) || attempt == maxAttempts {
+			return resp, err
+		}
+		delay := baseDelay * time.Duration(1<<(attempt-1))
+		fmt.Printf("[gitlab-retry] CreateBranch attempt %d/%d: %v; retrying in %s\n",
+			attempt, maxAttempts, err, delay)
+		time.Sleep(delay)
+	}
+	return resp, err
+}
+
 // CreateBranch creates a new branch in a GitLab project with the given projectID and newBranchName
 func (gc *GitlabClient) CreateBranch(projectID, newBranchName, defaultBranch string) error {
 	// Prepare the branch creation request
@@ -19,7 +53,7 @@ func (gc *GitlabClient) CreateBranch(projectID, newBranchName, defaultBranch str
 	}
 
 	// Perform the branch creation
-	_, _, err := gc.client.Branches.CreateBranch(projectID, branchOpts)
+	_, err := gc.createBranchWithRetry(projectID, branchOpts)
 	if err != nil {
 		return fmt.Errorf("failed to create branch %s in project %s: %w", newBranchName, projectID, err)
 	}
@@ -77,7 +111,7 @@ func (gc *GitlabClient) CreateGitlabNewBranch(projectID, branchName, sha, baseBr
 		Branch: &branchName,
 		Ref:    &sha,
 	}
-	_, resp, err := gc.client.Branches.CreateBranch(projectID, opt)
+	resp, err := gc.createBranchWithRetry(projectID, opt)
 	if err != nil {
 		// Check if the error is due to the branch already existing
 		if resp != nil && resp.StatusCode == http.StatusConflict {

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -255,6 +255,10 @@ const (
 	// ComponentGroup that the snapshot belongs to have been created
 	ParentSnapshotsCreatedCondition = "ParentSnapshotsCreated"
 
+	// SnapshotSupersededMessage is the AutoReleased condition message when
+	// an older Snapshot is skipped by a newer Snapshot for the same Application.
+	SnapshotSupersededMessage = "Released in newer Snapshot"
+
 	// SnapshotAddedToGlobalCandidateListCondition is the condition for marking if Snapshot's component was added to
 	// the global candidate list.
 	SnapshotAddedToGlobalCandidateListCondition = "AddedToGlobalCandidateList"
@@ -338,10 +342,8 @@ const (
 	ChildSnapshotAnnotation = TestLabelPrefix + "/child-snapshot"
 )
 
-var (
-	// SnapshotComponentLabel contains the name of the updated Snapshot component - it should match the pipeline label.
-	SnapshotComponentLabel = tektonconsts.ComponentNameLabel
-)
+// SnapshotComponentLabel contains the name of the updated Snapshot component - it should match the pipeline label.
+var SnapshotComponentLabel = tektonconsts.ComponentNameLabel
 
 const (
 	// maxPrefixLength is the maximum length of the prefix for the snapshot name
@@ -769,7 +771,6 @@ func HaveAppStudioTestsSucceeded(snapshot *applicationapiv1alpha1.Snapshot) bool
 
 // GetTestSucceededCondition checks status of tests on the snapshot
 func GetTestSucceededCondition(snapshot *applicationapiv1alpha1.Snapshot) (condition *metav1.Condition, ok bool) {
-
 	condition = meta.FindStatusCondition(snapshot.Status.Conditions, AppStudioTestSucceededCondition)
 	if condition == nil {
 		condition = meta.FindStatusCondition(snapshot.Status.Conditions, LegacyTestSucceededCondition)
@@ -1215,7 +1216,6 @@ func ResetSnapshotStatusConditions(ctx context.Context, adapterClient client.Cli
 // ObjectMeta: metav1.ObjectMeta{
 // TODO: replace 'object' with 'componentGroup' after application is deprecated. Also delete Application bool
 func CopySnapshotLabelsAndAnnotations(object *metav1.ObjectMeta, snapshot *applicationapiv1alpha1.Snapshot, componentName string, source *metav1.ObjectMeta, prefixes []string, objectIsApplication bool) {
-
 	if snapshot.Labels == nil {
 		snapshot.Labels = map[string]string{}
 	}
@@ -1242,7 +1242,6 @@ func CopySnapshotLabelsAndAnnotations(object *metav1.ObjectMeta, snapshot *appli
 		_ = metadata.CopyLabelsByPrefix(source, &snapshot.ObjectMeta, prefix)
 		_ = metadata.CopyAnnotationsByPrefix(source, &snapshot.ObjectMeta, prefix)
 	}
-
 }
 
 // BuildResultAnnotationKey normalizes a PipelineRun result name into a Snapshot annotation key.
@@ -1373,7 +1372,7 @@ func IsScenarioApplicableToSnapshotsContext(scenario *v1beta2.IntegrationTestSce
 		return true
 	}
 	for _, scenarioContext := range scenario.Spec.Contexts {
-		scenarioContext := scenarioContext //G601
+		scenarioContext := scenarioContext // G601
 		if IsContextValidForSnapshot(scenarioContext.Name, snapshot) {
 			return true
 		}
@@ -1386,7 +1385,7 @@ func IsScenarioApplicableToSnapshotsContext(scenario *v1beta2.IntegrationTestSce
 func FilterIntegrationTestScenariosWithContext(scenarios *[]v1beta2.IntegrationTestScenario, snapshot *applicationapiv1alpha1.Snapshot) *[]v1beta2.IntegrationTestScenario {
 	var filteredScenarioList []v1beta2.IntegrationTestScenario
 	for _, scenario := range *scenarios {
-		scenario := scenario //G601
+		scenario := scenario // G601
 		if IsScenarioApplicableToSnapshotsContext(&scenario, snapshot) {
 			filteredScenarioList = append(filteredScenarioList, scenario)
 		}
@@ -1417,7 +1416,6 @@ func FindMatchingSnapshotComponent(snapshot *applicationapiv1alpha1.Snapshot, co
 		}
 	}
 	return applicationapiv1alpha1.SnapshotComponent{}
-
 }
 
 // SortSnapshots sorts the snapshots according to the snapshot annotation BuildPipelineRunStartTime

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,10 @@ require (
 	github.com/tektoncd/pipeline v1.7.0
 	github.com/tonglil/buflogr v1.1.1
 	gitlab.com/gitlab-org/api/client-go v0.134.0
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0
+	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/exp v0.0.0-20260112195511-716be5621a96
@@ -152,12 +156,8 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,10 @@ require (
 	github.com/tektoncd/pipeline v1.7.0
 	github.com/tonglil/buflogr v1.1.1
 	gitlab.com/gitlab-org/api/client-go/v2 v2.36.0
+	go.opentelemetry.io/otel v1.40.0
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0
+	go.opentelemetry.io/otel/sdk v1.40.0
+	go.opentelemetry.io/otel/trace v1.40.0
 	go.uber.org/mock v0.6.0
 	go.uber.org/zap v1.27.1
 	golang.org/x/oauth2 v0.36.0
@@ -151,12 +155,8 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.64.0 // indirect
-	go.opentelemetry.io/otel v1.40.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.39.0 // indirect
-	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.39.0 // indirect
 	go.opentelemetry.io/otel/metric v1.40.0 // indirect
-	go.opentelemetry.io/otel/sdk v1.40.0 // indirect
-	go.opentelemetry.io/otel/trace v1.40.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.9.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -34,6 +34,7 @@ import (
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/snapshot"
 	"github.com/konflux-ci/integration-service/status"
 	"github.com/konflux-ci/integration-service/tekton"
@@ -342,6 +343,9 @@ func (a *Adapter) EnsureSnapshotExistsApplication() (result controller.Operation
 			"pipelineRun.Name", a.pipelineRun.Name)
 		return controller.RequeueWithError(err)
 	}
+
+	// Emit timing spans for the build PipelineRun if not already emitted
+	a.emitBuildTimingSpans()
 
 	canRemoveFinalizer = true
 	return controller.ContinueProcessing()
@@ -752,6 +756,11 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 
 	prefixes := []string{gitops.BuildPipelineRunPrefix, gitops.TestLabelPrefix, gitops.CustomLabelPrefix, gitops.ReleaseLabelPrefix}
 	gitops.CopySnapshotLabelsAndAnnotations(&application.ObjectMeta, snapshot, a.component.Name, &pipelineRun.ObjectMeta, prefixes, true)
+
+	// Propagate span context from build PipelineRun to Snapshot for distributed tracing
+	if tp, found := pipelineRun.Annotations[tektonconsts.SpanContextAnnotation]; found && tp != "" {
+		snapshot.Annotations[tektonconsts.SpanContextAnnotation] = tp
+	}
 
 	snapshot.Labels[gitops.BuildPipelineRunNameLabel] = pipelineRun.Name
 	if pipelineRun.Status.CompletionTime != nil {
@@ -1361,4 +1370,31 @@ func (a *Adapter) IsLatestBuildPipelineRunInComponentWithPRGroupHash(buildPlr *t
 
 	a.logger.Info(fmt.Sprintf("The build pipelineRun %s/%s with pr group %s is not the latest for its component, skipped", buildPlr.Namespace, buildPlr.Name, prGroupName))
 	return false, nil
+}
+
+// emitBuildTimingSpans emits timing spans for the build PipelineRun if not already emitted
+func (a *Adapter) emitBuildTimingSpans() {
+	// Check if timing spans have already been emitted
+	if _, found := a.pipelineRun.Annotations[tektonconsts.TimingEmittedAnnotation]; found {
+		return // Already emitted
+	}
+
+	// Get span context from the PipelineRun
+	tp := a.pipelineRun.Annotations[tektonconsts.SpanContextAnnotation]
+
+	// Emit timing spans
+	if tracing.EmitTimingSpans(a.pipelineRun, tracing.LoadLabelNames(), tp) {
+		// Mark as emitted to avoid duplicates on subsequent reconciles
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var err error
+			a.pipelineRun, err = a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
+			if err != nil {
+				return err
+			}
+			return tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.TimingEmittedAnnotation, "true", a.client)
+		})
+		if err != nil {
+			a.logger.Error(err, "Failed to mark build timing spans as emitted")
+		}
+	}
 }

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -34,6 +34,7 @@ import (
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/snapshot"
 	"github.com/konflux-ci/integration-service/status"
 	"github.com/konflux-ci/integration-service/tekton"
@@ -158,6 +159,7 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 	var canRemoveFinalizer bool
 
 	defer func() {
+		a.emitBuildTimingSpans()
 		// Don't write a failure annotation for transient Chains-not-signed errors
 		annotationErr := err
 		if h.IsChainsNotSignedError(err) {
@@ -261,6 +263,7 @@ func (a *Adapter) EnsureSnapshotExistsApplication() (result controller.Operation
 	var canRemoveFinalizer bool
 
 	defer func() {
+		a.emitBuildTimingSpans()
 		// Don't write a failure annotation for transient Chains-not-signed errors
 		annotationErr := err
 		if h.IsChainsNotSignedError(err) {
@@ -846,6 +849,11 @@ func (a *Adapter) prepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRu
 
 	prefixes := []string{gitops.BuildPipelineRunPrefix, gitops.TestLabelPrefix, gitops.CustomLabelPrefix, gitops.ReleaseLabelPrefix}
 	gitops.CopySnapshotLabelsAndAnnotations(&application.ObjectMeta, snapshot, a.component.Name, &pipelineRun.ObjectMeta, prefixes, true)
+
+	// Propagate span context from build PipelineRun to Snapshot for distributed tracing
+	if tp, found := pipelineRun.Annotations[tracing.SpanContextAnnotation]; found && tp != "" {
+		snapshot.Annotations[tracing.SpanContextAnnotation] = tp
+	}
 
 	snapshot.Labels[gitops.BuildPipelineRunNameLabel] = pipelineRun.Name
 	if pipelineRun.Status.CompletionTime != nil {
@@ -1465,4 +1473,19 @@ func (a *Adapter) IsLatestBuildPipelineRunInComponentWithPRGroupHash(buildPlr *t
 
 	a.logger.Info(fmt.Sprintf("The build pipelineRun %s/%s with pr group %s is not the latest for its component, skipped", buildPlr.Namespace, buildPlr.Name, prGroupName))
 	return false, nil
+}
+
+// emitBuildTimingSpans emits timing spans for the build PipelineRun if not already emitted
+func (a *Adapter) emitBuildTimingSpans() {
+	spanContext := a.pipelineRun.Annotations[tracing.SpanContextAnnotation]
+	patched, err := tracing.EmitAndMarkTimingSpans(a.context, a.pipelineRun, spanContext, "", a.client, func() (*tektonv1.PipelineRun, error) {
+		return a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
+	})
+	if err != nil {
+		a.logger.Error(err, "Failed to emit and mark build timing spans")
+		return
+	}
+	if patched != nil {
+		a.pipelineRun = patched
+	}
 }

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/snapshot"
 	"github.com/konflux-ci/integration-service/status"
 	"github.com/konflux-ci/integration-service/tekton"
@@ -39,6 +40,8 @@ import (
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
 
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/mock/gomock"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -3871,6 +3874,95 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			}, time.Second*10).Should(BeTrue())
 		})
 
+	})
+
+	When("emitBuildTimingSpans is called", func() {
+		BeforeEach(func() {
+			adapter = createAdapter()
+		})
+
+		It("does nothing when the PipelineRun already has the timingEmitted annotation", func() {
+			adapter.pipelineRun.Annotations[tracing.TimingEmittedAnnotation] = "true"
+			adapter.emitBuildTimingSpans()
+			Expect(adapter.pipelineRun.Annotations[tracing.TimingEmittedAnnotation]).To(Equal("true"))
+		})
+
+		It("does not annotate the PipelineRun when the global tracer provider is the noop", func() {
+			adapter.pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			adapter.pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			Expect(k8sClient.Status().Update(ctx, adapter.pipelineRun)).To(Succeed())
+
+			adapter.emitBuildTimingSpans()
+			Expect(adapter.pipelineRun.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+		})
+
+		It("does not annotate the PipelineRun when start or completion time is missing", func() {
+			prev := otel.GetTracerProvider()
+			tp := sdktrace.NewTracerProvider()
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(ctx)
+			})
+
+			adapter.emitBuildTimingSpans()
+			Expect(adapter.pipelineRun.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+		})
+
+		It("emits spans and patches the timingEmitted annotation when the run has completed", func() {
+			prev := otel.GetTracerProvider()
+			tp := sdktrace.NewTracerProvider()
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(ctx)
+			})
+
+			adapter.pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			adapter.pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			Expect(k8sClient.Status().Update(ctx, adapter.pipelineRun)).To(Succeed())
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.GetPipelineRunContextKey,
+					Resource:   adapter.pipelineRun,
+				},
+			})
+
+			adapter.emitBuildTimingSpans()
+
+			Eventually(func(g Gomega) {
+				updated := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adapter.pipelineRun.Name, Namespace: adapter.pipelineRun.Namespace}, updated)).To(Succeed())
+				g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(tracing.TimingEmittedAnnotation, "true"))
+			}).Should(Succeed())
+		})
+
+		It("logs and returns without marking the run when the refetch errors, so reconciliation continues and the next pass retries", func() {
+			prev := otel.GetTracerProvider()
+			tp := sdktrace.NewTracerProvider()
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(ctx)
+			})
+
+			adapter.pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			adapter.pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			Expect(k8sClient.Status().Update(ctx, adapter.pipelineRun)).To(Succeed())
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.GetPipelineRunContextKey,
+					Err:        errors.New("refetch boom"),
+				},
+			})
+
+			Expect(func() { adapter.emitBuildTimingSpans() }).NotTo(Panic())
+			Expect(adapter.pipelineRun.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+
+			stored := &tektonv1.PipelineRun{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adapter.pipelineRun.Name, Namespace: adapter.pipelineRun.Namespace}, stored)).To(Succeed())
+			Expect(stored.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+		})
 	})
 
 	createAdapter = func() *Adapter {

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -26,6 +26,7 @@ import (
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/status"
 
 	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
@@ -105,6 +106,11 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 	if err != nil {
 		a.logger.Error(err, "Failed to update pipeline status in snapshot")
 		return controller.RequeueWithError(fmt.Errorf("failed to update test status in snapshot: %w", err))
+	}
+
+	// Emit timing spans for the integration test PipelineRun if finished
+	if h.HasPipelineRunFinished(a.pipelineRun) {
+		a.emitTestTimingSpans()
 	}
 
 	// Remove the finalizer from Integration PLRs if the snapshot is not group or component type and its PLR has finished
@@ -205,4 +211,41 @@ func (a *Adapter) annotateIntegrationPipelineRunLogURL(ctx context.Context, adap
 		}
 		return err
 	})
+}
+
+// emitTestTimingSpans emits timing spans for the integration test PipelineRun if not already emitted.
+func (a *Adapter) emitTestTimingSpans() {
+	// Check if timing spans have already been emitted
+	if _, found := a.pipelineRun.Annotations[tektonconsts.TimingEmittedAnnotation]; found {
+		return // Already emitted
+	}
+
+	// Get span context from the snapshot (which got it from the build PLR)
+	tp := ""
+	if a.snapshot != nil && a.snapshot.Annotations != nil {
+		tp = a.snapshot.Annotations[tektonconsts.SpanContextAnnotation]
+	}
+
+	// Emit timing spans
+	emitted := tracing.EmitTimingSpans(a.pipelineRun, tracing.LoadLabelNames(), tp)
+
+	if emitted {
+		// Mark as emitted to avoid duplicates on subsequent reconciles
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			var err error
+			a.pipelineRun, err = a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
+			if err != nil {
+				return err
+			}
+			patch := client.MergeFrom(a.pipelineRun.DeepCopy())
+			if a.pipelineRun.Annotations == nil {
+				a.pipelineRun.Annotations = make(map[string]string)
+			}
+			a.pipelineRun.Annotations[tektonconsts.TimingEmittedAnnotation] = "true"
+			return a.client.Patch(a.context, a.pipelineRun, patch)
+		})
+		if err != nil {
+			a.logger.Error(err, "Failed to mark test timing spans as emitted")
+		}
+	}
 }

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -26,6 +26,7 @@ import (
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/status"
 
 	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
@@ -107,10 +108,24 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		return controller.RequeueWithError(fmt.Errorf("failed to update test status in snapshot: %w", err))
 	}
 
+	if h.HasPipelineRunFinished(a.pipelineRun) {
+		var failureMsg string
+		if pipelinerunStatus == intgteststat.IntegrationTestStatusTestFail {
+			failureMsg = detail
+		}
+		a.emitTestTimingSpans(failureMsg)
+	}
+
 	// Remove the finalizer from Integration PLRs if the snapshot is not group or component type and its PLR has finished
 	if (!gitops.IsGroupSnapshot(a.snapshot) && !gitops.IsComponentSnapshot(a.snapshot)) && (h.HasPipelineRunFinished(a.pipelineRun) ||
 		pipelinerunStatus == intgteststat.IntegrationTestStatusDeleted) {
-		err = h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.IntegrationPipelineRunFinalizer)
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			latest, fetchErr := a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
+			if fetchErr != nil {
+				return fetchErr
+			}
+			return h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, latest, h.IntegrationPipelineRunFinalizer)
+		})
 		if err != nil {
 			return controller.RequeueWithError(fmt.Errorf("failed to remove the finalizer: %w", err))
 		}
@@ -205,4 +220,22 @@ func (a *Adapter) annotateIntegrationPipelineRunLogURL(ctx context.Context, adap
 		}
 		return err
 	})
+}
+
+// emitTestTimingSpans emits timing spans for the integration test PipelineRun if not already emitted.
+func (a *Adapter) emitTestTimingSpans(failureMsg string) {
+	spanContext := ""
+	if a.snapshot != nil && a.snapshot.Annotations != nil {
+		spanContext = a.snapshot.Annotations[tracing.SpanContextAnnotation]
+	}
+	patched, err := tracing.EmitAndMarkTimingSpans(a.context, a.pipelineRun, spanContext, failureMsg, a.client, func() (*tektonv1.PipelineRun, error) {
+		return a.loader.GetPipelineRun(a.context, a.client, a.pipelineRun.Name, a.pipelineRun.Namespace)
+	})
+	if err != nil {
+		a.logger.Error(err, "Failed to emit and mark test timing spans")
+		return
+	}
+	if patched != nil {
+		a.pipelineRun = patched
+	}
 }

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package integrationpipeline
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"reflect"
@@ -29,7 +30,11 @@ import (
 	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
@@ -1247,6 +1252,95 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			detail, ok := statuses.GetScenarioStatus(integrationTestScenario.Name)
 			Expect(ok).To(BeTrue())
 			Expect(detail.TestPipelineRunName).To(Equal("test-pipeline-with-finalizer"))
+		})
+	})
+
+	When("emitTestTimingSpans is called", func() {
+		BeforeEach(func() {
+			adapter = NewAdapter(ctx, integrationPipelineRunComponent, hasSnapshot, logger, loader.NewMockLoader(), k8sClient)
+		})
+
+		It("does nothing when the PipelineRun already has the timingEmitted annotation", func() {
+			adapter.pipelineRun.Annotations[tracing.TimingEmittedAnnotation] = "true"
+			adapter.emitTestTimingSpans("")
+			Expect(adapter.pipelineRun.Annotations[tracing.TimingEmittedAnnotation]).To(Equal("true"))
+		})
+
+		It("does not annotate the PipelineRun when the global tracer provider is the noop", func() {
+			adapter.pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			adapter.pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			Expect(k8sClient.Status().Update(ctx, adapter.pipelineRun)).To(Succeed())
+
+			adapter.emitTestTimingSpans("")
+			Expect(adapter.pipelineRun.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+		})
+
+		It("does not annotate the PipelineRun when start or completion time is missing", func() {
+			prev := otel.GetTracerProvider()
+			tp := sdktrace.NewTracerProvider()
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(ctx)
+			})
+
+			adapter.emitTestTimingSpans("")
+			Expect(adapter.pipelineRun.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+		})
+
+		It("emits spans and patches the timingEmitted annotation when the run has completed", func() {
+			prev := otel.GetTracerProvider()
+			tp := sdktrace.NewTracerProvider()
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(ctx)
+			})
+
+			adapter.pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			adapter.pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			Expect(k8sClient.Status().Update(ctx, adapter.pipelineRun)).To(Succeed())
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.GetPipelineRunContextKey,
+					Resource:   adapter.pipelineRun,
+				},
+			})
+
+			adapter.emitTestTimingSpans("")
+
+			Eventually(func(g Gomega) {
+				updated := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adapter.pipelineRun.Name, Namespace: adapter.pipelineRun.Namespace}, updated)).To(Succeed())
+				g.Expect(updated.GetAnnotations()).To(HaveKeyWithValue(tracing.TimingEmittedAnnotation, "true"))
+			}).Should(Succeed())
+		})
+
+		It("logs and returns without marking the run when the refetch errors, so reconciliation continues and the next pass retries", func() {
+			prev := otel.GetTracerProvider()
+			tp := sdktrace.NewTracerProvider()
+			otel.SetTracerProvider(tp)
+			DeferCleanup(func() {
+				otel.SetTracerProvider(prev)
+				_ = tp.Shutdown(ctx)
+			})
+
+			adapter.pipelineRun.Status.StartTime = &metav1.Time{Time: time.Now().Add(-time.Minute)}
+			adapter.pipelineRun.Status.CompletionTime = &metav1.Time{Time: time.Now()}
+			Expect(k8sClient.Status().Update(ctx, adapter.pipelineRun)).To(Succeed())
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.GetPipelineRunContextKey,
+					Err:        errors.New("refetch boom"),
+				},
+			})
+
+			Expect(func() { adapter.emitTestTimingSpans("") }).NotTo(Panic())
+			Expect(adapter.pipelineRun.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+
+			stored := &tektonv1.PipelineRun{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: adapter.pipelineRun.Name, Namespace: adapter.pipelineRun.Namespace}, stored)).To(Succeed())
+			Expect(stored.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
 		})
 	})
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1092,6 +1092,11 @@ func (a *Adapter) prepareGroupSnapshot(application *applicationapiv1alpha1.Appli
 		return nil, nil, err
 	}
 
+	// Propagate span context from triggering snapshot
+	if tp := a.snapshot.Annotations[tektonconsts.SpanContextAnnotation]; tp != "" {
+		groupSnapshot.Annotations[tektonconsts.SpanContextAnnotation] = tp
+	}
+
 	return groupSnapshot, componentSnapshotInfos, nil
 }
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
 	clienterrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -36,6 +37,7 @@ import (
 	h "github.com/konflux-ci/integration-service/helpers"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
 	"github.com/konflux-ci/integration-service/pkg/metrics"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/release"
 	"github.com/konflux-ci/integration-service/snapshot"
 	"github.com/konflux-ci/integration-service/status"
@@ -666,7 +668,7 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 	autoReleaseMessage := ""
 	if len(*releasePlans) > 0 {
 		if !gitops.IgnoreSupersession(a.snapshot.ObjectMeta) && a.isSnapshotOlderThanLastBuild(a.snapshot) {
-			autoReleaseMessage = "Released in newer Snapshot"
+			autoReleaseMessage = gitops.SnapshotSupersededMessage
 		} else {
 			if err := a.createMissingReleasesForReleasePlans(releasePlans, a.snapshot); err != nil {
 				return a.handleReleaseError(err, "Failed to create new release")
@@ -687,7 +689,39 @@ func (a *Adapter) EnsureAllReleasesExist() (controller.OperationResult, error) {
 		return controller.RequeueWithError(err)
 	}
 
+	if autoReleaseMessage == gitops.SnapshotSupersededMessage {
+		a.emitSupersededWaitDuration()
+	}
+
 	return controller.ContinueProcessing()
+}
+
+func (a *Adapter) emitSupersededWaitDuration() {
+	if a.snapshot == nil {
+		return
+	}
+	spanContext := ""
+	if a.snapshot.Annotations != nil {
+		spanContext = a.snapshot.Annotations[tracing.SpanContextAnnotation]
+	}
+	start := a.snapshot.CreationTimestamp.Time
+	end := time.Now()
+	for _, cond := range a.snapshot.Status.Conditions {
+		if cond.Type == gitops.SnapshotAutoReleasedCondition {
+			end = cond.LastTransitionTime.Time
+			break
+		}
+	}
+	extraAttrs := []attribute.KeyValue{
+		tracing.NamespaceKey.String(a.snapshot.Namespace),
+		tracing.SnapshotKey.String(a.snapshot.Name),
+	}
+	if app := a.snapshot.Spec.Application; app != "" {
+		extraAttrs = append(extraAttrs, tracing.DeliveryApplicationKey.String(app))
+	}
+	if !tracing.EmitSupersededWaitDuration(spanContext, gitops.SnapshotSupersededMessage, start, end, extraAttrs...) {
+		a.logger.Info("Skipped supersede waitDuration emission", "snapshot.Name", a.snapshot.Name)
+	}
 }
 
 // shouldProcessReleases checks if snapshot is ready for release
@@ -1258,6 +1292,11 @@ func (a *Adapter) prepareGroupSnapshotApplication(prGroup, prGroupHash string) (
 	if err != nil {
 		a.logger.Error(err, "failed to annotate group snapshot")
 		return nil, nil, err
+	}
+
+	// Propagate span context from triggering snapshot
+	if tp := a.snapshot.Annotations[tracing.SpanContextAnnotation]; tp != "" {
+		groupSnapshot.Annotations[tracing.SpanContextAnnotation] = tp
 	}
 
 	return groupSnapshot, componentSnapshotInfos, nil

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -18,12 +18,18 @@ package snapshot
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"reflect"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/tonglil/buflogr"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.uber.org/mock/gomock"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -34,6 +40,7 @@ import (
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/status"
 	tekton "github.com/konflux-ci/integration-service/tekton"
 	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
@@ -56,6 +63,28 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+type capturingSpanExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *capturingSpanExporter) ExportSpans(_ context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *capturingSpanExporter) Shutdown(_ context.Context) error { return nil }
+
+func (e *capturingSpanExporter) GetSpans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]sdktrace.ReadOnlySpan, len(e.spans))
+	copy(out, e.spans)
+	return out
+}
 
 // the pipelinerun yaml gotten from git resolver is prepared for resolutionRequest unittest
 const expectedPipelineYAML = `---
@@ -2342,6 +2371,100 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			condition := meta.FindStatusCondition(hasOldSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
 			Expect(condition).ToNot(BeNil())
 			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
+		})
+
+		It("emits a waitDuration span carrying cicd.pipeline.result=skip when the supersede path is taken", func() {
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			exporter := &capturingSpanExporter{}
+			provider := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+			prev := otel.GetTracerProvider()
+			otel.SetTracerProvider(provider)
+			otel.SetTextMapPropagator(propagation.TraceContext{})
+			defer otel.SetTracerProvider(prev)
+			defer func() { _ = provider.Shutdown(ctx) }()
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.HaveAppStudioTestsFinished(hasOldSnapshot) &&
+					gitops.HaveAppStudioTestsSucceeded(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			metav1.SetMetaDataAnnotation(&hasOldSnapshot.ObjectMeta, tracing.SpanContextAnnotation,
+				`{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`)
+			Expect(k8sClient.Update(ctx, hasOldSnapshot)).Should(Succeed())
+
+			newerSibling := applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "newer-sibling-for-trace",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotComponentLabel:       "test-component-older",
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime: "1703124000000",
+					},
+				},
+			}
+
+			adapter = NewAdapter(ctx, hasOldSnapshot, hasCompGroup, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{ContextKey: loader.ComponentGroupContextKey, Resource: hasCompGroup},
+				{ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey, Resource: []applicationapiv1alpha1.Snapshot{newerSibling}},
+				{ContextKey: loader.SnapshotContextKey, Resource: hasOldSnapshot},
+				{ContextKey: loader.AutoReleasePlansContextKey, Resource: []releasev1alpha1.ReleasePlan{*hasReleasePlan}},
+			})
+
+			result, err := adapter.EnsureAllReleasesExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.IsSnapshotMarkedAsAutoReleased(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			var skipSpan sdktrace.ReadOnlySpan
+			for _, s := range exporter.GetSpans() {
+				if s.Name() == tracing.SpanWaitDuration {
+					skipSpan = s
+					break
+				}
+			}
+			Expect(skipSpan).ToNot(BeNil())
+			Expect(skipSpan.Parent().TraceID().String()).To(Equal("4bf92f3577b34da6a3ce929d0e0e4736"))
+
+			var resultVal, messageVal, namespaceVal, snapshotVal string
+			for _, attr := range skipSpan.Attributes() {
+				switch string(attr.Key) {
+				case string(semconv.CICDPipelineResultKey):
+					resultVal = attr.Value.AsString()
+				case string(tracing.DeliveryResultMessageKey):
+					messageVal = attr.Value.AsString()
+				case string(tracing.NamespaceKey):
+					namespaceVal = attr.Value.AsString()
+				case string(tracing.SnapshotKey):
+					snapshotVal = attr.Value.AsString()
+				}
+			}
+			Expect(resultVal).To(Equal(semconv.CICDPipelineResultSkip.Value.AsString()))
+			Expect(messageVal).To(Equal("Released in newer Snapshot"))
+			Expect(namespaceVal).To(Equal(hasOldSnapshot.Namespace))
+			Expect(snapshotVal).To(Equal(hasOldSnapshot.Name))
 		})
 	})
 

--- a/pkg/tracing/emit_and_mark.go
+++ b/pkg/tracing/emit_and_mark.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+
+	"github.com/konflux-ci/operator-toolkit/metadata"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"k8s.io/client-go/util/retry"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// EmitAndMarkTimingSpans emits a PipelineRun's timing spans and patches TimingEmittedAnnotation so subsequent reconciles skip re-emission.
+func EmitAndMarkTimingSpans(
+	ctx context.Context,
+	pr *tektonv1.PipelineRun,
+	spanContext, failureMsg string,
+	cl client.Client,
+	refetch func() (*tektonv1.PipelineRun, error),
+) (patched *tektonv1.PipelineRun, err error) {
+	if _, found := pr.Annotations[TimingEmittedAnnotation]; found {
+		return // already marked; nothing to do
+	}
+	if !EmitTimingSpans(pr, LoadLabelNames(), EmitOptions{SpanContext: spanContext, FailureMsg: failureMsg}) {
+		return // emission skipped (noop provider or run not yet complete)
+	}
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest, refetchErr := refetch()
+		if refetchErr != nil {
+			return refetchErr
+		}
+		mergePatch := client.MergeFrom(latest.DeepCopy())
+		_ = metadata.SetAnnotation(&latest.ObjectMeta, TimingEmittedAnnotation, "true")
+		if patchErr := cl.Patch(ctx, latest, mergePatch); patchErr != nil {
+			return patchErr
+		}
+		patched = latest
+		return nil
+	})
+	return
+}

--- a/pkg/tracing/emit_and_mark_test.go
+++ b/pkg/tracing/emit_and_mark_test.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/konflux-ci/integration-service/pkg/tracing"
+)
+
+var _ = Describe("EmitAndMarkTimingSpans", func() {
+	var (
+		ctx    context.Context
+		pr     *tektonv1.PipelineRun
+		cl     client.Client
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		scheme = runtime.NewScheme()
+		Expect(tektonv1.AddToScheme(scheme)).To(Succeed())
+
+		start := time.Now().Add(-time.Minute)
+		end := time.Now()
+		pr = &tektonv1.PipelineRun{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "pr-sample",
+				Namespace: "default",
+			},
+			Status: tektonv1.PipelineRunStatus{
+				PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+					StartTime:      &metav1.Time{Time: start},
+					CompletionTime: &metav1.Time{Time: end},
+				},
+			},
+		}
+		cl = fake.NewClientBuilder().WithScheme(scheme).WithObjects(pr.DeepCopy()).Build()
+	})
+
+	refetchFrom := func(c client.Client) func() (*tektonv1.PipelineRun, error) {
+		return func() (*tektonv1.PipelineRun, error) {
+			latest := &tektonv1.PipelineRun{}
+			if err := c.Get(ctx, client.ObjectKeyFromObject(pr), latest); err != nil {
+				return nil, err
+			}
+			return latest, nil
+		}
+	}
+
+	It("returns nil patched when the annotation is already present", func() {
+		pr.Annotations = map[string]string{tracing.TimingEmittedAnnotation: "true"}
+
+		patched, err := tracing.EmitAndMarkTimingSpans(ctx, pr, "", "", cl, refetchFrom(cl))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(patched).To(BeNil())
+	})
+
+	It("returns nil patched when the global tracer provider is the noop", func() {
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(noop.NewTracerProvider())
+		DeferCleanup(func() { otel.SetTracerProvider(prev) })
+
+		patched, err := tracing.EmitAndMarkTimingSpans(ctx, pr, "", "", cl, refetchFrom(cl))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(patched).To(BeNil())
+	})
+
+	It("returns nil patched when start or completion time is missing", func() {
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(sdktrace.NewTracerProvider())
+		DeferCleanup(func() { otel.SetTracerProvider(prev) })
+
+		pr.Status.StartTime = nil
+		pr.Status.CompletionTime = nil
+
+		patched, err := tracing.EmitAndMarkTimingSpans(ctx, pr, "", "", cl, refetchFrom(cl))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(patched).To(BeNil())
+	})
+
+	It("emits spans and patches the timingEmitted annotation when the run has completed", func() {
+		prev := otel.GetTracerProvider()
+		tp := sdktrace.NewTracerProvider()
+		otel.SetTracerProvider(tp)
+		DeferCleanup(func() {
+			otel.SetTracerProvider(prev)
+			_ = tp.Shutdown(ctx)
+		})
+
+		patched, err := tracing.EmitAndMarkTimingSpans(ctx, pr, "", "", cl, refetchFrom(cl))
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(patched).NotTo(BeNil())
+		Expect(patched.GetAnnotations()).To(HaveKeyWithValue(tracing.TimingEmittedAnnotation, "true"))
+
+		stored := &tektonv1.PipelineRun{}
+		Expect(cl.Get(ctx, client.ObjectKeyFromObject(pr), stored)).To(Succeed())
+		Expect(stored.GetAnnotations()).To(HaveKeyWithValue(tracing.TimingEmittedAnnotation, "true"))
+	})
+
+	It("surfaces the error when the refetch callback fails", func() {
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(sdktrace.NewTracerProvider())
+		DeferCleanup(func() { otel.SetTracerProvider(prev) })
+
+		boom := errors.New("refetch failed")
+		patched, err := tracing.EmitAndMarkTimingSpans(ctx, pr, "", "", cl, func() (*tektonv1.PipelineRun, error) {
+			return nil, boom
+		})
+
+		Expect(err).To(MatchError(boom))
+		Expect(patched).To(BeNil())
+	})
+
+	It("surfaces the patch error and leaves the timingEmitted annotation unset so a future reconcile retries", func() {
+		prev := otel.GetTracerProvider()
+		otel.SetTracerProvider(sdktrace.NewTracerProvider())
+		DeferCleanup(func() { otel.SetTracerProvider(prev) })
+
+		boom := errors.New("patch failed")
+		failingCl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pr.DeepCopy()).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Patch: func(_ context.Context, _ client.WithWatch, _ client.Object, _ client.Patch, _ ...client.PatchOption) error {
+					return boom
+				},
+			}).Build()
+
+		patched, err := tracing.EmitAndMarkTimingSpans(ctx, pr, "", "", failingCl, refetchFrom(failingCl))
+
+		Expect(err).To(MatchError(boom))
+		Expect(patched).To(BeNil())
+
+		stored := &tektonv1.PipelineRun{}
+		Expect(failingCl.Get(ctx, client.ObjectKeyFromObject(pr), stored)).To(Succeed())
+		Expect(stored.GetAnnotations()).NotTo(HaveKey(tracing.TimingEmittedAnnotation))
+	})
+})

--- a/pkg/tracing/timing_spans.go
+++ b/pkg/tracing/timing_spans.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func CtxFromSpanContext(jsonCarrier string) (context.Context, bool) {
+	if jsonCarrier == "" {
+		return context.Background(), false
+	}
+	var carrier map[string]string
+	if err := json.Unmarshal([]byte(jsonCarrier), &carrier); err != nil {
+		setupLog.Info("ignoring malformed span context annotation", "error", err)
+		return context.Background(), false
+	}
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.MapCarrier(carrier))
+	sc := trace.SpanContextFromContext(ctx)
+	return ctx, sc.IsValid()
+}
+
+func buildCommonAttributes(pr *tektonv1.PipelineRun, labels LabelNames) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 6)
+	attrs = append(attrs,
+		NamespaceKey.String(pr.Namespace),
+		PipelineRunKey.String(pr.Name),
+		DeliveryPipelineRunUIDKey.String(string(pr.UID)),
+	)
+	prLabels := pr.GetLabels()
+	for _, m := range []struct {
+		labelName string
+		key       attribute.Key
+	}{
+		{labels.Action, semconv.CICDPipelineActionNameKey},
+		{labels.Application, DeliveryApplicationKey},
+		{labels.Component, DeliveryComponentKey},
+	} {
+		if m.labelName == "" {
+			continue
+		}
+		if v := prLabels[m.labelName]; v != "" {
+			attrs = append(attrs, m.key.String(v))
+		}
+	}
+	return attrs
+}
+
+func buildExecuteAttributes(pr *tektonv1.PipelineRun) []attribute.KeyValue {
+	cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil {
+		return nil
+	}
+	attrs := []attribute.KeyValue{ResultEnum(cond)}
+	if cond.Status == corev1.ConditionFalse && cond.Message != "" {
+		attrs = append(attrs, DeliveryResultMessageKey.String(TruncateResultMessage(cond.Message)))
+	}
+	return attrs
+}
+
+func EmitWaitDuration(ctx context.Context, pr *tektonv1.PipelineRun, labels LabelNames) {
+	if pr.Status.StartTime == nil {
+		return
+	}
+	start := pr.CreationTimestamp.Time
+	end := pr.Status.StartTime.Time
+	if end.Before(start) {
+		return
+	}
+
+	_, span := otel.Tracer(TracerName).Start(ctx, SpanWaitDuration,
+		trace.WithTimestamp(start),
+		trace.WithAttributes(buildCommonAttributes(pr, labels)...),
+	)
+	span.End(trace.WithTimestamp(end))
+}
+
+func EmitExecuteDuration(ctx context.Context, pr *tektonv1.PipelineRun, labels LabelNames) {
+	if pr.Status.StartTime == nil || pr.Status.CompletionTime == nil {
+		return
+	}
+	start := pr.Status.StartTime.Time
+	end := pr.Status.CompletionTime.Time
+	if end.Before(start) {
+		return
+	}
+
+	common := buildCommonAttributes(pr, labels)
+	extra := buildExecuteAttributes(pr)
+	attrs := make([]attribute.KeyValue, 0, len(common)+len(extra))
+	attrs = append(attrs, common...)
+	attrs = append(attrs, extra...)
+
+	_, span := otel.Tracer(TracerName).Start(ctx, SpanExecuteDuration,
+		trace.WithTimestamp(start),
+		trace.WithAttributes(attrs...),
+	)
+	span.End(trace.WithTimestamp(end))
+}
+
+// EmitTimingSpans returns true only after both spans are emitted.
+func EmitTimingSpans(pr *tektonv1.PipelineRun, labels LabelNames, spanContext string) bool {
+	if _, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); !ok {
+		return false
+	}
+
+	if pr.Status.StartTime == nil || pr.Status.CompletionTime == nil {
+		return false
+	}
+
+	parentCtx, ok := CtxFromSpanContext(spanContext)
+	if !ok {
+		parentCtx = context.Background()
+	}
+
+	EmitWaitDuration(parentCtx, pr, labels)
+	EmitExecuteDuration(parentCtx, pr, labels)
+
+	return true
+}

--- a/pkg/tracing/timing_spans.go
+++ b/pkg/tracing/timing_spans.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+func CtxFromSpanContext(jsonCarrier string) (context.Context, bool) {
+	if jsonCarrier == "" {
+		return context.Background(), false
+	}
+	var carrier map[string]string
+	if err := json.Unmarshal([]byte(jsonCarrier), &carrier); err != nil {
+		setupLog.Info("ignoring malformed span context annotation", "error", err)
+		return context.Background(), false
+	}
+	ctx := otel.GetTextMapPropagator().Extract(context.Background(), propagation.MapCarrier(carrier))
+	sc := trace.SpanContextFromContext(ctx)
+	return ctx, sc.IsValid()
+}
+
+func buildCommonAttributes(pr *tektonv1.PipelineRun, labels LabelNames) []attribute.KeyValue {
+	attrs := make([]attribute.KeyValue, 0, 6)
+	attrs = append(attrs,
+		NamespaceKey.String(pr.Namespace),
+		PipelineRunKey.String(pr.Name),
+		DeliveryPipelineRunUIDKey.String(string(pr.UID)),
+	)
+	prLabels := pr.GetLabels()
+	for _, m := range []struct {
+		labelName string
+		key       attribute.Key
+	}{
+		{labels.Action, semconv.CICDPipelineActionNameKey},
+		{labels.Application, DeliveryApplicationKey},
+		{labels.Component, DeliveryComponentKey},
+	} {
+		if m.labelName == "" {
+			continue
+		}
+		if v := prLabels[m.labelName]; v != "" {
+			attrs = append(attrs, m.key.String(v))
+		}
+	}
+	return attrs
+}
+
+func buildExecuteAttributes(pr *tektonv1.PipelineRun, failureMsg string) []attribute.KeyValue {
+	cond := pr.Status.GetCondition(apis.ConditionSucceeded)
+	if cond == nil {
+		return nil
+	}
+	attrs := []attribute.KeyValue{ResultEnum(cond)}
+	if cond.Status == corev1.ConditionFalse {
+		msg := failureMsg
+		if msg == "" {
+			msg = cond.Message
+		}
+		if msg != "" {
+			attrs = append(attrs, DeliveryResultMessageKey.String(TruncateResultMessage(msg)))
+		}
+	}
+	return attrs
+}
+
+func EmitWaitDuration(ctx context.Context, pr *tektonv1.PipelineRun, labels LabelNames) {
+	if pr.Status.StartTime == nil {
+		return
+	}
+	start := pr.CreationTimestamp.Time
+	end := pr.Status.StartTime.Time
+	if end.Before(start) {
+		return
+	}
+
+	_, span := otel.Tracer(TracerName).Start(ctx, SpanWaitDuration,
+		trace.WithTimestamp(start),
+		trace.WithAttributes(buildCommonAttributes(pr, labels)...),
+	)
+	span.End(trace.WithTimestamp(end))
+}
+
+func EmitExecuteDuration(ctx context.Context, pr *tektonv1.PipelineRun, labels LabelNames, failureMsg string) {
+	if pr.Status.StartTime == nil || pr.Status.CompletionTime == nil {
+		return
+	}
+	start := pr.Status.StartTime.Time
+	end := pr.Status.CompletionTime.Time
+	if end.Before(start) {
+		return
+	}
+
+	common := buildCommonAttributes(pr, labels)
+	extra := buildExecuteAttributes(pr, failureMsg)
+	attrs := make([]attribute.KeyValue, 0, len(common)+len(extra))
+	attrs = append(attrs, common...)
+	attrs = append(attrs, extra...)
+
+	_, span := otel.Tracer(TracerName).Start(ctx, SpanExecuteDuration,
+		trace.WithTimestamp(start),
+		trace.WithAttributes(attrs...),
+	)
+	span.End(trace.WithTimestamp(end))
+}
+
+type EmitOptions struct {
+	SpanContext string
+	FailureMsg  string
+}
+
+// EmitSupersededWaitDuration emits a wait span when a newer snapshot for the same application has
+// released, so the trace shows intentional dedup rather than a broken chain.
+func EmitSupersededWaitDuration(spanContext, resultMessage string, start, end time.Time, extraAttrs ...attribute.KeyValue) bool {
+	if _, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); !ok {
+		return false
+	}
+	if start.IsZero() || end.IsZero() || end.Before(start) {
+		return false
+	}
+
+	parentCtx, ok := CtxFromSpanContext(spanContext)
+	if !ok {
+		parentCtx = context.Background()
+	}
+
+	attrs := make([]attribute.KeyValue, 0, 2+len(extraAttrs))
+	attrs = append(attrs, semconv.CICDPipelineResultSkip)
+	if resultMessage != "" {
+		attrs = append(attrs, DeliveryResultMessageKey.String(TruncateResultMessage(resultMessage)))
+	}
+	attrs = append(attrs, extraAttrs...)
+
+	_, span := otel.Tracer(TracerName).Start(parentCtx, SpanWaitDuration,
+		trace.WithTimestamp(start),
+		trace.WithAttributes(attrs...),
+	)
+	span.End(trace.WithTimestamp(end))
+	return true
+}
+
+func EmitTimingSpans(pr *tektonv1.PipelineRun, labels LabelNames, opts EmitOptions) bool {
+	if _, ok := otel.GetTracerProvider().(*sdktrace.TracerProvider); !ok {
+		return false
+	}
+
+	if pr.Status.StartTime == nil || pr.Status.CompletionTime == nil {
+		return false
+	}
+
+	parentCtx, ok := CtxFromSpanContext(opts.SpanContext)
+	if !ok {
+		parentCtx = context.Background()
+	}
+
+	EmitWaitDuration(parentCtx, pr, labels)
+	EmitExecuteDuration(parentCtx, pr, labels, opts.FailureMsg)
+
+	return true
+}

--- a/pkg/tracing/timing_spans_test.go
+++ b/pkg/tracing/timing_spans_test.go
@@ -1,0 +1,535 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/konflux-ci/integration-service/pkg/tracing"
+)
+
+type testExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *testExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *testExporter) Shutdown(ctx context.Context) error { return nil }
+
+func (e *testExporter) GetSpans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.spans
+}
+
+func (e *testExporter) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = nil
+}
+
+func spanAttr(s sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.Emit()
+		}
+	}
+	return ""
+}
+
+func hasAttr(s sdktrace.ReadOnlySpan, key string) bool {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultLabels() tracing.LabelNames {
+	return tracing.LabelNames{
+		Action:      tracing.DefaultTracingLabelAction,
+		Application: tracing.DefaultTracingLabelApplication,
+		Component:   tracing.DefaultTracingLabelComponent,
+	}
+}
+
+var _ = Describe("Timing Spans", func() {
+	var (
+		exporter *testExporter
+		provider *sdktrace.TracerProvider
+	)
+
+	BeforeEach(func() {
+		exporter = &testExporter{}
+		provider = sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+		otel.SetTracerProvider(provider)
+		otel.SetTextMapPropagator(propagation.TraceContext{})
+	})
+
+	AfterEach(func() {
+		exporter.Reset()
+		_ = provider.Shutdown(context.Background())
+	})
+
+	Describe("CtxFromSpanContext", func() {
+		It("returns background context and false for empty string", func() {
+			ctx, valid := tracing.CtxFromSpanContext("")
+			Expect(valid).To(BeFalse())
+			Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+		})
+
+		It("returns background context and false for invalid JSON", func() {
+			ctx, valid := tracing.CtxFromSpanContext("not-json")
+			Expect(valid).To(BeFalse())
+			Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+		})
+
+		It("returns valid context and true for valid W3C traceparent", func() {
+			validSpanContext := `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`
+			ctx, valid := tracing.CtxFromSpanContext(validSpanContext)
+			Expect(valid).To(BeTrue())
+			sc := trace.SpanContextFromContext(ctx)
+			Expect(sc.IsValid()).To(BeTrue())
+			Expect(sc.TraceID().String()).To(Equal("4bf92f3577b34da6a3ce929d0e0e4736"))
+			Expect(sc.SpanID().String()).To(Equal("00f067aa0ba902b7"))
+		})
+	})
+
+	Describe("EmitWaitDuration", func() {
+		It("does nothing if StartTime is nil", func() {
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("does nothing if end time is before start time", func() {
+			now := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: now.Add(-time.Minute)},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits span with correct name and timestamps", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			Expect(spans[0].Name()).To(Equal(tracing.SpanWaitDuration))
+			Expect(spans[0].StartTime()).To(BeTemporally("~", creationTime, time.Second))
+			Expect(spans[0].EndTime()).To(BeTemporally("~", startTime, time.Second))
+		})
+	})
+
+	Describe("EmitExecuteDuration", func() {
+		It("does nothing if StartTime is nil", func() {
+			pr := &tektonv1.PipelineRun{}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("does nothing if CompletionTime is nil", func() {
+			pr := &tektonv1.PipelineRun{
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits span with correct name and timestamps", func() {
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			Expect(spans[0].Name()).To(Equal(tracing.SpanExecuteDuration))
+			Expect(spans[0].StartTime()).To(BeTemporally("~", startTime, time.Second))
+			Expect(spans[0].EndTime()).To(BeTemporally("~", completionTime, time.Second))
+		})
+	})
+
+	Describe("EmitTimingSpans", func() {
+		It("returns false if StartTime is nil", func() {
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), "")
+			Expect(result).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns false and emits nothing if CompletionTime is nil", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), "")
+			Expect(result).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns true and emits both spans if CompletionTime is set", func() {
+			creationTime := time.Now().Add(-2 * time.Minute)
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), "")
+			Expect(result).To(BeTrue())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(2))
+			Expect([]string{spans[0].Name(), spans[1].Name()}).To(ContainElements(tracing.SpanWaitDuration, tracing.SpanExecuteDuration))
+		})
+
+		It("uses parent context from valid span context", func() {
+			creationTime := time.Now().Add(-2 * time.Minute)
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			validSpanContext := `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), validSpanContext)
+			Expect(result).To(BeTrue())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(2))
+			Expect(spans[0].Parent().TraceID().String()).To(Equal("4bf92f3577b34da6a3ce929d0e0e4736"))
+		})
+
+		It("returns false and emits nothing when the global TracerProvider is the noop", func() {
+			otel.SetTracerProvider(noop.NewTracerProvider())
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute))},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), "")
+			Expect(result).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits the PipelineRun condition message as result_message on failure", func() {
+			creationTime := time.Now().Add(-2 * time.Minute)
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.NewTime(creationTime),
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionFalse,
+							Reason:  tektonv1.PipelineRunReasonFailedValidation.String(),
+							Message: "pr-level only",
+						}},
+					},
+				},
+			}
+
+			Expect(tracing.EmitTimingSpans(pr, defaultLabels(), "")).To(BeTrue())
+			var executeMsg string
+			for _, s := range exporter.GetSpans() {
+				if s.Name() == tracing.SpanExecuteDuration {
+					executeMsg = spanAttr(s, string(tracing.DeliveryResultMessageKey))
+				}
+			}
+			Expect(executeMsg).To(Equal("pr-level only"))
+		})
+	})
+
+	Describe("EmitExecuteDuration negative path: clock skew", func() {
+		It("emits no span when CompletionTime is before StartTime", func() {
+			now := time.Now()
+			pr := &tektonv1.PipelineRun{
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: now},
+						CompletionTime: &metav1.Time{Time: now.Add(-time.Second)},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+	})
+
+	Describe("Outcome attributes — extra cases for full coverage", func() {
+		It("emits no result attribute when the Succeeded condition is missing entirely", func() {
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.NewTime(startTime.Add(-30 * time.Second)),
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(semconv.CICDPipelineResultKey))).To(BeFalse())
+			Expect(hasAttr(s, string(tracing.DeliveryResultMessageKey))).To(BeFalse())
+		})
+	})
+
+	Describe("Label-driven attribute emission", func() {
+		It("emits identity + label attributes on waitDuration using the configured label names", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "test-ns",
+					UID:               types.UID("test-uid-123"),
+					CreationTimestamp: metav1.NewTime(creationTime),
+					Labels: map[string]string{
+						tracing.DefaultTracingLabelAction:      "build",
+						tracing.DefaultTracingLabelApplication: "my-app",
+						tracing.DefaultTracingLabelComponent:   "my-comp",
+					},
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			s := spans[0]
+			Expect(spanAttr(s, string(tracing.NamespaceKey))).To(Equal("test-ns"))
+			Expect(spanAttr(s, string(tracing.PipelineRunKey))).To(Equal("test-pr"))
+			Expect(spanAttr(s, string(tracing.DeliveryPipelineRunUIDKey))).To(Equal("test-uid-123"))
+			Expect(spanAttr(s, string(semconv.CICDPipelineActionNameKey))).To(Equal("build"))
+			Expect(spanAttr(s, string(tracing.DeliveryApplicationKey))).To(Equal("my-app"))
+			Expect(spanAttr(s, string(tracing.DeliveryComponentKey))).To(Equal("my-comp"))
+		})
+
+		It("omits attributes when labels are missing from the PipelineRun", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(semconv.CICDPipelineActionNameKey))).To(BeFalse())
+			Expect(hasAttr(s, string(tracing.DeliveryApplicationKey))).To(BeFalse())
+			Expect(hasAttr(s, string(tracing.DeliveryComponentKey))).To(BeFalse())
+		})
+
+		It("skips a configured-empty label name without reading any label", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			partial := tracing.LabelNames{
+				Action:      "",
+				Application: tracing.DefaultTracingLabelApplication,
+				Component:   tracing.DefaultTracingLabelComponent,
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(creationTime),
+					Labels: map[string]string{
+						tracing.DefaultTracingLabelAction:      "should-not-be-emitted",
+						tracing.DefaultTracingLabelApplication: "my-app",
+					},
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, partial)
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(semconv.CICDPipelineActionNameKey))).To(BeFalse())
+			Expect(spanAttr(s, string(tracing.DeliveryApplicationKey))).To(Equal("my-app"))
+		})
+	})
+
+	Describe("Outcome attributes", func() {
+		makeCompletedPR := func(status corev1.ConditionStatus, reason string, message string) *tektonv1.PipelineRun {
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			return &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(startTime.Add(-30 * time.Second)),
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:    apis.ConditionSucceeded,
+							Status:  status,
+							Reason:  reason,
+							Message: message,
+						}},
+					},
+				},
+			}
+		}
+
+		It("maps successful PipelineRun to success and omits result_message", func() {
+			pr := makeCompletedPR(corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(), "All steps completed")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultSuccess.Value.AsString()))
+			Expect(hasAttr(s, string(tracing.DeliveryResultMessageKey))).To(BeFalse())
+		})
+
+		It("maps failed PipelineRun to failure and emits cond.Message as result_message", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(), "pr-level failure detail")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultFailure.Value.AsString()))
+			Expect(spanAttr(s, string(tracing.DeliveryResultMessageKey))).To(Equal("pr-level failure detail"))
+		})
+
+		It("maps validation failure to error and emits cond.Message", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailedValidation.String(), "validation failed")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultError.Value.AsString()))
+			Expect(spanAttr(s, string(tracing.DeliveryResultMessageKey))).To(Equal("validation failed"))
+		})
+
+		It("maps timed-out PipelineRun to timeout", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonTimedOut.String(), "timed out")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			Expect(spanAttr(exporter.GetSpans()[0], string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultTimeout.Value.AsString()))
+		})
+
+		It("maps cancelled PipelineRun to cancellation", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelled.String(), "")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			Expect(spanAttr(exporter.GetSpans()[0], string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultCancellation.Value.AsString()))
+		})
+
+		It("truncates an overlong cond.Message", func() {
+			long := strings.Repeat("x", tracing.MaxResultMessageLen*2)
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(), long)
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels())
+			emitted := spanAttr(exporter.GetSpans()[0], string(tracing.DeliveryResultMessageKey))
+			Expect(len(emitted)).To(BeNumerically("<=", tracing.MaxResultMessageLen))
+			Expect(emitted).To(HaveSuffix(tracing.TruncatedSuffix))
+		})
+	})
+})

--- a/pkg/tracing/timing_spans_test.go
+++ b/pkg/tracing/timing_spans_test.go
@@ -1,0 +1,617 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/apis"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
+
+	"github.com/konflux-ci/integration-service/pkg/tracing"
+)
+
+type testExporter struct {
+	mu    sync.Mutex
+	spans []sdktrace.ReadOnlySpan
+}
+
+func (e *testExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = append(e.spans, spans...)
+	return nil
+}
+
+func (e *testExporter) Shutdown(ctx context.Context) error { return nil }
+
+func (e *testExporter) GetSpans() []sdktrace.ReadOnlySpan {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.spans
+}
+
+func (e *testExporter) Reset() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	e.spans = nil
+}
+
+func spanAttr(s sdktrace.ReadOnlySpan, key string) string {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return attr.Value.Emit()
+		}
+	}
+	return ""
+}
+
+func hasAttr(s sdktrace.ReadOnlySpan, key string) bool {
+	for _, attr := range s.Attributes() {
+		if string(attr.Key) == key {
+			return true
+		}
+	}
+	return false
+}
+
+func defaultLabels() tracing.LabelNames {
+	return tracing.LabelNames{
+		Action:      tracing.DefaultTracingLabelAction,
+		Application: tracing.DefaultTracingLabelApplication,
+		Component:   tracing.DefaultTracingLabelComponent,
+	}
+}
+
+var _ = Describe("Timing Spans", func() {
+	var (
+		exporter *testExporter
+		provider *sdktrace.TracerProvider
+	)
+
+	BeforeEach(func() {
+		prev := otel.GetTracerProvider()
+		DeferCleanup(func() { otel.SetTracerProvider(prev) })
+		exporter = &testExporter{}
+		provider = sdktrace.NewTracerProvider(sdktrace.WithSyncer(exporter))
+		otel.SetTracerProvider(provider)
+		otel.SetTextMapPropagator(propagation.TraceContext{})
+	})
+
+	AfterEach(func() {
+		exporter.Reset()
+		_ = provider.Shutdown(context.Background())
+	})
+
+	Describe("CtxFromSpanContext", func() {
+		It("returns background context and false for empty string", func() {
+			ctx, valid := tracing.CtxFromSpanContext("")
+			Expect(valid).To(BeFalse())
+			Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+		})
+
+		It("returns background context and false for invalid JSON", func() {
+			ctx, valid := tracing.CtxFromSpanContext("not-json")
+			Expect(valid).To(BeFalse())
+			Expect(trace.SpanContextFromContext(ctx).IsValid()).To(BeFalse())
+		})
+
+		It("returns valid context and true for valid W3C traceparent", func() {
+			validSpanContext := `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`
+			ctx, valid := tracing.CtxFromSpanContext(validSpanContext)
+			Expect(valid).To(BeTrue())
+			sc := trace.SpanContextFromContext(ctx)
+			Expect(sc.IsValid()).To(BeTrue())
+			Expect(sc.TraceID().String()).To(Equal("4bf92f3577b34da6a3ce929d0e0e4736"))
+			Expect(sc.SpanID().String()).To(Equal("00f067aa0ba902b7"))
+		})
+	})
+
+	Describe("EmitWaitDuration", func() {
+		It("does nothing if StartTime is nil", func() {
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("does nothing if end time is before start time", func() {
+			now := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(now)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: now.Add(-time.Minute)},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits span with correct name and timestamps", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			Expect(spans[0].Name()).To(Equal(tracing.SpanWaitDuration))
+			Expect(spans[0].StartTime()).To(BeTemporally("~", creationTime, time.Second))
+			Expect(spans[0].EndTime()).To(BeTemporally("~", startTime, time.Second))
+		})
+	})
+
+	Describe("EmitExecuteDuration", func() {
+		It("does nothing if StartTime is nil", func() {
+			pr := &tektonv1.PipelineRun{}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("does nothing if CompletionTime is nil", func() {
+			pr := &tektonv1.PipelineRun{
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits span with correct name and timestamps", func() {
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			Expect(spans[0].Name()).To(Equal(tracing.SpanExecuteDuration))
+			Expect(spans[0].StartTime()).To(BeTemporally("~", startTime, time.Second))
+			Expect(spans[0].EndTime()).To(BeTemporally("~", completionTime, time.Second))
+		})
+	})
+
+	Describe("EmitTimingSpans", func() {
+		It("returns false if StartTime is nil", func() {
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.Now()},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), tracing.EmitOptions{})
+			Expect(result).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns false and emits nothing if CompletionTime is nil", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), tracing.EmitOptions{})
+			Expect(result).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns true and emits both spans if CompletionTime is set", func() {
+			creationTime := time.Now().Add(-2 * time.Minute)
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), tracing.EmitOptions{})
+			Expect(result).To(BeTrue())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(2))
+			Expect([]string{spans[0].Name(), spans[1].Name()}).To(ContainElements(tracing.SpanWaitDuration, tracing.SpanExecuteDuration))
+		})
+
+		It("uses parent context from valid span context", func() {
+			creationTime := time.Now().Add(-2 * time.Minute)
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			validSpanContext := `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), tracing.EmitOptions{SpanContext: validSpanContext})
+			Expect(result).To(BeTrue())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(2))
+			Expect(spans[0].Parent().TraceID().String()).To(Equal("4bf92f3577b34da6a3ce929d0e0e4736"))
+		})
+
+		It("returns false and emits nothing when the global TracerProvider is the noop", func() {
+			otel.SetTracerProvider(noop.NewTracerProvider())
+
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Minute))},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: time.Now()},
+					},
+				},
+			}
+			result := tracing.EmitTimingSpans(pr, defaultLabels(), tracing.EmitOptions{})
+			Expect(result).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits the PipelineRun condition message as result_message on failure", func() {
+			creationTime := time.Now().Add(-2 * time.Minute)
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.NewTime(creationTime),
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:    apis.ConditionSucceeded,
+							Status:  corev1.ConditionFalse,
+							Reason:  tektonv1.PipelineRunReasonFailedValidation.String(),
+							Message: "pr-level only",
+						}},
+					},
+				},
+			}
+
+			Expect(tracing.EmitTimingSpans(pr, defaultLabels(), tracing.EmitOptions{})).To(BeTrue())
+			var executeMsg string
+			for _, s := range exporter.GetSpans() {
+				if s.Name() == tracing.SpanExecuteDuration {
+					executeMsg = spanAttr(s, string(tracing.DeliveryResultMessageKey))
+				}
+			}
+			Expect(executeMsg).To(Equal("pr-level only"))
+		})
+	})
+
+	Describe("EmitExecuteDuration negative path: clock skew", func() {
+		It("emits no span when CompletionTime is before StartTime", func() {
+			now := time.Now()
+			pr := &tektonv1.PipelineRun{
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: now},
+						CompletionTime: &metav1.Time{Time: now.Add(-time.Second)},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+	})
+
+	Describe("Outcome attributes: extra cases for full coverage", func() {
+		It("emits no result attribute when the Succeeded condition is missing entirely", func() {
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "ns",
+					CreationTimestamp: metav1.NewTime(startTime.Add(-30 * time.Second)),
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+				},
+			}
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(semconv.CICDPipelineResultKey))).To(BeFalse())
+			Expect(hasAttr(s, string(tracing.DeliveryResultMessageKey))).To(BeFalse())
+		})
+	})
+
+	Describe("Label-driven attribute emission", func() {
+		It("emits identity + label attributes on waitDuration using the configured label names", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "test-ns",
+					UID:               types.UID("test-uid-123"),
+					CreationTimestamp: metav1.NewTime(creationTime),
+					Labels: map[string]string{
+						tracing.DefaultTracingLabelAction:      "build",
+						tracing.DefaultTracingLabelApplication: "my-app",
+						tracing.DefaultTracingLabelComponent:   "my-comp",
+					},
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			s := spans[0]
+			Expect(spanAttr(s, string(tracing.NamespaceKey))).To(Equal("test-ns"))
+			Expect(spanAttr(s, string(tracing.PipelineRunKey))).To(Equal("test-pr"))
+			Expect(spanAttr(s, string(tracing.DeliveryPipelineRunUIDKey))).To(Equal("test-uid-123"))
+			Expect(spanAttr(s, string(semconv.CICDPipelineActionNameKey))).To(Equal("build"))
+			Expect(spanAttr(s, string(tracing.DeliveryApplicationKey))).To(Equal("my-app"))
+			Expect(spanAttr(s, string(tracing.DeliveryComponentKey))).To(Equal("my-comp"))
+		})
+
+		It("omits attributes when labels are missing from the PipelineRun", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{CreationTimestamp: metav1.NewTime(creationTime)},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, defaultLabels())
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(semconv.CICDPipelineActionNameKey))).To(BeFalse())
+			Expect(hasAttr(s, string(tracing.DeliveryApplicationKey))).To(BeFalse())
+			Expect(hasAttr(s, string(tracing.DeliveryComponentKey))).To(BeFalse())
+		})
+
+		It("skips a configured-empty label name without reading any label", func() {
+			creationTime := time.Now().Add(-time.Minute)
+			startTime := time.Now()
+			partial := tracing.LabelNames{
+				Action:      "",
+				Application: tracing.DefaultTracingLabelApplication,
+				Component:   tracing.DefaultTracingLabelComponent,
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					CreationTimestamp: metav1.NewTime(creationTime),
+					Labels: map[string]string{
+						tracing.DefaultTracingLabelAction:      "should-not-be-emitted",
+						tracing.DefaultTracingLabelApplication: "my-app",
+					},
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime: &metav1.Time{Time: startTime},
+					},
+				},
+			}
+			tracing.EmitWaitDuration(context.Background(), pr, partial)
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(semconv.CICDPipelineActionNameKey))).To(BeFalse())
+			Expect(spanAttr(s, string(tracing.DeliveryApplicationKey))).To(Equal("my-app"))
+		})
+	})
+
+	Describe("Outcome attributes", func() {
+		makeCompletedPR := func(status corev1.ConditionStatus, reason string, message string) *tektonv1.PipelineRun {
+			startTime := time.Now().Add(-time.Minute)
+			completionTime := time.Now()
+			return &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              "test-pr",
+					Namespace:         "test-ns",
+					CreationTimestamp: metav1.NewTime(startTime.Add(-30 * time.Second)),
+				},
+				Status: tektonv1.PipelineRunStatus{
+					PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+						StartTime:      &metav1.Time{Time: startTime},
+						CompletionTime: &metav1.Time{Time: completionTime},
+					},
+					Status: duckv1.Status{
+						Conditions: duckv1.Conditions{{
+							Type:    apis.ConditionSucceeded,
+							Status:  status,
+							Reason:  reason,
+							Message: message,
+						}},
+					},
+				},
+			}
+		}
+
+		It("maps successful PipelineRun to success and omits result_message", func() {
+			pr := makeCompletedPR(corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(), "All steps completed")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultSuccess.Value.AsString()))
+			Expect(hasAttr(s, string(tracing.DeliveryResultMessageKey))).To(BeFalse())
+		})
+
+		It("maps failed PipelineRun to failure and emits cond.Message as result_message", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(), "pr-level failure detail")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultFailure.Value.AsString()))
+			Expect(spanAttr(s, string(tracing.DeliveryResultMessageKey))).To(Equal("pr-level failure detail"))
+		})
+
+		It("maps validation failure to error and emits cond.Message", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailedValidation.String(), "validation failed")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultError.Value.AsString()))
+			Expect(spanAttr(s, string(tracing.DeliveryResultMessageKey))).To(Equal("validation failed"))
+		})
+
+		It("maps timed-out PipelineRun to timeout", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonTimedOut.String(), "timed out")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			Expect(spanAttr(exporter.GetSpans()[0], string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultTimeout.Value.AsString()))
+		})
+
+		It("maps cancelled PipelineRun to cancellation", func() {
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelled.String(), "")
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			Expect(spanAttr(exporter.GetSpans()[0], string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultCancellation.Value.AsString()))
+		})
+
+		It("truncates an overlong cond.Message", func() {
+			long := strings.Repeat("x", tracing.MaxResultMessageLen*2)
+			pr := makeCompletedPR(corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(), long)
+			tracing.EmitExecuteDuration(context.Background(), pr, defaultLabels(), "")
+			emitted := spanAttr(exporter.GetSpans()[0], string(tracing.DeliveryResultMessageKey))
+			Expect(len(emitted)).To(BeNumerically("<=", tracing.MaxResultMessageLen))
+			Expect(emitted).To(HaveSuffix(tracing.TruncatedSuffix))
+		})
+	})
+
+	Describe("EmitSupersededWaitDuration", func() {
+		var (
+			start = time.Now().Add(-time.Minute)
+			end   = time.Now()
+		)
+
+		It("returns false and emits nothing when the global TracerProvider is the noop", func() {
+			otel.SetTracerProvider(noop.NewTracerProvider())
+			Expect(tracing.EmitSupersededWaitDuration("", "Released in newer Snapshot", start, end)).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns false when start time is zero", func() {
+			Expect(tracing.EmitSupersededWaitDuration("", "msg", time.Time{}, end)).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns false when end time is zero", func() {
+			Expect(tracing.EmitSupersededWaitDuration("", "msg", start, time.Time{})).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("returns false when end precedes start", func() {
+			Expect(tracing.EmitSupersededWaitDuration("", "msg", end, start)).To(BeFalse())
+			Expect(exporter.GetSpans()).To(BeEmpty())
+		})
+
+		It("emits a waitDuration span carrying result=skip and result_message", func() {
+			Expect(tracing.EmitSupersededWaitDuration("", "Released in newer Snapshot", start, end)).To(BeTrue())
+			spans := exporter.GetSpans()
+			Expect(spans).To(HaveLen(1))
+			s := spans[0]
+			Expect(s.Name()).To(Equal(tracing.SpanWaitDuration))
+			Expect(s.StartTime()).To(BeTemporally("~", start, time.Second))
+			Expect(s.EndTime()).To(BeTemporally("~", end, time.Second))
+			Expect(spanAttr(s, string(semconv.CICDPipelineResultKey))).To(Equal(semconv.CICDPipelineResultSkip.Value.AsString()))
+			Expect(spanAttr(s, string(tracing.DeliveryResultMessageKey))).To(Equal("Released in newer Snapshot"))
+		})
+
+		It("omits result_message when the supplied message is empty", func() {
+			Expect(tracing.EmitSupersededWaitDuration("", "", start, end)).To(BeTrue())
+			s := exporter.GetSpans()[0]
+			Expect(hasAttr(s, string(tracing.DeliveryResultMessageKey))).To(BeFalse())
+		})
+
+		It("truncates an overlong result message", func() {
+			long := strings.Repeat("x", tracing.MaxResultMessageLen*2)
+			Expect(tracing.EmitSupersededWaitDuration("", long, start, end)).To(BeTrue())
+			emitted := spanAttr(exporter.GetSpans()[0], string(tracing.DeliveryResultMessageKey))
+			Expect(len(emitted)).To(BeNumerically("<=", tracing.MaxResultMessageLen))
+			Expect(emitted).To(HaveSuffix(tracing.TruncatedSuffix))
+		})
+
+		It("propagates extra attributes onto the emitted span", func() {
+			extras := []attribute.KeyValue{
+				tracing.NamespaceKey.String("test-ns"),
+				tracing.DeliveryApplicationKey.String("my-app"),
+			}
+			Expect(tracing.EmitSupersededWaitDuration("", "msg", start, end, extras...)).To(BeTrue())
+			s := exporter.GetSpans()[0]
+			Expect(spanAttr(s, string(tracing.NamespaceKey))).To(Equal("test-ns"))
+			Expect(spanAttr(s, string(tracing.DeliveryApplicationKey))).To(Equal("my-app"))
+		})
+
+		It("parents the span on the supplied carrier when valid", func() {
+			validSpanContext := `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`
+			Expect(tracing.EmitSupersededWaitDuration(validSpanContext, "msg", start, end)).To(BeTrue())
+			s := exporter.GetSpans()[0]
+			Expect(s.Parent().TraceID().String()).To(Equal("4bf92f3577b34da6a3ce929d0e0e4736"))
+			Expect(s.Parent().SpanID().String()).To(Equal("00f067aa0ba902b7"))
+		})
+
+		It("emits as a root span when no carrier is supplied", func() {
+			Expect(tracing.EmitSupersededWaitDuration("", "msg", start, end)).To(BeTrue())
+			s := exporter.GetSpans()[0]
+			Expect(s.Parent().IsValid()).To(BeFalse())
+		})
+	})
+})

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"unicode/utf8"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	TracerName      = "integration-service"
+	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+	EnvTracesSampler    = "OTEL_TRACES_SAMPLER"
+	EnvTracesSamplerArg = "OTEL_TRACES_SAMPLER_ARG"
+
+	EnvTracingLabelAction      = "TRACING_LABEL_ACTION"
+	EnvTracingLabelApplication = "TRACING_LABEL_APPLICATION"
+	EnvTracingLabelComponent   = "TRACING_LABEL_COMPONENT"
+)
+
+const AttrNamespace = "delivery.tekton.dev"
+
+var (
+	DefaultTracingLabelAction      = AttrNamespace + "/action"
+	DefaultTracingLabelApplication = AttrNamespace + "/application"
+	DefaultTracingLabelComponent   = AttrNamespace + "/component"
+)
+
+const (
+	SpanWaitDuration    = "waitDuration"
+	SpanExecuteDuration = "executeDuration"
+)
+
+const MaxResultMessageLen = 1024
+
+const TruncatedSuffix = "...[truncated]"
+
+var (
+	NamespaceKey   = attribute.Key("namespace")
+	PipelineRunKey = attribute.Key("pipelinerun")
+
+	DeliveryPipelineRunUIDKey = attribute.Key(AttrNamespace + ".pipelinerun_uid")
+	DeliveryApplicationKey    = attribute.Key(AttrNamespace + ".application")
+	DeliveryComponentKey      = attribute.Key(AttrNamespace + ".component")
+	DeliveryResultMessageKey  = attribute.Key(AttrNamespace + ".result_message")
+)
+
+func ResultEnum(cond *apis.Condition) attribute.KeyValue {
+	if cond.Status == corev1.ConditionTrue {
+		return semconv.CICDPipelineResultSuccess
+	}
+	switch cond.Reason {
+	case tektonv1.PipelineRunReasonCancelled.String(),
+		tektonv1.PipelineRunReasonCancelledRunningFinally.String():
+		return semconv.CICDPipelineResultCancellation
+	case tektonv1.PipelineRunReasonTimedOut.String():
+		return semconv.CICDPipelineResultTimeout
+	case tektonv1.PipelineRunReasonFailed.String():
+		return semconv.CICDPipelineResultFailure
+	}
+	return semconv.CICDPipelineResultError
+}
+
+func TruncateResultMessage(msg string) string {
+	if len(msg) <= MaxResultMessageLen {
+		return msg
+	}
+	keep := MaxResultMessageLen - len(TruncatedSuffix)
+	if keep < 0 {
+		keep = 0
+	}
+	head := msg[:keep]
+	for len(head) > 0 {
+		r, size := utf8.DecodeLastRuneInString(head)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		head = head[:len(head)-size]
+	}
+	return head + TruncatedSuffix
+}
+
+type LabelNames struct {
+	Action      string
+	Application string
+	Component   string
+}
+
+// LoadLabelNames: an explicit empty env value disables the corresponding attribute.
+func LoadLabelNames() LabelNames {
+	return LabelNames{
+		Action:      envOr(EnvTracingLabelAction, DefaultTracingLabelAction),
+		Application: envOr(EnvTracingLabelApplication, DefaultTracingLabelApplication),
+		Component:   envOr(EnvTracingLabelComponent, DefaultTracingLabelComponent),
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}
+
+func samplerFromEnv() sdktrace.Sampler {
+	name := os.Getenv(EnvTracesSampler)
+	argStr := os.Getenv(EnvTracesSamplerArg)
+	arg, err := strconv.ParseFloat(argStr, 64)
+	if err != nil && argStr != "" {
+		setupLog.Error(err, "ignoring malformed sampler argument", "env", EnvTracesSamplerArg, "value", argStr)
+	}
+	switch name {
+	case "always_on":
+		return sdktrace.AlwaysSample()
+	case "always_off":
+		return sdktrace.NeverSample()
+	case "traceidratio":
+		return sdktrace.TraceIDRatioBased(arg)
+	case "parentbased_always_off":
+		return sdktrace.ParentBased(sdktrace.NeverSample())
+	case "parentbased_traceidratio":
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(arg))
+	}
+	return sdktrace.ParentBased(sdktrace.AlwaysSample())
+}
+
+var setupLog = ctrl.Log.WithName("tracing")
+
+type TracerProvider struct {
+	provider trace.TracerProvider
+	shutdown func(context.Context) error
+}
+
+func New(ctx context.Context) (*TracerProvider, error) {
+	if os.Getenv(EnvOTLPEndpoint) == "" {
+		setupLog.Info("OTLP endpoint not configured, using noop tracer provider")
+		return &TracerProvider{
+			provider: noop.NewTracerProvider(),
+			shutdown: func(context.Context) error { return nil },
+		}, nil
+	}
+
+	exporter, err := otlptracegrpc.New(ctx,
+		otlptracegrpc.WithEndpointURL(os.Getenv(EnvOTLPEndpoint)),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to create OTLP exporter, using noop tracer provider")
+		return &TracerProvider{
+			provider: noop.NewTracerProvider(),
+			shutdown: func(context.Context) error { return nil },
+		}, nil
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(TracerName),
+		),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to create resource")
+		res = resource.Default()
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(samplerFromEnv()),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	setupLog.Info("tracing initialized", "endpoint", os.Getenv(EnvOTLPEndpoint))
+
+	return &TracerProvider{
+		provider: tp,
+		shutdown: tp.Shutdown,
+	}, nil
+}
+
+func (tp *TracerProvider) Shutdown(ctx context.Context) error {
+	if tp.shutdown != nil {
+		return tp.shutdown(ctx)
+	}
+	return nil
+}

--- a/pkg/tracing/tracing.go
+++ b/pkg/tracing/tracing.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"unicode/utf8"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+const (
+	TracerName      = "integration-service"
+	EnvOTLPEndpoint = "OTEL_EXPORTER_OTLP_ENDPOINT"
+
+	EnvTracesSampler    = "OTEL_TRACES_SAMPLER"
+	EnvTracesSamplerArg = "OTEL_TRACES_SAMPLER_ARG"
+
+	EnvTracingLabelAction      = "TRACING_LABEL_ACTION"
+	EnvTracingLabelApplication = "TRACING_LABEL_APPLICATION"
+	EnvTracingLabelComponent   = "TRACING_LABEL_COMPONENT"
+)
+
+const (
+	tektonPrefix  = "tekton.dev"
+	AttrNamespace = "delivery." + tektonPrefix
+)
+
+var (
+	DefaultTracingLabelAction      = AttrNamespace + "/action"
+	DefaultTracingLabelApplication = AttrNamespace + "/application"
+	DefaultTracingLabelComponent   = AttrNamespace + "/component"
+)
+
+const (
+	SpanWaitDuration    = "waitDuration"
+	SpanExecuteDuration = "executeDuration"
+)
+
+const (
+	SpanContextAnnotation   = tektonPrefix + "/pipelinerunSpanContext"
+	TimingEmittedAnnotation = AttrNamespace + "/timingEmitted"
+)
+
+const MaxResultMessageLen = 1024
+
+const TruncatedSuffix = "...[truncated]"
+
+var (
+	NamespaceKey   = attribute.Key("namespace")
+	PipelineRunKey = attribute.Key("pipelinerun")
+	SnapshotKey    = attribute.Key("snapshot")
+
+	DeliveryPipelineRunUIDKey = attribute.Key(AttrNamespace + ".pipelinerun_uid")
+	DeliveryApplicationKey    = attribute.Key(AttrNamespace + ".application")
+	DeliveryComponentKey      = attribute.Key(AttrNamespace + ".component")
+	DeliveryResultMessageKey  = attribute.Key(AttrNamespace + ".result_message")
+)
+
+func ResultEnum(cond *apis.Condition) attribute.KeyValue {
+	if cond.Status == corev1.ConditionTrue {
+		return semconv.CICDPipelineResultSuccess
+	}
+	switch cond.Reason {
+	case tektonv1.PipelineRunReasonCancelled.String(),
+		tektonv1.PipelineRunReasonCancelledRunningFinally.String():
+		return semconv.CICDPipelineResultCancellation
+	case tektonv1.PipelineRunReasonTimedOut.String():
+		return semconv.CICDPipelineResultTimeout
+	case tektonv1.PipelineRunReasonFailed.String():
+		return semconv.CICDPipelineResultFailure
+	}
+	return semconv.CICDPipelineResultError
+}
+
+func TruncateResultMessage(msg string) string {
+	if len(msg) <= MaxResultMessageLen {
+		return msg
+	}
+	keep := MaxResultMessageLen - len(TruncatedSuffix)
+	if keep < 0 {
+		keep = 0
+	}
+	head := msg[:keep]
+	for len(head) > 0 {
+		r, size := utf8.DecodeLastRuneInString(head)
+		if r != utf8.RuneError || size > 1 {
+			break
+		}
+		head = head[:len(head)-size]
+	}
+	return head + TruncatedSuffix
+}
+
+type LabelNames struct {
+	Action      string
+	Application string
+	Component   string
+}
+
+// LoadLabelNames returns the configured tracing label names; an empty env value disables the corresponding attribute.
+func LoadLabelNames() LabelNames {
+	return LabelNames{
+		Action:      envOr(EnvTracingLabelAction, DefaultTracingLabelAction),
+		Application: envOr(EnvTracingLabelApplication, DefaultTracingLabelApplication),
+		Component:   envOr(EnvTracingLabelComponent, DefaultTracingLabelComponent),
+	}
+}
+
+func envOr(key, fallback string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return fallback
+}
+
+func samplerFromEnv() sdktrace.Sampler {
+	name := os.Getenv(EnvTracesSampler)
+	argStr := os.Getenv(EnvTracesSamplerArg)
+	arg, err := strconv.ParseFloat(argStr, 64)
+	if err != nil && argStr != "" {
+		setupLog.Error(err, "ignoring malformed sampler argument", "env", EnvTracesSamplerArg, "value", argStr)
+	}
+	if argStr == "" && (name == "traceidratio" || name == "parentbased_traceidratio") {
+		setupLog.Info("ratio sampler selected without "+EnvTracesSamplerArg+"; defaulting to 0% sampling", "env", EnvTracesSampler, "value", name)
+	}
+	switch name {
+	case "always_on":
+		return sdktrace.AlwaysSample()
+	case "always_off":
+		return sdktrace.NeverSample()
+	case "traceidratio":
+		return sdktrace.TraceIDRatioBased(arg)
+	case "parentbased_always_off":
+		return sdktrace.ParentBased(sdktrace.NeverSample())
+	case "parentbased_traceidratio":
+		return sdktrace.ParentBased(sdktrace.TraceIDRatioBased(arg))
+	}
+	return sdktrace.ParentBased(sdktrace.AlwaysSample())
+}
+
+var setupLog = ctrl.Log.WithName("tracing")
+
+type TracerProvider struct {
+	shutdown func(context.Context) error
+}
+
+func New() *TracerProvider {
+	if os.Getenv(EnvOTLPEndpoint) == "" {
+		setupLog.Info("OTLP endpoint not configured, using noop tracer provider")
+		return &TracerProvider{shutdown: func(context.Context) error { return nil }}
+	}
+
+	exporter, err := otlptracegrpc.New(context.Background(),
+		otlptracegrpc.WithEndpointURL(os.Getenv(EnvOTLPEndpoint)),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to create OTLP exporter, using noop tracer provider")
+		return &TracerProvider{shutdown: func(context.Context) error { return nil }}
+	}
+
+	res, err := resource.Merge(
+		resource.Default(),
+		resource.NewWithAttributes(
+			semconv.SchemaURL,
+			semconv.ServiceName(TracerName),
+		),
+	)
+	if err != nil {
+		setupLog.Error(err, "failed to create resource")
+		res = resource.Default()
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exporter),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(samplerFromEnv()),
+	)
+
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+
+	setupLog.Info("tracing initialized", "endpoint", os.Getenv(EnvOTLPEndpoint))
+
+	return &TracerProvider{shutdown: tp.Shutdown}
+}
+
+func (tp *TracerProvider) Shutdown(ctx context.Context) error {
+	if tp.shutdown != nil {
+		return tp.shutdown(ctx)
+	}
+	return nil
+}

--- a/pkg/tracing/tracing_suite_test.go
+++ b/pkg/tracing/tracing_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestTracing(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Tracing Suite")
+}

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,299 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace/noop"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+
+	"github.com/konflux-ci/integration-service/pkg/tracing"
+)
+
+func snapshotTracingEnv(keys ...string) map[string]string {
+	saved := map[string]string{}
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			saved[k] = v
+		}
+	}
+	return saved
+}
+
+func restoreTracingEnv(keys []string, saved map[string]string) {
+	for _, k := range keys {
+		_ = os.Unsetenv(k)
+	}
+	for k, v := range saved {
+		_ = os.Setenv(k, v)
+	}
+}
+
+func resetGlobalTracerProviderOnCleanup() {
+	prev := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	DeferCleanup(func() {
+		otel.SetTracerProvider(prev)
+		otel.SetTextMapPropagator(prevProp)
+	})
+}
+
+var _ = Describe("ResultEnum", func() {
+	DescribeTable("maps PipelineRun Succeeded condition to the semconv enum",
+		func(status corev1.ConditionStatus, reason, want string) {
+			cond := &apis.Condition{Status: status, Reason: reason}
+			Expect(tracing.ResultEnum(cond).Value.AsString()).To(Equal(want))
+		},
+		Entry("success",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(),
+			semconv.CICDPipelineResultSuccess.Value.AsString()),
+		Entry("completed is also success",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonCompleted.String(),
+			semconv.CICDPipelineResultSuccess.Value.AsString()),
+		Entry("failure",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(),
+			semconv.CICDPipelineResultFailure.Value.AsString()),
+		Entry("timeout",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonTimedOut.String(),
+			semconv.CICDPipelineResultTimeout.Value.AsString()),
+		Entry("cancelled",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelled.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("cancelled-running-finally",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelledRunningFinally.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("validation failure falls back to error",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailedValidation.String(),
+			semconv.CICDPipelineResultError.Value.AsString()),
+		Entry("unknown reason falls back to error",
+			corev1.ConditionFalse, "SomeFutureTektonReason",
+			semconv.CICDPipelineResultError.Value.AsString()),
+	)
+})
+
+var _ = Describe("TruncateResultMessage", func() {
+	It("passes through a short message unchanged", func() {
+		Expect(tracing.TruncateResultMessage("short")).To(Equal("short"))
+	})
+
+	It("passes through a message exactly at the limit unchanged", func() {
+		msg := strings.Repeat("a", tracing.MaxResultMessageLen)
+		Expect(tracing.TruncateResultMessage(msg)).To(Equal(msg))
+	})
+
+	It("truncates and suffixes a message over the limit", func() {
+		msg := strings.Repeat("a", tracing.MaxResultMessageLen+50)
+		got := tracing.TruncateResultMessage(msg)
+		Expect(len(got)).To(BeNumerically("<=", tracing.MaxResultMessageLen))
+		Expect(got).To(HaveSuffix(tracing.TruncatedSuffix))
+	})
+
+	It("preserves UTF-8 boundaries when truncating", func() {
+		prefix := strings.Repeat("a", tracing.MaxResultMessageLen-len(tracing.TruncatedSuffix)-2)
+		msg := prefix + "世" + strings.Repeat("b", 100)
+		got := tracing.TruncateResultMessage(msg)
+		head := strings.TrimSuffix(got, tracing.TruncatedSuffix)
+		Expect(head).NotTo(Equal(got))
+		for _, r := range head {
+			Expect(r).NotTo(Equal('�'))
+		}
+	})
+})
+
+var _ = Describe("LoadLabelNames", func() {
+	envKeys := []string{
+		tracing.EnvTracingLabelAction,
+		tracing.EnvTracingLabelApplication,
+		tracing.EnvTracingLabelComponent,
+	}
+
+	snapshotEnv := func() map[string]string {
+		saved := map[string]string{}
+		for _, k := range envKeys {
+			if v, ok := os.LookupEnv(k); ok {
+				saved[k] = v
+			}
+		}
+		return saved
+	}
+
+	restoreEnv := func(saved map[string]string) {
+		for _, k := range envKeys {
+			_ = os.Unsetenv(k)
+		}
+		for k, v := range saved {
+			_ = os.Setenv(k, v)
+		}
+	}
+
+	It("returns the delivery.tekton.dev/* defaults when env vars are unset", func() {
+		saved := snapshotEnv()
+		DeferCleanup(restoreEnv, saved)
+		for _, k := range envKeys {
+			_ = os.Unsetenv(k)
+		}
+		got := tracing.LoadLabelNames()
+		Expect(got.Action).To(Equal(tracing.DefaultTracingLabelAction))
+		Expect(got.Application).To(Equal(tracing.DefaultTracingLabelApplication))
+		Expect(got.Component).To(Equal(tracing.DefaultTracingLabelComponent))
+	})
+
+	It("treats an explicit empty-string as disabling the attribute", func() {
+		saved := snapshotEnv()
+		DeferCleanup(restoreEnv, saved)
+		for _, k := range envKeys {
+			_ = os.Setenv(k, "")
+		}
+		got := tracing.LoadLabelNames()
+		Expect(got.Action).To(Equal(""))
+		Expect(got.Application).To(Equal(""))
+		Expect(got.Component).To(Equal(""))
+	})
+})
+
+var _ = Describe("New (TracerProvider lifecycle)", func() {
+	envKeys := []string{
+		tracing.EnvOTLPEndpoint,
+		tracing.EnvTracesSampler,
+		tracing.EnvTracesSamplerArg,
+	}
+
+	It("disables sampling when the OTLP endpoint env var is unset", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		_ = os.Unsetenv(tracing.EnvOTLPEndpoint)
+		resetGlobalTracerProviderOnCleanup()
+
+		tp, err := tracing.New(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tp).NotTo(BeNil())
+
+		_, isSDK := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+		Expect(isSDK).To(BeFalse())
+
+		_, span := otel.Tracer("no-endpoint-probe").Start(context.Background(), "probe")
+		defer span.End()
+		Expect(span.SpanContext().IsSampled()).To(BeFalse())
+
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("installs an SDK TracerProvider and W3C TraceContext propagator when the endpoint is well-formed", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		// otlptracegrpc dials lazily; an unreachable endpoint still yields a usable provider.
+		_ = os.Setenv(tracing.EnvOTLPEndpoint, "http://localhost:4317")
+		resetGlobalTracerProviderOnCleanup()
+
+		tp, err := tracing.New(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tp).NotTo(BeNil())
+
+		_, isSDK := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+		Expect(isSDK).To(BeTrue())
+		_, isW3C := otel.GetTextMapPropagator().(propagation.TraceContext)
+		Expect(isW3C).To(BeTrue())
+
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+})
+
+var _ = Describe("TracerProvider.Shutdown", func() {
+	envKeys := []string{tracing.EnvOTLPEndpoint}
+
+	It("returns nil for a noop-backed provider", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		_ = os.Unsetenv(tracing.EnvOTLPEndpoint)
+		resetGlobalTracerProviderOnCleanup()
+
+		tp, err := tracing.New(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("is idempotent for an SDK-backed provider", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		_ = os.Setenv(tracing.EnvOTLPEndpoint, "http://localhost:4317")
+		resetGlobalTracerProviderOnCleanup()
+
+		tp, err := tracing.New(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+		// A second call must not panic or surface an error.
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+})
+
+var _ = Describe("samplerFromEnv (verified through New)", func() {
+	envKeys := []string{
+		tracing.EnvOTLPEndpoint,
+		tracing.EnvTracesSampler,
+		tracing.EnvTracesSamplerArg,
+	}
+
+	DescribeTable("the OTEL_TRACES_SAMPLER env var drives the sampling decision",
+		func(samplerEnv, samplerArg string, wantSampled bool) {
+			saved := snapshotTracingEnv(envKeys...)
+			DeferCleanup(restoreTracingEnv, envKeys, saved)
+			resetGlobalTracerProviderOnCleanup()
+
+			_ = os.Setenv(tracing.EnvOTLPEndpoint, "http://localhost:4317")
+			if samplerEnv == "" {
+				_ = os.Unsetenv(tracing.EnvTracesSampler)
+			} else {
+				_ = os.Setenv(tracing.EnvTracesSampler, samplerEnv)
+			}
+			if samplerArg == "" {
+				_ = os.Unsetenv(tracing.EnvTracesSamplerArg)
+			} else {
+				_ = os.Setenv(tracing.EnvTracesSamplerArg, samplerArg)
+			}
+
+			tp, err := tracing.New(context.Background())
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+			_, span := otel.Tracer("samplerFromEnv-probe").Start(context.Background(), "probe")
+			defer span.End()
+			Expect(span.SpanContext().IsSampled()).To(Equal(wantSampled))
+		},
+		Entry("always_off blocks sampling", "always_off", "", false),
+		Entry("always_on samples", "always_on", "", true),
+		Entry("traceidratio with arg=1.0 samples every trace", "traceidratio", "1.0", true),
+		Entry("traceidratio with arg=0 samples nothing", "traceidratio", "0", false),
+		Entry("parentbased_always_off without parent context defaults to off", "parentbased_always_off", "", false),
+		Entry("parentbased_traceidratio with arg=1.0 samples root spans", "parentbased_traceidratio", "1.0", true),
+		Entry("unset env defaults to parent-based-always-on (samples root spans)", "", "", true),
+		Entry("unrecognized value falls back to the default sampler", "some-future-otel-keyword", "", true),
+	)
+})

--- a/pkg/tracing/tracing_test.go
+++ b/pkg/tracing/tracing_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tracing_test
+
+import (
+	"context"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	"go.opentelemetry.io/otel/trace/noop"
+	corev1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/apis"
+
+	"github.com/konflux-ci/integration-service/pkg/tracing"
+)
+
+func snapshotTracingEnv(keys ...string) map[string]string {
+	saved := map[string]string{}
+	for _, k := range keys {
+		if v, ok := os.LookupEnv(k); ok {
+			saved[k] = v
+		}
+	}
+	return saved
+}
+
+func restoreTracingEnv(keys []string, saved map[string]string) {
+	for _, k := range keys {
+		_ = os.Unsetenv(k)
+	}
+	for k, v := range saved {
+		_ = os.Setenv(k, v)
+	}
+}
+
+func resetGlobalTracerProviderOnCleanup() {
+	prev := otel.GetTracerProvider()
+	prevProp := otel.GetTextMapPropagator()
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator())
+	DeferCleanup(func() {
+		otel.SetTracerProvider(prev)
+		otel.SetTextMapPropagator(prevProp)
+	})
+}
+
+var _ = Describe("ResultEnum", func() {
+	DescribeTable("maps PipelineRun Succeeded condition to the semconv enum",
+		func(status corev1.ConditionStatus, reason, want string) {
+			cond := &apis.Condition{Status: status, Reason: reason}
+			Expect(tracing.ResultEnum(cond).Value.AsString()).To(Equal(want))
+		},
+		Entry("success",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonSuccessful.String(),
+			semconv.CICDPipelineResultSuccess.Value.AsString()),
+		Entry("completed is also success",
+			corev1.ConditionTrue, tektonv1.PipelineRunReasonCompleted.String(),
+			semconv.CICDPipelineResultSuccess.Value.AsString()),
+		Entry("failure",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailed.String(),
+			semconv.CICDPipelineResultFailure.Value.AsString()),
+		Entry("timeout",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonTimedOut.String(),
+			semconv.CICDPipelineResultTimeout.Value.AsString()),
+		Entry("cancelled",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelled.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("cancelled-running-finally",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonCancelledRunningFinally.String(),
+			semconv.CICDPipelineResultCancellation.Value.AsString()),
+		Entry("validation failure falls back to error",
+			corev1.ConditionFalse, tektonv1.PipelineRunReasonFailedValidation.String(),
+			semconv.CICDPipelineResultError.Value.AsString()),
+		Entry("unknown reason falls back to error",
+			corev1.ConditionFalse, "SomeFutureTektonReason",
+			semconv.CICDPipelineResultError.Value.AsString()),
+	)
+})
+
+var _ = Describe("TruncateResultMessage", func() {
+	It("passes through a short message unchanged", func() {
+		Expect(tracing.TruncateResultMessage("short")).To(Equal("short"))
+	})
+
+	It("passes through a message exactly at the limit unchanged", func() {
+		msg := strings.Repeat("a", tracing.MaxResultMessageLen)
+		Expect(tracing.TruncateResultMessage(msg)).To(Equal(msg))
+	})
+
+	It("truncates and suffixes a message over the limit", func() {
+		msg := strings.Repeat("a", tracing.MaxResultMessageLen+50)
+		got := tracing.TruncateResultMessage(msg)
+		Expect(len(got)).To(BeNumerically("<=", tracing.MaxResultMessageLen))
+		Expect(got).To(HaveSuffix(tracing.TruncatedSuffix))
+	})
+
+	It("preserves UTF-8 boundaries when truncating", func() {
+		prefix := strings.Repeat("a", tracing.MaxResultMessageLen-len(tracing.TruncatedSuffix)-2)
+		msg := prefix + "世" + strings.Repeat("b", 100)
+		got := tracing.TruncateResultMessage(msg)
+		head := strings.TrimSuffix(got, tracing.TruncatedSuffix)
+		Expect(head).NotTo(Equal(got))
+		for _, r := range head {
+			Expect(r).NotTo(Equal('�'))
+		}
+	})
+})
+
+var _ = Describe("LoadLabelNames", func() {
+	envKeys := []string{
+		tracing.EnvTracingLabelAction,
+		tracing.EnvTracingLabelApplication,
+		tracing.EnvTracingLabelComponent,
+	}
+
+	snapshotEnv := func() map[string]string {
+		saved := map[string]string{}
+		for _, k := range envKeys {
+			if v, ok := os.LookupEnv(k); ok {
+				saved[k] = v
+			}
+		}
+		return saved
+	}
+
+	restoreEnv := func(saved map[string]string) {
+		for _, k := range envKeys {
+			_ = os.Unsetenv(k)
+		}
+		for k, v := range saved {
+			_ = os.Setenv(k, v)
+		}
+	}
+
+	It("returns the delivery.tekton.dev/* defaults when env vars are unset", func() {
+		saved := snapshotEnv()
+		DeferCleanup(restoreEnv, saved)
+		for _, k := range envKeys {
+			_ = os.Unsetenv(k)
+		}
+		got := tracing.LoadLabelNames()
+		Expect(got.Action).To(Equal(tracing.DefaultTracingLabelAction))
+		Expect(got.Application).To(Equal(tracing.DefaultTracingLabelApplication))
+		Expect(got.Component).To(Equal(tracing.DefaultTracingLabelComponent))
+	})
+
+	It("treats an explicit empty-string as disabling the attribute", func() {
+		saved := snapshotEnv()
+		DeferCleanup(restoreEnv, saved)
+		for _, k := range envKeys {
+			_ = os.Setenv(k, "")
+		}
+		got := tracing.LoadLabelNames()
+		Expect(got.Action).To(Equal(""))
+		Expect(got.Application).To(Equal(""))
+		Expect(got.Component).To(Equal(""))
+	})
+})
+
+var _ = Describe("New (TracerProvider lifecycle)", func() {
+	envKeys := []string{
+		tracing.EnvOTLPEndpoint,
+		tracing.EnvTracesSampler,
+		tracing.EnvTracesSamplerArg,
+	}
+
+	It("disables sampling when the OTLP endpoint env var is unset", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		_ = os.Unsetenv(tracing.EnvOTLPEndpoint)
+		resetGlobalTracerProviderOnCleanup()
+
+		tp := tracing.New()
+		Expect(tp).NotTo(BeNil())
+
+		_, isSDK := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+		Expect(isSDK).To(BeFalse())
+
+		_, span := otel.Tracer("no-endpoint-probe").Start(context.Background(), "probe")
+		defer span.End()
+		Expect(span.SpanContext().IsSampled()).To(BeFalse())
+
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("installs an SDK TracerProvider and W3C TraceContext propagator when the endpoint is well-formed", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		// otlptracegrpc dials lazily; an unreachable endpoint still yields a usable provider.
+		_ = os.Setenv(tracing.EnvOTLPEndpoint, "http://localhost:4317")
+		resetGlobalTracerProviderOnCleanup()
+
+		tp := tracing.New()
+		Expect(tp).NotTo(BeNil())
+
+		_, isSDK := otel.GetTracerProvider().(*sdktrace.TracerProvider)
+		Expect(isSDK).To(BeTrue())
+		_, isW3C := otel.GetTextMapPropagator().(propagation.TraceContext)
+		Expect(isW3C).To(BeTrue())
+
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+})
+
+var _ = Describe("TracerProvider.Shutdown", func() {
+	envKeys := []string{tracing.EnvOTLPEndpoint}
+
+	It("returns nil for a noop-backed provider", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		_ = os.Unsetenv(tracing.EnvOTLPEndpoint)
+		resetGlobalTracerProviderOnCleanup()
+
+		tp := tracing.New()
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+
+	It("is idempotent for an SDK-backed provider", func() {
+		saved := snapshotTracingEnv(envKeys...)
+		DeferCleanup(restoreTracingEnv, envKeys, saved)
+		_ = os.Setenv(tracing.EnvOTLPEndpoint, "http://localhost:4317")
+		resetGlobalTracerProviderOnCleanup()
+
+		tp := tracing.New()
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+		// A second call must not panic or surface an error.
+		Expect(tp.Shutdown(context.Background())).To(Succeed())
+	})
+})
+
+var _ = Describe("samplerFromEnv (verified through New)", func() {
+	envKeys := []string{
+		tracing.EnvOTLPEndpoint,
+		tracing.EnvTracesSampler,
+		tracing.EnvTracesSamplerArg,
+	}
+
+	DescribeTable("the OTEL_TRACES_SAMPLER env var drives the sampling decision",
+		func(samplerEnv, samplerArg string, wantSampled bool) {
+			saved := snapshotTracingEnv(envKeys...)
+			DeferCleanup(restoreTracingEnv, envKeys, saved)
+			resetGlobalTracerProviderOnCleanup()
+
+			_ = os.Setenv(tracing.EnvOTLPEndpoint, "http://localhost:4317")
+			if samplerEnv == "" {
+				_ = os.Unsetenv(tracing.EnvTracesSampler)
+			} else {
+				_ = os.Setenv(tracing.EnvTracesSampler, samplerEnv)
+			}
+			if samplerArg == "" {
+				_ = os.Unsetenv(tracing.EnvTracesSamplerArg)
+			} else {
+				_ = os.Setenv(tracing.EnvTracesSamplerArg, samplerArg)
+			}
+
+			tp := tracing.New()
+			DeferCleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+			_, span := otel.Tracer("samplerFromEnv-probe").Start(context.Background(), "probe")
+			defer span.End()
+			Expect(span.SpanContext().IsSampled()).To(Equal(wantSampled))
+		},
+		Entry("always_off blocks sampling", "always_off", "", false),
+		Entry("always_on samples", "always_on", "", true),
+		Entry("traceidratio with arg=1.0 samples every trace", "traceidratio", "1.0", true),
+		Entry("traceidratio with arg=0 samples nothing", "traceidratio", "0", false),
+		Entry("parentbased_always_off without parent context defaults to off", "parentbased_always_off", "", false),
+		Entry("parentbased_traceidratio with arg=1.0 samples root spans", "parentbased_traceidratio", "1.0", true),
+		Entry("unset env defaults to parent-based-always-on (samples root spans)", "", "", true),
+		Entry("unrecognized value falls back to the default sampler", "some-future-otel-keyword", "", true),
+		Entry("malformed sampler arg logs the parse error and falls through to ratio 0", "traceidratio", "not-a-number", false),
+		Entry("traceidratio with unset arg logs the warning and defaults to 0% sampling", "traceidratio", "", false),
+		Entry("parentbased_traceidratio with unset arg logs the warning and defaults to 0% sampling on root", "parentbased_traceidratio", "", false),
+	)
+})

--- a/release/releaseplan.go
+++ b/release/releaseplan.go
@@ -21,6 +21,7 @@ import (
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/gitops"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
 	releasev1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	releasemetadata "github.com/konflux-ci/release-service/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,17 @@ func NewReleaseForReleasePlan(ctx context.Context, releasePlan *releasev1alpha1.
 			ReleasePlan: releasePlan.Name,
 		},
 	}
+
+	// Propagate span context from snapshot for distributed tracing
+	if snapshot.Annotations != nil {
+		if tp := snapshot.Annotations[tektonconsts.SpanContextAnnotation]; tp != "" {
+			if newRelease.Annotations == nil {
+				newRelease.Annotations = make(map[string]string)
+			}
+			newRelease.Annotations[tektonconsts.SpanContextAnnotation] = tp
+		}
+	}
+
 	return newRelease
 }
 

--- a/release/releaseplan.go
+++ b/release/releaseplan.go
@@ -21,6 +21,7 @@ import (
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/gitops"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	releasev1alpha1 "github.com/konflux-ci/release-service/api/v1alpha1"
 	releasemetadata "github.com/konflux-ci/release-service/metadata"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,6 +47,17 @@ func NewReleaseForReleasePlan(ctx context.Context, releasePlan *releasev1alpha1.
 			ReleasePlan: releasePlan.Name,
 		},
 	}
+
+	// Propagate span context from snapshot for distributed tracing
+	if snapshot.Annotations != nil {
+		if tp := snapshot.Annotations[tracing.SpanContextAnnotation]; tp != "" {
+			if newRelease.Annotations == nil {
+				newRelease.Annotations = make(map[string]string)
+			}
+			newRelease.Annotations[tracing.SpanContextAnnotation] = tp
+		}
+	}
+
 	return newRelease
 }
 

--- a/snapshot/create.go
+++ b/snapshot/create.go
@@ -31,6 +31,7 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/tekton"
 	"github.com/konflux-ci/operator-toolkit/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -68,6 +69,10 @@ func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Cli
 
 	prefixes := []string{gitops.BuildPipelineRunPrefix, gitops.TestLabelPrefix, gitops.CustomLabelPrefix, gitops.ReleaseLabelPrefix}
 	gitops.CopySnapshotLabelsAndAnnotations(&componentGroup.ObjectMeta, snapshot, componentName, &pipelineRun.ObjectMeta, prefixes, false)
+
+	if tp, found := pipelineRun.Annotations[tracing.SpanContextAnnotation]; found && tp != "" {
+		snapshot.Annotations[tracing.SpanContextAnnotation] = tp
+	}
 
 	snapshot.Labels[gitops.BuildPipelineRunNameLabel] = pipelineRun.Name
 	if pipelineRun.Status.CompletionTime != nil {
@@ -161,7 +166,6 @@ func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Clie
 // PrepareSnapshot prepares the Snapshot for a given componentGroup, components and the updated component (if any).
 // In case the Snapshot can't be created, an error will be returned.
 func PrepareSnapshot(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, newSnapshotComponent applicationapiv1alpha1.SnapshotComponent, loader loader.ObjectLoader, logger helpers.IntegrationLogger) (*applicationapiv1alpha1.Snapshot, error) {
-
 	// Get nested snapshotComponents
 	snapshotComponentsMap, invalidComponents, err := getAllNestedSnapshotComponents(componentGroup, []string{}, 0, loader, ctx, adapterClient, logger)
 	if err != nil {
@@ -228,7 +232,6 @@ func PrepareParentSnapshot(ctx context.Context, adapterClient client.Client, loa
 				return nil, fmt.Errorf("failed to set annotation %s: %w", gitops.SnapshotGitSourceRepoURLAnnotation, err)
 			}
 		}
-
 	}
 
 	// Annotate snapshot with warning about invalid components

--- a/snapshot/create_test.go
+++ b/snapshot/create_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/tekton"
 	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
 	toolkit "github.com/konflux-ci/operator-toolkit/loader"
@@ -149,10 +150,12 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 					ResolverRef: tektonv1.ResolverRef{
 						Resolver: "bundle",
 						Params: tektonv1.Params{
-							{Name: "bundle",
+							{
+								Name:  "bundle",
 								Value: tektonv1.ParamValue{Type: "string", StringVal: "quay.io/redhat-appstudio/example-tekton-bundle:test"},
 							},
-							{Name: "name",
+							{
+								Name:  "name",
 								Value: tektonv1.ParamValue{Type: "string", StringVal: "test-task"},
 							},
 						},
@@ -212,14 +215,14 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			},
 			Spec: v1beta2.ComponentGroupSpec{
 				Components: []v1beta2.ComponentReference{
-					v1beta2.ComponentReference{
+					{
 						Name: componentName,
 						ComponentVersion: v1beta2.ComponentVersionReference{
 							Name:     "v1",
 							Revision: "main",
 						},
 					},
-					v1beta2.ComponentReference{
+					{
 						Name: componentName2,
 						ComponentVersion: v1beta2.ComponentVersionReference{
 							Name:     "v1",
@@ -233,7 +236,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 		hasCompGroup.Status = v1beta2.ComponentGroupStatus{
 			GlobalCandidateList: []v1beta2.ComponentState{
-				v1beta2.ComponentState{
+				{
 					Name:                  componentName,
 					Version:               "v1",
 					URL:                   SampleRepoLink,
@@ -241,12 +244,12 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 					LastPromotedCommit:    SampleCommit,
 					LastPromotedBuildTime: nil,
 				},
-				v1beta2.ComponentState{
+				{
 					Name:    componentName2,
 					Version: "v1",
 					URL:     "",
 				},
-				v1beta2.ComponentState{
+				{
 					Name:    "deleted-component",
 					Version: "v1",
 				},
@@ -264,10 +267,12 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 					ResolverRef: tektonv1.ResolverRef{
 						Resolver: "bundle",
 						Params: tektonv1.Params{
-							{Name: "bundle",
+							{
+								Name:  "bundle",
 								Value: tektonv1.ParamValue{Type: "string", StringVal: "quay.io/redhat-appstudio/example-tekton-bundle:test"},
 							},
-							{Name: "name",
+							{
+								Name:  "name",
 								Value: tektonv1.ParamValue{Type: "string", StringVal: "test-task"},
 							},
 						},
@@ -400,7 +405,6 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			Expect(copyToSnapshot.Annotations["build.appstudio.openshift.io/repo"]).To(Equal("https://github.com/devfile-samples/devfile-sample-go-basic?rev=c713067b0e65fb3de50d1f7c457eb51c2ab0dbb0"))
 			Expect(copyToSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel]).To(Equal(buildPipelineRun.Labels["pipelinesascode.tekton.dev/event-type"]))
 			Expect(copyToSnapshot.Labels[customLabel]).To(Equal(buildPipelineRun.Labels[customLabel]))
-
 		})
 
 		It("ensures that snapshot has Pull request label based on the merge queue's temporary source branch extracted from build pipelinerun", func() {
@@ -479,6 +483,17 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			label, found := snapshot.GetLabels()["pac.test.appstudio.openshift.io/event-type"]
 			Expect(found).To(BeTrue())
 			Expect(label).To(Equal("pull_request"))
+		})
+
+		It("propagates pipelinerunSpanContext annotation from the build PipelineRun to the Snapshot", func() {
+			const carrier = `{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`
+			buildPipelineRun.Annotations[tracing.SpanContextAnnotation] = carrier
+			defer delete(buildPipelineRun.Annotations, tracing.SpanContextAnnotation)
+
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, loader.NewMockLoader())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(snapshot).ToNot(BeNil())
+			Expect(snapshot.GetAnnotations()[tracing.SpanContextAnnotation]).To(Equal(carrier))
 		})
 
 		It("ensures non-pipelines as code labels and annotations are NOT propagated to the snapshot", func() {
@@ -577,7 +592,6 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			Expect(invalidName).To(Equal(componentName2))
 
 			Expect(buf.String()).To(ContainSubstring("componentVersion was deleted from spec.Components"))
-
 		})
 
 		It("Ensures built component can replace existing snapshotComponent", func() {
@@ -594,7 +608,6 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			Expect(snapshotComponents).To(HaveLen(1))
 			Expect(snapshotComponents[helpers.GetComponentVersionString(componentName, "v1")].Name).To(Equal(componentName))
 			Expect(invalidComponents).To(HaveLen(1))
-
 		})
 
 		It("Ensures built component is added under its version key when an unversioned entry exists", func() {

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -34,6 +34,9 @@ const (
 	// CustomLabelPrefix contains the prefix applied to custom user-defined labels and annotations.
 	CustomLabelPrefix = "custom.appstudio.openshift.io"
 
+	// TektonPrefix contains the prefix for annotations defined by the upstream Tekton project.
+	TektonPrefix = "tekton.dev"
+
 	// resource labels for snapshot, application and component
 	ResourceLabelSuffix = "appstudio.openshift.io"
 
@@ -134,6 +137,12 @@ const (
 
 	// PipelineRunShouldReleaseResultName is the name of the SHOULD_RELEASE result in build PipelineRuns
 	PipelineRunShouldReleaseResultName = "SHOULD_RELEASE"
+
+	// SpanContextAnnotation is the annotation key for the serialized span context.
+	SpanContextAnnotation = TektonPrefix + "/pipelinerunSpanContext"
+
+	// TimingEmittedAnnotation marks that timing spans have been emitted.
+	TimingEmittedAnnotation = TektonPrefix + "/timingEmitted"
 )
 
 var (

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -487,6 +487,11 @@ func (r *IntegrationPipelineRun) WithSnapshot(snapshot *applicationapiv1alpha1.S
 		_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &r.ObjectMeta, prefix)
 	}
 
+	// Propagate span context from Snapshot to test PipelineRun for distributed tracing
+	if tp, found := snapshot.Annotations[consts.SpanContextAnnotation]; found && tp != "" {
+		_ = metadata.SetAnnotation(r, consts.SpanContextAnnotation, tp)
+	}
+
 	return r
 }
 

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -34,6 +34,7 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/tekton/consts"
 	"github.com/konflux-ci/operator-toolkit/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -485,6 +486,11 @@ func (r *IntegrationPipelineRun) WithSnapshot(snapshot *applicationapiv1alpha1.S
 		// Copy labels and annotations prefixed with defined prefix
 		_ = metadata.CopyAnnotationsByPrefix(&snapshot.ObjectMeta, &r.ObjectMeta, prefix)
 		_ = metadata.CopyLabelsByPrefix(&snapshot.ObjectMeta, &r.ObjectMeta, prefix)
+	}
+
+	// Propagate span context from Snapshot to test PipelineRun for distributed tracing
+	if tp, found := snapshot.Annotations[tracing.SpanContextAnnotation]; found && tp != "" {
+		_ = metadata.SetAnnotation(r, tracing.SpanContextAnnotation, tp)
 	}
 
 	return r


### PR DESCRIPTION
Propagate W3C trace context from build PipelineRuns through Snapshots,
integration PipelineRuns, and Release CRs. Emit waitDuration and
executeDuration timing spans on PipelineRun completion across both
ComponentGroup and Application model flows. When a Snapshot is skipped
because a newer one for the same Application has already released,
emit a supersede waitDuration so the trace distinguishes deliberate
dedup from a broken chain.

Annotation constants live in `pkg/tracing`: `TimingEmittedAnnotation`
under `delivery.tekton.dev` (controller-internal), `SpanContextAnnotation`
under `tekton.dev` (cross-service contract).

See `docs/tracing.md`.

Assisted-by: Claude Code