### PR TITLE
fix(e2e): fix git reference in the e2e pipeline

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -137,11 +137,9 @@ spec:
         resolver: git
         params:
           - name: url
-            # TODO: change to "https://github.com/konflux-ci/integration-service" after merging PR #1532
-            value: https://github.com/lipka28/integration-service
+            value: https://github.com/konflux-ci/integration-service.git
           - name: revision
-            # TODO: change to "main" after merging PR #1532
-            value: test_migration
+            value: main
           - name: pathInRepo
             value: integration-tests/tasks/konflux-e2e-tests/0.1/konflux-e2e-tests.yaml
       params:


### PR DESCRIPTION
This is a follow-up for https://github.com/konflux-ci/integration-service/pull/1532. To correct the git repo and branch referenced in the e2e pipeline.

It needed to reference an existing repo/branch so the tests could run befor the PR is merged. Now that the PR is merged it can point directly to this repo.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
