### PR TITLE
feat(STONEINTG-1406): add Forgejo happy-path integration suite

### DIFF
--- a/e2e-tests/pkg/clients/common/client.go
+++ b/e2e-tests/pkg/clients/common/client.go
@@ -4,6 +4,7 @@ import (
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
 	imagecontroller "github.com/konflux-ci/image-controller/api/v1alpha1"
 	integrationservicev1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
 
 	release "github.com/konflux-ci/release-service/api/v1alpha1"
 	tekton "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -34,6 +35,7 @@ func init() {
 	utilruntime.Must(release.AddToScheme(scheme))
 	utilruntime.Must(integrationservicev1beta2.AddToScheme(scheme))
 	utilruntime.Must(imagecontroller.AddToScheme(scheme))
+	utilruntime.Must(pacv1alpha1.AddToScheme(scheme))
 }
 
 // Kube returns the clientset for Kubernetes upstream.

--- a/e2e-tests/pkg/clients/forgejo/client.go
+++ b/e2e-tests/pkg/clients/forgejo/client.go
@@ -4,13 +4,17 @@ import (
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
 )
 
-// ForgejoClient wraps the Forgejo SDK client
+// ForgejoClient wraps the Forgejo SDK client.
 type ForgejoClient struct {
 	client *forgejo.Client
+	apiURL string
+	token  string
 }
 
-// NewForgejoClient creates a new Forgejo client
+// NewForgejoClient creates a new Forgejo client.
 func NewForgejoClient(accessToken, baseURL, org string) (*ForgejoClient, error) {
+	_ = org // reserved for callers passing default org; API paths use full owner/repo IDs
+
 	client, err := forgejo.NewClient(baseURL, forgejo.SetToken(accessToken))
 	if err != nil {
 		return nil, err
@@ -18,5 +22,12 @@ func NewForgejoClient(accessToken, baseURL, org string) (*ForgejoClient, error) 
 
 	return &ForgejoClient{
 		client: client,
+		apiURL: baseURL,
+		token:  accessToken,
 	}, nil
+}
+
+// GetClient returns the underlying Forgejo API client.
+func (fc *ForgejoClient) GetClient() *forgejo.Client {
+	return fc.client
 }

--- a/e2e-tests/pkg/clients/forgejo/git.go
+++ b/e2e-tests/pkg/clients/forgejo/git.go
@@ -3,12 +3,171 @@ package forgejo
 import (
 	"encoding/base64"
 	"fmt"
+	"net/http"
 	"strings"
+	"time"
 
 	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+	gomega "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils"
 )
 
-// CreateFile creates a new file in a repository
+// CreateBranch creates a new branch in a Forgejo repository.
+// projectID must be "owner/repo".
+func (fc *ForgejoClient) CreateBranch(projectID, newBranchName, baseBranch string) error {
+	owner, repo := splitProjectID(projectID)
+
+	opts := forgejo.CreateBranchOption{
+		BranchName:    newBranchName,
+		OldBranchName: baseBranch,
+	}
+
+	_, resp, err := fc.client.CreateBranch(owner, repo, opts)
+	if err != nil {
+		return fmt.Errorf("failed to create branch %s in project %s: %w", newBranchName, projectID, err)
+	}
+	if resp != nil && resp.StatusCode != http.StatusCreated {
+		return fmt.Errorf("unexpected status code when creating branch %s: %d", newBranchName, resp.StatusCode)
+	}
+
+	gomega.Eventually(func() bool {
+		exists, err := fc.ExistsBranch(projectID, newBranchName)
+		if err != nil {
+			return false
+		}
+		return exists
+	}, 2*time.Minute, 2*time.Second).Should(gomega.BeTrue())
+
+	return nil
+}
+
+// ExistsBranch reports whether a branch exists in a Forgejo repository.
+func (fc *ForgejoClient) ExistsBranch(projectID, branchName string) (bool, error) {
+	owner, repo := splitProjectID(projectID)
+
+	_, resp, err := fc.client.GetRepoBranch(owner, repo, branchName)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// DeleteBranch deletes a branch from a Forgejo repository.
+func (fc *ForgejoClient) DeleteBranch(projectID, branchName string) error {
+	owner, repo := splitProjectID(projectID)
+
+	_, _, err := fc.client.DeleteRepoBranch(owner, repo, branchName)
+	if err != nil {
+		return fmt.Errorf("failed to delete branch %s: %w", branchName, err)
+	}
+	return nil
+}
+
+// GetPullRequests lists open pull requests in a repository.
+func (fc *ForgejoClient) GetPullRequests(projectID string) ([]*forgejo.PullRequest, error) {
+	owner, repo := splitProjectID(projectID)
+
+	opts := forgejo.ListPullRequestsOptions{
+		State: forgejo.StateOpen,
+		ListOptions: forgejo.ListOptions{
+			Page:     1,
+			PageSize: 100,
+		},
+	}
+
+	prs, _, err := fc.client.ListRepoPullRequests(owner, repo, opts)
+	if err != nil {
+		return nil, err
+	}
+	return prs, nil
+}
+
+// CreatePullRequest creates a new pull request.
+func (fc *ForgejoClient) CreatePullRequest(projectID, title, body, head, base string) (*forgejo.PullRequest, error) {
+	owner, repo := splitProjectID(projectID)
+
+	opts := forgejo.CreatePullRequestOption{
+		Title: title,
+		Body:  body,
+		Head:  head,
+		Base:  base,
+	}
+
+	pr, _, err := fc.client.CreatePullRequest(owner, repo, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pull request: %w", err)
+	}
+	return pr, nil
+}
+
+// MergePullRequest merges a pull request.
+func (fc *ForgejoClient) MergePullRequest(projectID string, prNumber int64) (*forgejo.PullRequest, error) {
+	owner, repo := splitProjectID(projectID)
+
+	opts := forgejo.MergePullRequestOption{
+		Style: forgejo.MergeStyleMerge,
+	}
+
+	success, _, err := fc.client.MergePullRequest(owner, repo, prNumber, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to merge pull request: %w", err)
+	}
+	if !success {
+		return nil, fmt.Errorf("merge was not successful")
+	}
+
+	pr, _, err := fc.client.GetPullRequest(owner, repo, prNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get merged pull request: %w", err)
+	}
+	return pr, nil
+}
+
+// UpdatePullRequestBranch updates a pull request branch (merge base into PR branch).
+func (fc *ForgejoClient) UpdatePullRequestBranch(projectID string, prNumber int64) error {
+	owner, repo := splitProjectID(projectID)
+
+	url := fmt.Sprintf("%s/api/v1/repos/%s/%s/pulls/%d/update", strings.TrimSuffix(fc.apiURL, "/"), owner, repo, prNumber)
+	req, err := http.NewRequest(http.MethodPost, url, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for updating PR branch #%d: %w", prNumber, err)
+	}
+	req.Header.Set("Authorization", "token "+fc.token)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to update pull request branch for PR #%d: %w", prNumber, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code when updating PR branch #%d: %d", prNumber, resp.StatusCode)
+	}
+	return nil
+}
+
+// ClosePullRequest closes a pull request without merging.
+func (fc *ForgejoClient) ClosePullRequest(projectID string, prNumber int64) error {
+	owner, repo := splitProjectID(projectID)
+
+	state := forgejo.StateClosed
+	opts := forgejo.EditPullRequestOption{
+		State: &state,
+	}
+
+	_, _, err := fc.client.EditPullRequest(owner, repo, prNumber, opts)
+	if err != nil {
+		return fmt.Errorf("failed to close pull request %d: %w", prNumber, err)
+	}
+	return nil
+}
+
+// CreateFile creates a new file in a repository.
 func (fc *ForgejoClient) CreateFile(projectID, pathToFile, content, branchName string) (*forgejo.FileResponse, error) {
 	owner, repo := splitProjectID(projectID)
 
@@ -24,11 +183,185 @@ func (fc *ForgejoClient) CreateFile(projectID, pathToFile, content, branchName s
 	if err != nil {
 		return nil, fmt.Errorf("failed to create file %s: %w", pathToFile, err)
 	}
-
 	return fileResp, nil
 }
 
-// splitProjectID splits a projectID in format "owner/repo" into owner and repo
+// GetFile returns decoded file contents and metadata for a path on a branch.
+func (fc *ForgejoClient) GetFile(projectID, pathToFile, branchName string) (string, *forgejo.ContentsResponse, error) {
+	owner, repo := splitProjectID(projectID)
+
+	cr, _, err := fc.client.GetContents(owner, repo, branchName, pathToFile)
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to get file %s: %w", pathToFile, err)
+	}
+	if cr == nil || cr.Content == nil {
+		return "", cr, nil
+	}
+	decoded, err := base64.StdEncoding.DecodeString(strings.TrimSpace(*cr.Content))
+	if err != nil {
+		return "", nil, fmt.Errorf("failed to decode file content: %w", err)
+	}
+	return string(decoded), cr, nil
+}
+
+// DeleteWebhooks deletes the first repo webhook whose URL contains clusterAppDomain.
+func (fc *ForgejoClient) DeleteWebhooks(projectID, clusterAppDomain string) error {
+	if clusterAppDomain == "" {
+		return fmt.Errorf("clusterAppDomain is empty")
+	}
+
+	owner, repo := splitProjectID(projectID)
+
+	hooks, _, err := fc.client.ListRepoHooks(owner, repo, forgejo.ListHooksOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to list webhooks: %w", err)
+	}
+
+	for _, hook := range hooks {
+		if hook.Config == nil {
+			continue
+		}
+		if urlStr, ok := hook.Config["url"]; ok && strings.Contains(urlStr, clusterAppDomain) {
+			_, err := fc.client.DeleteRepoHook(owner, repo, hook.ID)
+			if err != nil {
+				return fmt.Errorf("failed to delete webhook (ID: %d): %w", hook.ID, err)
+			}
+			break
+		}
+	}
+	return nil
+}
+
+// ForkRepository clones sourceProjectID into a new repository targetProjectID via MigrateRepo.
+func (fc *ForgejoClient) ForkRepository(sourceProjectID, targetProjectID string) (*forgejo.Repository, error) {
+	sourceOwner, sourceRepo := splitProjectID(sourceProjectID)
+	targetOwner, targetRepo := splitProjectID(targetProjectID)
+
+	cloneAddr := fmt.Sprintf("%s/%s/%s.git", strings.TrimSuffix(fc.apiURL, "/"), sourceOwner, sourceRepo)
+
+	var migratedRepo *forgejo.Repository
+	var lastErr error
+
+	err := utils.WaitUntilWithInterval(func() (bool, error) {
+		var resp *forgejo.Response
+		var migrateErr error
+		migratedRepo, resp, migrateErr = fc.client.MigrateRepo(forgejo.MigrateRepoOption{
+			RepoName:  targetRepo,
+			RepoOwner: targetOwner,
+			CloneAddr: cloneAddr,
+			Service:   forgejo.GitServiceForgejo,
+			AuthToken: fc.token,
+		})
+		if migrateErr != nil {
+			lastErr = migrateErr
+			statusCode := 0
+			if resp != nil && resp.Response != nil {
+				statusCode = resp.StatusCode
+			}
+			if statusCode == http.StatusNotFound || statusCode == http.StatusUnauthorized || statusCode == http.StatusForbidden {
+				return false, fmt.Errorf("error migrating project %s to %s (HTTP %d): %w", sourceProjectID, targetProjectID, statusCode, migrateErr)
+			}
+			if statusCode == http.StatusConflict {
+				existingRepo, _, getErr := fc.client.GetRepo(targetOwner, targetRepo)
+				if getErr != nil {
+					return false, fmt.Errorf("error migrating project %s to %s: repo already exists but failed to fetch it: %w", sourceProjectID, targetProjectID, getErr)
+				}
+				migratedRepo = existingRepo
+				return true, nil
+			}
+			return false, nil
+		}
+		return true, nil
+	}, time.Second*10, time.Minute*5)
+
+	if err != nil {
+		if lastErr != nil {
+			return nil, fmt.Errorf("error migrating project %s to %s (last error: %v): %w", sourceProjectID, targetProjectID, lastErr, err)
+		}
+		return nil, fmt.Errorf("error migrating project %s to %s: %w", sourceProjectID, targetProjectID, err)
+	}
+	return migratedRepo, nil
+}
+
+// DeleteRepository deletes a repository.
+func (fc *ForgejoClient) DeleteRepository(projectID string) error {
+	owner, repo := splitProjectID(projectID)
+
+	_, err := fc.client.DeleteRepo(owner, repo)
+	if err != nil {
+		if strings.Contains(err.Error(), "404") {
+			return nil
+		}
+		return fmt.Errorf("failed to delete repository %s: %w", projectID, err)
+	}
+	return nil
+}
+
+// DeleteRepositoryIfExists deletes a repository if it exists.
+func (fc *ForgejoClient) DeleteRepositoryIfExists(projectID string) error {
+	owner, repo := splitProjectID(projectID)
+
+	_, resp, err := fc.client.GetRepo(owner, repo)
+	if err != nil {
+		if resp != nil && resp.StatusCode == http.StatusNotFound {
+			return nil
+		}
+		return fmt.Errorf("error checking if repository exists: %w", err)
+	}
+	return fc.DeleteRepository(projectID)
+}
+
+// GetCommitStatusConclusion waits for a commit status whose context contains statusName and returns its state string.
+func (fc *ForgejoClient) GetCommitStatusConclusion(statusName, projectID, commitSHA string, prNumber int64) string {
+	_ = prNumber
+	owner, repo := splitProjectID(projectID)
+	var matchingStatus *forgejo.CombinedStatus
+	timeout := time.Minute * 10
+
+	gomega.Eventually(func() bool {
+		combinedStatus, _, err := fc.client.GetCombinedStatus(owner, repo, commitSHA)
+		if err != nil {
+			return false
+		}
+		for _, status := range combinedStatus.Statuses {
+			if strings.Contains(status.Context, statusName) {
+				matchingStatus = combinedStatus
+				return true
+			}
+		}
+		return false
+	}, timeout, 2*time.Second).Should(gomega.BeTrue(),
+		fmt.Sprintf("timed out waiting for the PaC commit status to appear for %s", commitSHA))
+
+	gomega.Eventually(func() bool {
+		combinedStatus, _, err := fc.client.GetCombinedStatus(owner, repo, commitSHA)
+		if err != nil {
+			return false
+		}
+		for _, status := range combinedStatus.Statuses {
+			if strings.Contains(status.Context, statusName) {
+				if status.State != forgejo.StatusPending {
+					matchingStatus = combinedStatus
+					return true
+				}
+				return false
+			}
+		}
+		return false
+	}, timeout, 2*time.Second).Should(gomega.BeTrue(),
+		fmt.Sprintf("timed out waiting for the PaC commit status to be completed for %s", commitSHA))
+
+	if matchingStatus == nil {
+		return ""
+	}
+	for _, status := range matchingStatus.Statuses {
+		if strings.Contains(status.Context, statusName) {
+			return string(status.State)
+		}
+	}
+	return ""
+}
+
 func splitProjectID(projectID string) (string, string) {
 	parts := strings.SplitN(projectID, "/", 2)
 	if len(parts) != 2 {

--- a/e2e-tests/pkg/clients/git/forgejo.go
+++ b/e2e-tests/pkg/clients/git/forgejo.go
@@ -1,0 +1,181 @@
+package git
+
+import (
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/clients/forgejo"
+)
+
+// ForgejoClient adapts forgejo.ForgejoClient to the git Client interface.
+type ForgejoClient struct {
+	*forgejo.ForgejoClient
+}
+
+// NewForgejoClient wraps a Forgejo API client.
+func NewForgejoClient(fc *forgejo.ForgejoClient) *ForgejoClient {
+	return &ForgejoClient{fc}
+}
+
+// CreateBranch creates branchName from baseBranchName (revision is ignored for Forgejo).
+func (f *ForgejoClient) CreateBranch(repository, baseBranchName, _, branchName string) error {
+	return f.ForgejoClient.CreateBranch(repository, branchName, baseBranchName)
+}
+
+// BranchExists reports whether a branch exists.
+func (f *ForgejoClient) BranchExists(repository, branchName string) (bool, error) {
+	return f.ExistsBranch(repository, branchName)
+}
+
+// ListPullRequests lists open pull requests.
+func (f *ForgejoClient) ListPullRequests(projectID string) ([]*PullRequest, error) {
+	prs, err := f.GetPullRequests(projectID)
+	if err != nil {
+		return nil, err
+	}
+	var pullRequests []*PullRequest
+	for _, pr := range prs {
+		if pr.Head == nil || pr.Base == nil {
+			continue
+		}
+		pullRequests = append(pullRequests, &PullRequest{
+			Number:       int(pr.Index),
+			SourceBranch: pr.Head.Ref,
+			TargetBranch: pr.Base.Ref,
+			HeadSHA:      pr.Head.Sha,
+		})
+	}
+	return pullRequests, nil
+}
+
+// CreateFile creates a file on a branch.
+func (f *ForgejoClient) CreateFile(repository, pathToFile, content, branchName string) (*RepositoryFile, error) {
+	fileResp, err := f.ForgejoClient.CreateFile(repository, pathToFile, content, branchName)
+	if err != nil {
+		return nil, err
+	}
+	resultFile := &RepositoryFile{}
+	if fileResp != nil && fileResp.Commit != nil {
+		resultFile.CommitSHA = fileResp.Commit.SHA
+	}
+	return resultFile, nil
+}
+
+// GetFile fetches file contents from a branch.
+func (f *ForgejoClient) GetFile(repository, pathToFile, branchName string) (*RepositoryFile, error) {
+	content, contentsResp, err := f.ForgejoClient.GetFile(repository, pathToFile, branchName)
+	if err != nil {
+		return nil, err
+	}
+	resultFile := &RepositoryFile{
+		Content: content,
+	}
+	if contentsResp != nil {
+		resultFile.CommitSHA = contentsResp.SHA
+	}
+	return resultFile, nil
+}
+
+// MergePullRequest merges a pull request by number.
+func (f *ForgejoClient) MergePullRequest(repository string, prNumber int) (*PullRequest, error) {
+	pr, err := f.ForgejoClient.MergePullRequest(repository, int64(prNumber))
+	if err != nil {
+		return nil, err
+	}
+	mergeCommitSHA := ""
+	if pr.MergedCommitID != nil {
+		mergeCommitSHA = *pr.MergedCommitID
+	}
+	headSha := ""
+	if pr.Head != nil {
+		headSha = pr.Head.Sha
+	}
+	src, tgt := "", ""
+	if pr.Head != nil {
+		src = pr.Head.Ref
+	}
+	if pr.Base != nil {
+		tgt = pr.Base.Ref
+	}
+	return &PullRequest{
+		Number:         int(pr.Index),
+		SourceBranch:   src,
+		TargetBranch:   tgt,
+		HeadSHA:        headSha,
+		MergeCommitSHA: mergeCommitSHA,
+	}, nil
+}
+
+// CreatePullRequest creates a new pull request.
+func (f *ForgejoClient) CreatePullRequest(repository, title, body, head, base string) (*PullRequest, error) {
+	pr, err := f.ForgejoClient.CreatePullRequest(repository, title, body, head, base)
+	if err != nil {
+		return nil, err
+	}
+	headSha := ""
+	if pr.Head != nil {
+		headSha = pr.Head.Sha
+	}
+	src, tgt := "", ""
+	if pr.Head != nil {
+		src = pr.Head.Ref
+	}
+	if pr.Base != nil {
+		tgt = pr.Base.Ref
+	}
+	return &PullRequest{
+		Number:       int(pr.Index),
+		SourceBranch: src,
+		TargetBranch: tgt,
+		HeadSHA:      headSha,
+	}, nil
+}
+
+// UpdatePullRequestBranch merges the base branch into the PR branch.
+func (f *ForgejoClient) UpdatePullRequestBranch(repository string, prNumber int) error {
+	return f.ForgejoClient.UpdatePullRequestBranch(repository, int64(prNumber))
+}
+
+// CleanupWebhooks removes webhooks matching the cluster app domain.
+func (f *ForgejoClient) CleanupWebhooks(repository, clusterAppDomain string) error {
+	return f.DeleteWebhooks(repository, clusterAppDomain)
+}
+
+// DeleteBranchAndClosePullRequest deletes the PR source branch and closes the PR.
+func (f *ForgejoClient) DeleteBranchAndClosePullRequest(repository string, prNumber int) error {
+	prs, err := f.GetPullRequests(repository)
+	if err != nil {
+		return err
+	}
+	var sourceBranch string
+	for _, pr := range prs {
+		if int(pr.Index) == prNumber && pr.Head != nil {
+			sourceBranch = pr.Head.Ref
+			break
+		}
+	}
+	if sourceBranch != "" {
+		if err := f.ForgejoClient.DeleteBranch(repository, sourceBranch); err != nil {
+			return err
+		}
+	}
+	return f.ClosePullRequest(repository, int64(prNumber))
+}
+
+// ForkRepository migrates/clones source into a new repository name.
+func (f *ForgejoClient) ForkRepository(sourceRepoName, targetRepoName string) error {
+	_, err := f.ForgejoClient.ForkRepository(sourceRepoName, targetRepoName)
+	return err
+}
+
+// DeleteRepositoryIfExists deletes a repository if present.
+func (f *ForgejoClient) DeleteRepositoryIfExists(repoName string) error {
+	return f.ForgejoClient.DeleteRepositoryIfExists(repoName)
+}
+
+// DeleteBranch deletes a branch.
+func (f *ForgejoClient) DeleteBranch(repository, branchName string) error {
+	return f.ForgejoClient.DeleteBranch(repository, branchName)
+}
+
+// GetCommitStatusConclusion returns the commit status state string for a scenario.
+func (f *ForgejoClient) GetCommitStatusConclusion(statusName, projectID, commitSHA string, prNumber int) string {
+	return f.ForgejoClient.GetCommitStatusConclusion(statusName, projectID, commitSHA, int64(prNumber))
+}

--- a/e2e-tests/pkg/clients/git/git.go
+++ b/e2e-tests/pkg/clients/git/git.go
@@ -1,0 +1,37 @@
+package git
+
+// PullRequest is a provider-agnostic pull/merge request.
+type PullRequest struct {
+	Number int
+	// SourceBranch includes the changes made in the pull request
+	SourceBranch string
+	// TargetBranch is the base branch on top of which the changes are merged
+	TargetBranch string
+	// MergeCommitSHA is the revision of the commit which merged the PullRequest
+	MergeCommitSHA string
+	// HeadSHA is the revision of the commit on top of the SourceBranch
+	HeadSHA string
+}
+
+// RepositoryFile is a provider-agnostic file in a repository.
+type RepositoryFile struct {
+	CommitSHA string
+	Content   string
+}
+
+// Client is implemented by provider-specific git clients used in e2e tests.
+type Client interface {
+	CreateBranch(repository, baseBranchName, revision, branchName string) error
+	DeleteBranch(repository, branchName string) error
+	BranchExists(repository, branchName string) (bool, error)
+	ListPullRequests(repository string) ([]*PullRequest, error)
+	CreateFile(repository, pathToFile, content, branchName string) (*RepositoryFile, error)
+	GetFile(repository, pathToFile, branchName string) (*RepositoryFile, error)
+	CreatePullRequest(repository, title, body, head, base string) (*PullRequest, error)
+	MergePullRequest(repository string, prNumber int) (*PullRequest, error)
+	UpdatePullRequestBranch(repository string, prNumber int) error
+	DeleteBranchAndClosePullRequest(repository string, prNumber int) error
+	CleanupWebhooks(repository, clusterAppDomain string) error
+	ForkRepository(sourceRepoName, targetRepoName string) error
+	DeleteRepositoryIfExists(repoName string) error
+}

--- a/e2e-tests/pkg/clients/git/retry.go
+++ b/e2e-tests/pkg/clients/git/retry.go
@@ -1,0 +1,26 @@
+package git
+
+import (
+	"fmt"
+	"time"
+
+	"k8s.io/klog/v2"
+)
+
+// ListPullRequestsWithRetry wraps Client.ListPullRequests with retries on transient errors.
+func ListPullRequestsWithRetry(client Client, repository string) ([]*PullRequest, error) {
+	const maxRetries = 3
+	var prs []*PullRequest
+	var err error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		prs, err = client.ListPullRequests(repository)
+		if err == nil {
+			return prs, nil
+		}
+		klog.Warningf("error listing PRs in %s (attempt %d/%d): %v", repository, attempt, maxRetries, err)
+		if attempt < maxRetries {
+			time.Sleep(5 * time.Second)
+		}
+	}
+	return nil, fmt.Errorf("failed to list pull requests for %s after %d retries: %w", repository, maxRetries, err)
+}

--- a/e2e-tests/pkg/clients/tekton/repository.go
+++ b/e2e-tests/pkg/clients/tekton/repository.go
@@ -1,0 +1,85 @@
+package tekton
+
+import (
+	"context"
+	"fmt"
+
+	pacv1alpha1 "github.com/openshift-pipelines/pipelines-as-code/pkg/apis/pipelinesascode/v1alpha1"
+	rclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetRepositoryParams returns the params for a PaC Repository CR owned by the
+// given component. Build-service sets the Component as an ownerReference on the
+// Repository CR regardless of the CR naming scheme.
+func (t *TektonController) GetRepositoryParams(componentName, namespace string) ([]pacv1alpha1.Params, error) {
+	ctx := context.Background()
+	repositoryList := &pacv1alpha1.RepositoryList{}
+	if err := t.KubeRest().List(ctx, repositoryList, &rclient.ListOptions{Namespace: namespace}); err != nil {
+		return nil, fmt.Errorf("list PaC repositories in namespace %s: %w", namespace, err)
+	}
+
+	if len(repositoryList.Items) == 0 {
+		return nil, fmt.Errorf("no PaC Repository CRs found in namespace %s (component %s)", namespace, componentName)
+	}
+
+	for i := range repositoryList.Items {
+		repo := &repositoryList.Items[i]
+		for _, ref := range repo.OwnerReferences {
+			if ref.Kind == "Component" && ref.Name == componentName {
+				if repo.Spec.Params == nil {
+					return []pacv1alpha1.Params{}, nil
+				}
+				return *repo.Spec.Params, nil
+			}
+		}
+	}
+
+	names := make([]string, 0, len(repositoryList.Items))
+	for _, r := range repositoryList.Items {
+		names = append(names, r.Name)
+	}
+	return nil, fmt.Errorf("no PaC Repository CR owned by component %q in namespace %s (%d repositories: %v)",
+		componentName, namespace, len(repositoryList.Items), names)
+}
+
+// PatchRepositoryPullRequestPolicy adds users to the PaC Repository CR's
+// spec.settings.policy.pull_request allowlist for Gitea/Forgejo authorization.
+func (t *TektonController) PatchRepositoryPullRequestPolicy(componentName, namespace string, users []string) error {
+	ctx := context.Background()
+	repositoryList := &pacv1alpha1.RepositoryList{}
+	if err := t.KubeRest().List(ctx, repositoryList, &rclient.ListOptions{Namespace: namespace}); err != nil {
+		return fmt.Errorf("list PaC repositories in namespace %s: %w", namespace, err)
+	}
+
+	for i := range repositoryList.Items {
+		repo := &repositoryList.Items[i]
+		for _, ref := range repo.OwnerReferences {
+			if ref.Kind != "Component" || ref.Name != componentName {
+				continue
+			}
+			if repo.Spec.Settings == nil {
+				repo.Spec.Settings = &pacv1alpha1.Settings{}
+			}
+			if repo.Spec.Settings.Policy == nil {
+				repo.Spec.Settings.Policy = &pacv1alpha1.Policy{}
+			}
+			existing := make(map[string]struct{}, len(repo.Spec.Settings.Policy.PullRequest))
+			for _, u := range repo.Spec.Settings.Policy.PullRequest {
+				existing[u] = struct{}{}
+			}
+			for _, u := range users {
+				if _, ok := existing[u]; !ok {
+					repo.Spec.Settings.Policy.PullRequest = append(repo.Spec.Settings.Policy.PullRequest, u)
+				}
+			}
+			return t.KubeRest().Update(ctx, repo)
+		}
+	}
+
+	names := make([]string, 0, len(repositoryList.Items))
+	for _, r := range repositoryList.Items {
+		names = append(names, r.Name)
+	}
+	return fmt.Errorf("no PaC Repository CR owned by component %q in namespace %s (%d repositories: %v)",
+		componentName, namespace, len(repositoryList.Items), names)
+}

--- a/e2e-tests/pkg/utils/build/git.go
+++ b/e2e-tests/pkg/utils/build/git.go
@@ -29,3 +29,25 @@ func CreateGitlabBuildSecret(f *framework.Framework, secretName string, annotati
 	}
 	return nil
 }
+
+// CreateCodebergBuildSecret creates a Kubernetes secret for Codeberg/Forgejo build credentials.
+func CreateCodebergBuildSecret(f *framework.Framework, secretName string, annotations map[string]string, token string) error {
+	buildSecret := v1.Secret{}
+	buildSecret.Name = secretName
+	buildSecret.Labels = map[string]string{
+		"appstudio.redhat.com/credentials": "scm",
+		"appstudio.redhat.com/scm.host":    "codeberg.org",
+	}
+	if annotations != nil {
+		buildSecret.Annotations = annotations
+	}
+	buildSecret.Type = "kubernetes.io/basic-auth"
+	buildSecret.StringData = map[string]string{
+		"password": token,
+	}
+	_, err := f.AsKubeAdmin.CommonController.CreateSecret(f.UserNamespace, &buildSecret)
+	if err != nil {
+		return fmt.Errorf("error creating build secret: %v", err)
+	}
+	return nil
+}

--- a/e2e-tests/tests/integration-service/README.md
+++ b/e2e-tests/tests/integration-service/README.md
@@ -27,7 +27,14 @@ This suite verifies the reporting of integration test statuses to GitLab Merge R
 - `https://gitlab.com/redhat-appstudio-qe/hacbs-test-project-integration`
 - `https://github.com/konflux-ci/integration-examples`
 
-### 4. E2E Tests within `group-snapshots-tests.go`
+### 4. E2E Tests within `forgejo-integration-reporting.go`
+This suite verifies the reporting of integration test statuses to Forgejo merge requests on Codeberg (same overall flow as the GitLab MR status-reporting suite). Each run migrates a fresh repository from the shared template so webhooks and secrets do not collide across parallel jobs. It checks commit status, MR comments, merge, and a follow-up push PipelineRun.
+
+**Repositories:**
+- `https://codeberg.org/konflux-qe/konflux-test-integration` (template; per-run clone)
+- `https://github.com/konflux-ci/integration-examples`
+
+### 5. E2E Tests within `group-snapshots-tests.go`
 This suite tests the creation of group snapshots for both monorepo and multiple repositories scenarios. It verifies the integration service's ability to handle multiple components across different repository structures, including proper group snapshot creation, component coordination, and snapshot lifecycle management.
 
 **Repositories:**
@@ -35,7 +42,7 @@ This suite tests the creation of group snapshots for both monorepo and multiple 
 - `https://github.com/redhat-appstudio-qe/konflux-test-integration-clone`
 - `https://github.com/konflux-ci/integration-examples`
 
-### 5. E2E Tests within `pipelinerun-resolution.go`
+### 6. E2E Tests within `pipelinerun-resolution.go`
 This suite tests the integration service's pipeline resolution functionality, focusing on ResolutionRequest lifecycle management and ensuring proper cleanup of resolution resources after pipeline execution.
 
 **Repositories:**
@@ -100,7 +107,15 @@ Checkpoints:
 - Validating that at least one MR note contains the final integration test result (pass/fail or scenario name).
 - Merge MR and repeat three tests above.
 
-### 4. Happy Path Tests within `group-snapshots-tests.go`
+### 4. Happy Path Tests within `forgejo-integration-reporting.go`
+Checkpoints:
+- Migrating a disposable Codeberg repository from the shared template (avoids webhook secret races).
+- Creating an IntegrationTestScenario expected to pass.
+- Creating a custom branch and PaC init merge request; build PipelineRun completes.
+- Verifying integration status on the MR (commit status and MR comments).
+- Merging the MR and validating a push PipelineRun plus post-merge integration reporting.
+
+### 5. Happy Path Tests within `group-snapshots-tests.go`
 Checkpoints:
 - Creating multiple components (A, B, C) with different repository structures (monorepo and multi-repo).
 - Verifying that BuildPipelineRuns are triggered for each component and complete successfully.
@@ -114,7 +129,7 @@ Checkpoints:
 - Ensuring that group snapshots reference the correct build PipelineRuns for each component.
 - **Verifying that older snapshots and their associated integration PipelineRuns are cancelled when new group snapshots are created.**
 
-### 5. Happy Path Tests within `pipelinerun-resolution.go`
+### 6. Happy Path Tests within `pipelinerun-resolution.go`
 Checkpoints:
 - Testing for successful creation of applications and components with pipeline resolution.
 - Checking if the BuildPipelineRun is successfully triggered and completed with proper resolution.
@@ -158,8 +173,7 @@ Checkpoints:
 - Asserting that no releases are triggered if any integration test fails.
 - Merge MR and repeat three tests above.
 
-
-### 5. Negative Test Cases within `pipelinerun-resolution.go`
+### 4. Negative Test Cases within `pipelinerun-resolution.go`
 Checkpoints:
 - Verifying that ResolutionRequest objects are not cleaned up properly after pipeline resolution.
 - Ensuring that orphaned ResolutionRequest objects are detected and cleaned up.

--- a/e2e-tests/tests/integration-service/const.go
+++ b/e2e-tests/tests/integration-service/const.go
@@ -23,15 +23,17 @@ const (
 	autoReleasePlan                = "auto-releaseplan"
 	targetReleaseNamespace         = "default"
 
-	componentRepoNameForResolution            = "konflux-test-integration-resolution"
-	componentRepoNameForGeneralIntegration    = "konflux-test-integration"
-	componentRepoNameForGroupIntegration      = "konflux-test-integration-clone"
-	componentRepoNameForStatusReporting       = "konflux-test-integration-status-report"
-	multiComponentRepoNameForGroupSnapshot    = "group-snapshot-multi-component"
-	multiComponentDefaultBranch               = "onboarding"
-	multiComponentGitRevision                 = "0d1835404efb8ab7bb1ab5b5b82cda1ebfda4b25"
-	multiRepoComponentGitRevision             = "79402df023e646c5ad108abc879ad1b28799cbc4"
-	gitlabComponentRepoName                   = "hacbs-test-project-integration"
+	componentRepoNameForResolution         = "konflux-test-integration-resolution"
+	componentRepoNameForGeneralIntegration = "konflux-test-integration"
+	componentRepoNameForGroupIntegration   = "konflux-test-integration-clone"
+	componentRepoNameForStatusReporting    = "konflux-test-integration-status-report"
+	multiComponentRepoNameForGroupSnapshot = "group-snapshot-multi-component"
+	multiComponentDefaultBranch            = "onboarding"
+	multiComponentGitRevision              = "0d1835404efb8ab7bb1ab5b5b82cda1ebfda4b25"
+	multiRepoComponentGitRevision          = "79402df023e646c5ad108abc879ad1b28799cbc4"
+	gitlabComponentRepoName                = "hacbs-test-project-integration"
+	// Codeberg template for Forgejo integration status-reporting tests (see https://codeberg.org/konflux-qe/konflux-test-integration).
+	forgejoComponentRepoName                  = "konflux-test-integration"
 	componentDefaultBranch                    = "onboarding"
 	fallbackBranchName                        = "main"
 	componentRevision                         = "79402df023e646c5ad108abc879ad1b28799cbc4"
@@ -72,4 +74,6 @@ var (
 	gitlabOrg                                     = utils.GetEnv(constants.GITLAB_QE_ORG_ENV, constants.DefaultGitLabQEOrg)
 	gitlabProjectIDForStatusReporting             = fmt.Sprintf("%s/%s", gitlabOrg, gitlabComponentRepoName)
 	gitlabComponentGitSourceURLForStatusReporting = fmt.Sprintf("https://gitlab.com/%s/%s", gitlabOrg, gitlabComponentRepoName)
+	forgejoOrg                                    = utils.GetEnv(constants.CODEBERG_QE_ORG_ENV, constants.DefaultCodebergQEOrg)
+	forgejoProjectIDForStatusReporting            = fmt.Sprintf("%s/%s", forgejoOrg, forgejoComponentRepoName)
 )

--- a/e2e-tests/tests/integration-service/forgejo-integration-reporting.go
+++ b/e2e-tests/tests/integration-service/forgejo-integration-reporting.go
@@ -1,0 +1,315 @@
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"codeberg.org/mvdkleijn/forgejo-sdk/forgejo/v3"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/clients/git"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/clients/has"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils/build"
+
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+)
+
+var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of Integration tests", ginkgo.Label("integration-service", "forgejo-status-reporting"), func() {
+	defer ginkgo.GinkgoRecover()
+
+	var f *framework.Framework
+	var err error
+
+	var mrID int
+	var mrSha, forgejoToken string
+	var snapshot *appstudioApi.Snapshot
+	var component *appstudioApi.Component
+	var buildPipelineRun, testPipelinerun *pipeline.PipelineRun
+	var integrationTestScenarioPass *integrationv1beta2.IntegrationTestScenario
+	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
+	var mergeResultSha string
+
+	var gitClient git.Client
+	var forgejoGitClient *git.ForgejoClient
+	var reportingRepoURL, reportingRepository string
+
+	ginkgo.AfterEach(framework.ReportFailure(&f))
+
+	ginkgo.Describe("Forgejo with status reporting of Integration tests in the associated merge request", ginkgo.Ordered, func() {
+		ginkgo.BeforeAll(func() {
+			if os.Getenv(constants.SKIP_PAC_TESTS_ENV) == "true" {
+				ginkgo.Skip("Skipping this test due to configuration issue with Spray proxy")
+			}
+
+			f, err = framework.NewFramework(utils.GetGeneratedNamespace("forgejo-rep"))
+			gomega.Expect(err).NotTo(gomega.HaveOccurred())
+			testNamespace = f.UserNamespace
+
+			if utils.IsPrivateHostname(f.OpenshiftConsoleHost) {
+				ginkgo.Skip("Using private cluster (not reachable from Forgejo/Codeberg), skipping...")
+			}
+
+			applicationName = createApp(*f, testNamespace)
+
+			gomega.Eventually(func() error {
+				_, err := f.AsKubeAdmin.HasController.GetApplication(applicationName, testNamespace)
+				return err
+			}, time.Minute*2, time.Second*5).Should(gomega.Succeed(),
+				fmt.Sprintf("Application %s should be available in namespace %s", applicationName, testNamespace))
+
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{})
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			componentName = fmt.Sprintf("%s-%s", "test-comp-pac-forgejo", utils.GenerateRandomString(6))
+			pacBranchName = constants.PaCPullRequestBranchPrefix + componentName
+			componentBaseBranchName = fmt.Sprintf("base-forgejo-%s", utils.GenerateRandomString(6))
+
+			forgejoToken = utils.GetEnv(constants.CODEBERG_BOT_TOKEN_ENV, "")
+			gomega.Expect(forgejoToken).ShouldNot(gomega.BeEmpty(), fmt.Sprintf("'%s' env var is not set", constants.CODEBERG_BOT_TOKEN_ENV))
+			gomega.Expect(f.AsKubeAdmin.CommonController.Forgejo).NotTo(gomega.BeNil())
+
+			forgejoGitClient = git.NewForgejoClient(f.AsKubeAdmin.CommonController.Forgejo)
+			gitClient = forgejoGitClient
+
+			reportingRepository = fmt.Sprintf("%s/%s", forgejoOrg, forgejoComponentRepoName+"-"+utils.GenerateRandomString(6))
+			err = gitClient.ForkRepository(forgejoProjectIDForStatusReporting, reportingRepository)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			reportingRepoURL = fmt.Sprintf("https://codeberg.org/%s", reportingRepository)
+
+			err = build.CreateCodebergBuildSecret(f, "forgejo-build-secret", map[string]string{}, forgejoToken)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+			err = gitClient.CreateBranch(reportingRepository, componentDefaultBranch, "", componentBaseBranchName)
+			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+		})
+
+		ginkgo.AfterAll(func() {
+			if !ginkgo.CurrentSpecReport().Failed() {
+				if mrID != 0 {
+					_ = gitClient.DeleteBranchAndClosePullRequest(reportingRepository, mrID)
+				}
+
+				gomega.Expect(gitClient.DeleteRepositoryIfExists(reportingRepository)).To(gomega.Succeed())
+			}
+
+			if !ginkgo.CurrentSpecReport().Failed() {
+				gomega.Expect(f.AsKubeAdmin.HasController.DeleteAllComponentsInASpecificNamespace(testNamespace, time.Minute*2)).To(gomega.Succeed())
+				gomega.Expect(f.AsKubeAdmin.HasController.DeleteAllApplicationsInASpecificNamespace(testNamespace, time.Minute*2)).To(gomega.Succeed())
+			}
+		})
+
+		ginkgo.When("a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
+			ginkgo.BeforeAll(func() {
+				componentObj := appstudioApi.ComponentSpec{
+					ComponentName: componentName,
+					Application:   applicationName,
+					Source: appstudioApi.ComponentSource{
+						ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
+							GitSource: &appstudioApi.GitSource{
+								URL:           reportingRepoURL,
+								Revision:      componentBaseBranchName,
+								DockerfileURL: "Dockerfile",
+							},
+						},
+					},
+				}
+				buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
+				gitProviderAnnotation := map[string]string{"git-provider": "forgejo"}
+
+				component, err = f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, testNamespace, "", "", applicationName, false,
+					utils.MergeMaps(
+						utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation),
+						gitProviderAnnotation,
+					))
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+				gomega.Eventually(func() error {
+					_, getErr := f.AsKubeAdmin.TektonController.GetRepositoryParams(componentName, testNamespace)
+					return getErr
+				}, time.Minute*5, time.Second*5).Should(gomega.Succeed(),
+					fmt.Sprintf("timed out waiting for PaC Repository CR for component %s in namespace %s", componentName, testNamespace))
+
+				gomega.Eventually(func() bool {
+					prs, listErr := git.ListPullRequestsWithRetry(gitClient, reportingRepository)
+					if listErr != nil {
+						ginkgo.GinkgoWriter.Printf("error listing pull requests while waiting for PaC init PR: %v\n", listErr)
+						return false
+					}
+					for _, pr := range prs {
+						if pr.SourceBranch == pacBranchName {
+							mrID = pr.Number
+							return true
+						}
+					}
+					return false
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(),
+					fmt.Sprintf("timed out waiting for PaC init PR (branch %s) to be created in %s", pacBranchName, reportingRepository))
+			})
+
+			ginkgo.It("triggers a Build PipelineRun", func() {
+				gomega.Eventually(func() error {
+					buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+					if err != nil {
+						ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
+						return err
+					}
+					if !buildPipelineRun.HasStarted() {
+						return fmt.Errorf("build pipelinerun %s/%s hasn't started yet", buildPipelineRun.GetNamespace(), buildPipelineRun.GetName())
+					}
+					return nil
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", testNamespace, componentName))
+			})
+
+			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+				gomega.Expect(buildPipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
+			})
+
+			ginkgo.It("should lead to build PipelineRun finishing successfully", func() {
+				gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "",
+					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, buildPipelineRun)).To(gomega.Succeed())
+			})
+
+			ginkgo.It("should have a related PaC init MR created", func() {
+				gomega.Eventually(func() bool {
+					prs, err := git.ListPullRequestsWithRetry(gitClient, reportingRepository)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+					for _, pr := range prs {
+						if pr.SourceBranch == pacBranchName {
+							mrID = pr.Number
+							mrSha = pr.HeadSHA
+							return true
+						}
+					}
+					return false
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC MR (branch name '%s') to be created in %s repository", pacBranchName, reportingRepository))
+
+				buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mrSha)
+				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.It(fmt.Sprintf("the PipelineRun should eventually finish successfully for component %s", componentName), func() {
+				gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "", "",
+					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(gomega.Succeed())
+			})
+		})
+
+		ginkgo.When("the PaC build pipelineRun run succeeded", func() {
+			ginkgo.It("checks if the BuildPipelineRun has the annotation of chains signed", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(gomega.Succeed())
+			})
+
+			ginkgo.It("checks if the Snapshot is created", func() {
+				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+			})
+
+			ginkgo.It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(gomega.Succeed())
+			})
+		})
+
+		ginkgo.When("the Snapshot was created", func() {
+			ginkgo.It("should find the Integration Test Scenario PipelineRun", func() {
+				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
+				gomega.Expect(err).ToNot(gomega.HaveOccurred())
+				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
+				gomega.Expect(testPipelinerun.Labels[scenarioAnnotation]).To(gomega.ContainSubstring(integrationTestScenarioPass.Name))
+			})
+		})
+
+		ginkgo.When("Integration PipelineRun is created", func() {
+			ginkgo.It("should eventually complete successfully", func() {
+				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
+					fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
+			})
+
+			ginkgo.It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+				gomega.Expect(
+					forgejoGitClient.GetCommitStatusConclusion(integrationTestScenarioPass.Name, reportingRepository, mrSha, mrID),
+				).To(gomega.Equal(integrationPipelineRunCommitStatusSuccess))
+			})
+
+			ginkgo.It("validates at least one MR comment contains the final integration test result", func() {
+				gomega.Eventually(func() bool {
+					owner, repo, ok := strings.Cut(reportingRepository, "/")
+					if !ok {
+						return false
+					}
+					comments, _, err := f.AsKubeAdmin.CommonController.Forgejo.GetClient().ListIssueComments(owner, repo, int64(mrID), forgejo.ListIssueCommentOptions{})
+					if err != nil {
+						ginkgo.GinkgoWriter.Printf("failed to list issue/PR comments: %v\n", err)
+						return false
+					}
+					for _, c := range comments {
+						if c == nil {
+							continue
+						}
+						body := c.Body
+						if strings.Contains(body, integrationTestScenarioPass.Name) {
+							return true
+						}
+						if strings.Contains(body, "integration") &&
+							(strings.Contains(body, "pass") || strings.Contains(body, "success")) {
+							return true
+						}
+					}
+					return false
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(),
+					fmt.Sprintf("no MR comment found containing integration test result for PR #%d in project %s", mrID, reportingRepository))
+			})
+
+			ginkgo.It("merging the PR should be successful", func() {
+				var mergeResult *git.PullRequest
+				gomega.Eventually(func() error {
+					mergeResult, err = gitClient.MergePullRequest(reportingRepository, mrID)
+					return err
+				}, shortTimeout, constants.PipelineRunPollingInterval).ShouldNot(gomega.HaveOccurred(),
+					fmt.Sprintf("error when merging PaC merge request ID #%d in repo %s", mrID, reportingRepository))
+
+				mergeResultSha = mergeResult.MergeCommitSHA
+				if mergeResultSha == "" {
+					mergeResultSha = mergeResult.HeadSHA
+				}
+				ginkgo.GinkgoWriter.Printf("merged result sha: %s for MR #%d\n", mergeResultSha, mrID)
+			})
+
+			ginkgo.It("leads to triggering a push PipelineRun", func() {
+				gomega.Eventually(func() error {
+					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
+					if err != nil {
+						ginkgo.GinkgoWriter.Printf("Push PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
+						return err
+					}
+					if !pipelineRun.HasStarted() {
+						return fmt.Errorf("push pipelinerun %s/%s hasn't started yet", pipelineRun.GetNamespace(), pipelineRun.GetName())
+					}
+					return nil
+				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(),
+					fmt.Sprintf("timed out when waiting for the push PipelineRun to start for the component %s/%s", testNamespace, componentName))
+			})
+		})
+
+		ginkgo.When("Run integration tests after Merged MR", func() {
+			ginkgo.It("should eventually complete successfully", func() {
+				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
+					fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
+			})
+
+			ginkgo.It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+				gomega.Expect(
+					forgejoGitClient.GetCommitStatusConclusion(integrationTestScenarioPass.Name, reportingRepository, mrSha, mrID),
+				).To(gomega.Equal(integrationPipelineRunCommitStatusSuccess))
+			})
+		})
+	})
+})

--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -566,8 +566,9 @@ func (a *Adapter) iterateIntegrationTestStatusDetailsInStatusReport(reporter sta
 		srs.SetLastUpdateTime(integrationTestStatusDetail.ScenarioName, destinationSnapshot.Name, integrationTestStatusDetail.LastUpdateTime)
 	}
 
-	// update integration test status comment for gitlab reporter when comment is not disabled
-	if reporter.GetReporterName() == status.GitLabProvider {
+	// update integration test status comment for gitlab and forgejo reporters when comment is not disabled
+	if reporter.GetReporterName() == status.GitLabProvider ||
+		reporter.GetReporterName() == status.ForgejoProvider {
 		loader := loader.NewLoader()
 		// get the destination snapshot's component to check if comment is disabled for all comments for pac repository or integration test
 		component, err := loader.GetComponentFromSnapshot(a.context, a.client, destinationSnapshot)

--- a/status/status.go
+++ b/status/status.go
@@ -729,9 +729,10 @@ func IterateIntegrationTestScenarioWithSameStatus(ctx context.Context, client cl
 		}
 	}
 
-	// if git provider is gitlab, and comment is neither disabled for component nor pac repository, it can extent to more git provider
-	// it delete existing comment and post one new comment with the latest test report summary of all ITS to gitlab merge request for each component
-	if reporter.GetReporterName() == GitLabProvider {
+	// if git provider is gitlab or forgejo, and comment is neither disabled for component nor pac repository,
+	// delete existing comment and post one new comment with the latest test report summary of all ITS to the merge/pull request for each component
+	if reporter.GetReporterName() == GitLabProvider ||
+		reporter.GetReporterName() == ForgejoProvider {
 		_, isMergeRequest := snapshot.GetAnnotations()[gitops.PipelineAsCodePullRequestAnnotation]
 		if isMergeRequest {
 			// get the destination snapshot's component to check if comment is disabled for all comments for pac repository or integration test


### PR DESCRIPTION
 Add e2e test suite for Integration Service status reporting to Forgejo (Codeberg) merge requests
covering the full happy path: build PipelineRun,
Snapshot creation, integration pipeline execution, commit status and MR comment reporting, MR merge, and push PipelineRun trigger

Also we identified a bug in integration-service , reported  [STONEINTG-1617](https://redhat.atlassian.net/browse/STONEINTG-1617)  fixed in  [2nd commit](https://github.com/konflux-ci/integration-service/pull/1544/changes/9610f7226bb10ca4531905c33f198378a1a8b969) 



for more info see [thread](https://redhat-internal.slack.com/archives/C07PZ0U12MA/p1777035196948009)
[STONEINTG-1429](https://redhat.atlassian.net/browse/STONEINTG-1429)

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


[STONEINTG-1429]: https://redhat.atlassian.net/browse/STONEINTG-1429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[STONEINTG-1617]: https://redhat.atlassian.net/browse/STONEINTG-1617?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ