### PR TITLE
chore(STONEINTG-1566): add extra buckets to measure response times

### DIFF
--- a/pkg/metrics/integration.go
+++ b/pkg/metrics/integration.go
@@ -31,7 +31,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "integration_svc_response_seconds",
 			Help:    "Integration service response time from the moment the buildPipelineRun is completed till the snapshot is marked as in progress status",
-			Buckets: []float64{0.5, 1, 2, 3, 4, 5, 6, 7, 10, 15, 30, 60, 120, 240},
+			Buckets: []float64{0.5, 1, 2, 3, 4, 5, 6, 7, 10, 15, 30, 60, 120, 240, 300, 450, 600, 750, 900, 1050, 1200},
 		},
 	)
 


### PR DESCRIPTION
in IntgSvceResponseSeconds

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
