### PR TITLE
feat(stoneintg-1350): add dependent snapshot creation logic

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -328,6 +328,12 @@ const (
 	GitCommentPolicyAnnotation = "test.appstudio.openshift.io/comment_strategy"
 	// GitCommentPolicyAllDisabled is the value to disable all test comments for the component got pac repository
 	GitCommentPolicyAllDisabled = "disable_all"
+
+	// ParentSnapshotAnnotation is the snapshot that created this snapshot from a ComponentGroup dependency chain
+	ParentSnapshotAnnotation = TestLabelPrefix + "/parent-snapshot"
+
+	// OriginSnapshotAnnotation is the snapshot that set off the chain of ComponentGroup dependent snapshot creation
+	OriginSnapshotAnnotation = TestLabelPrefix + "/origin-snapshot"
 )
 
 var (

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -219,7 +219,7 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 	}
 
 	for _, componentGroup := range *a.componentGroups {
-		expectedSnapshot, err := snapshot.PrepareSnapshotForPipelineRun(a.context, a.client, a.pipelineRun, a.component.Name, &componentGroup)
+		expectedSnapshot, err := snapshot.PrepareSnapshotForPipelineRun(a.context, a.client, a.pipelineRun, a.component.Name, &componentGroup, a.logger)
 		if err != nil {
 			return a.updatePipelineRunWithCustomizedError(&canRemoveFinalizer, err, a.context, a.pipelineRun, a.client, a.logger)
 		}

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -742,7 +742,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					},
 				},
 			})
-			_, err := snapshot.PrepareSnapshotForPipelineRun(adapter.context, adapter.client, adapter.pipelineRun, adapter.component.Name, hasCompGroup)
+			_, err := snapshot.PrepareSnapshotForPipelineRun(adapter.context, adapter.client, adapter.pipelineRun, adapter.component.Name, hasCompGroup, adapter.logger)
 			Expect(helpers.IsInvalidImageDigestError(err)).To(BeTrue())
 			Eventually(func() bool {
 				result, err := adapter.EnsureSnapshotExists()

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -98,6 +98,40 @@ func NewAdapter(context context.Context, snapshot *applicationapiv1alpha1.Snapsh
 	}
 }
 
+func (a *Adapter) EnsureDependentSnapshotsExist() (controller.OperationResult, error) {
+	// Get dependent ComponentGroups from a.componentGroup LOADER
+	dependents, loaderErrs := a.loader.GetDependentComponentGroups(a.context, a.client, a.componentGroup)
+	if len(loaderErrs) != 0 {
+		// if the only errors are IsNotFound errors then we don't want to requeue
+		// A user may have deleted a componentGroup and not removed it from another
+		// componentGroup's dependents list
+		var requeueableError error
+		for cg, err := range loaderErrs {
+			if clienterrors.IsNotFound(err) {
+				continue
+			}
+			requeueableError = errors.Join(requeueableError, fmt.Errorf("error getting componentGroup %s: %v", cg, err))
+		}
+
+		if requeueableError != nil {
+			return controller.RequeueWithError(requeueableError)
+		}
+	}
+
+	// Create snapshot from GCL for each ComponentGroup SNAPSHOT PACKAGE - should return componentGroupName:snapshot map
+	originSnapshot, ok := a.snapshot.GetAnnotations()[gitops.OriginSnapshotAnnotation]
+	if !ok {
+		originSnapshot = a.snapshot.Name
+	}
+	createdSnapshots, err := snapshot.CreateDependentComponentGroupSnapshots(a.context, a.client, dependents, a.snapshot.Name, originSnapshot, a.logger)
+	if err != nil {
+		a.logger.Error(err, "Ran into errors while creating dependent snapshots")
+	}
+	a.logger.Info("Created dependent snapshots for snapshot", "snapshot", a.snapshot.Name, "depedentSnapshots", createdSnapshots)
+
+	return controller.ContinueProcessing()
+}
+
 // EnsureRerunPipelineRunsExist is responsible for recreating integration test pipelineruns triggered by users
 func (a *Adapter) EnsureRerunPipelineRunsExist() (controller.OperationResult, error) {
 	runLabelValue, ok := gitops.GetIntegrationTestRunLabelValue(a.snapshot)

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -82,6 +82,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		testReleasePlan                           *releasev1alpha1.ReleasePlan
 		hasApp                                    *applicationapiv1alpha1.Application
 		hasCompGroup                              *v1beta2.ComponentGroup
+		dependentCompGroup                        *v1beta2.ComponentGroup
 		hasComp                                   *applicationapiv1alpha1.Component
 		hasCompMissingImageDigest                 *applicationapiv1alpha1.Component
 		hasCompWithValidImage                     *applicationapiv1alpha1.Component
@@ -157,6 +158,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 						},
 					},
 				},
+				Dependents: []string{"dependent-component-group"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, hasCompGroup)).Should(Succeed())
@@ -183,6 +185,25 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 		Expect(k8sClient.Status().Update(ctx, hasCompGroup)).Should(Succeed())
+
+		dependentCompGroup = &v1beta2.ComponentGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "dependent-component-group",
+				Namespace: "default",
+			},
+			Spec: v1beta2.ComponentGroupSpec{
+				Components: []v1beta2.ComponentReference{
+					v1beta2.ComponentReference{
+						Name: "component-sample",
+						ComponentVersion: v1beta2.ComponentVersionReference{
+							Name:     "v1",
+							Revision: "main",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dependentCompGroup)).Should(Succeed())
 
 		integrationTestScenario = &v1beta2.IntegrationTestScenario{
 			ObjectMeta: metav1.ObjectMeta{
@@ -3922,4 +3943,13 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		})
 	})
 
+	When("A snapshot with dependents is created", func() {
+		It("Should not return an error", func() {
+			adapter = NewAdapter(ctx, hasCGSnapshot, hasCompGroup, logger, loader.NewMockLoader(), k8sClient)
+			result, err := adapter.EnsureDependentSnapshotsExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).Should(Succeed())
+		})
+	})
 })

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -81,6 +81,7 @@ type ObjectLoader interface {
 	GetResolutionRequest(ctx context.Context, c client.Client, namespace, name string) (resolutionv1beta1.ResolutionRequest, error)
 	GetPRComponentSnapshotsForComponentApplication(ctx context.Context, c client.Client, namespace, applicationName, componentName, prNumber string) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetPRComponentSnapshotsForComponent(ctx context.Context, c client.Client, componentGroupNames []string, namespace, componentName, prNumber string) (*[]applicationapiv1alpha1.Snapshot, error)
+	GetDependentComponentGroups(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) ([]*v1beta2.ComponentGroup, map[string]error)
 }
 
 type loader struct{}
@@ -940,4 +941,20 @@ func (l *loader) GetPRComponentSnapshotsForComponentApplication(ctx context.Cont
 		return nil, err
 	}
 	return &snapshots.Items, nil
+}
+
+func (l *loader) GetDependentComponentGroups(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) (dependents []*v1beta2.ComponentGroup, errsForDependents map[string]error) {
+	errsForDependents = make(map[string]error)
+	dependentNames := componentGroup.Spec.Dependents
+
+	for _, name := range dependentNames {
+		// Get componentGroup
+		dependentCG, err := l.GetComponentGroup(ctx, c, name, componentGroup.Namespace)
+		if err != nil {
+			errsForDependents[name] = err
+			continue
+		}
+		dependents = append(dependents, dependentCG)
+	}
+	return
 }

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -412,3 +412,18 @@ func (l *mockLoader) GetPRComponentSnapshotsForComponentApplication(ctx context.
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPRComponentSnapshotsForComponentContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }
+
+func (l *mockLoader) GetDependentComponentGroups(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) (dependents []*v1beta2.ComponentGroup, errsForDependents map[string]error) {
+	if ctx.Value(ComponentGroupsContextKey) == nil {
+		return l.loader.GetDependentComponentGroups(ctx, c, componentGroup)
+	}
+	dependents, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ComponentGroupsContextKey, []*v1beta2.ComponentGroup{})
+	if err == nil {
+		return dependents, nil
+	}
+	name := "error"
+	if componentGroup != nil {
+		name = componentGroup.Name
+	}
+	return dependents, map[string]error{name: err}
+}

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -477,4 +477,19 @@ var _ = Describe("Release Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
+	Context("When calling GetDependentComponentGroups", func() {
+		It("returns resource and error from the context", func() {
+			dependents := []*v1beta2.ComponentGroup{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: ComponentGroupsContextKey,
+					Resource:   dependents,
+				},
+			})
+			resource, err := loader.GetDependentComponentGroups(mockContext, nil, nil)
+			Expect(resource).To(Equal(dependents))
+			Expect(err).To(BeNil())
+		})
+	})
 })

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -120,6 +120,7 @@ var _ = Describe("Loader", Ordered, func() {
 						},
 					},
 				},
+				Dependents: []string{hasComponentGroup1.Name, "nonexistent-componentgroup"},
 			},
 		}
 		Expect(k8sClient.Create(ctx, hasComponentGroup2)).Should(Succeed())
@@ -1329,5 +1330,15 @@ var _ = Describe("Loader", Ordered, func() {
 			Expect((*snapshots)[0].Namespace).To(Equal(hasSnapshot.Namespace))
 			Expect((*snapshots)[0].Spec).To(Equal(hasSnapshot.Spec))
 		})
+	})
+
+	It("Can get dependents for a componentGroup", func() {
+		dependents, errs := loader.GetDependentComponentGroups(ctx, k8sClient, hasComponentGroup2)
+
+		Expect(dependents).To(HaveLen(1))
+		Expect(dependents[0].Name).To(Equal(hasComponentGroup1.Name))
+
+		Expect(errs).To(HaveLen(1))
+		Expect(errs["nonexistent-componentgroup"].Error()).To(ContainSubstring("ComponentGroup.appstudio.redhat.com \"nonexistent-componentgroup\" not found"))
 	})
 })

--- a/snapshot/create.go
+++ b/snapshot/create.go
@@ -24,7 +24,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-logr/logr"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
@@ -36,15 +35,12 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // PrepareSnapshotForPipelineRun prepares the Snapshot for a given PipelineRun,
 // component and application. In case the Snapshot can't be created, an error will be returned.
-func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun, componentName string, componentGroup *v1beta2.ComponentGroup) (*applicationapiv1alpha1.Snapshot, error) {
-	log := log.FromContext(ctx)
-
-	newSnapshotComponent, err := getSnapshotComponentFromBuildPLR(pipelineRun, componentName, log)
+func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun, componentName string, componentGroup *v1beta2.ComponentGroup, logger helpers.IntegrationLogger) (*applicationapiv1alpha1.Snapshot, error) {
+	newSnapshotComponent, err := getSnapshotComponentFromBuildPLR(pipelineRun, componentName, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +50,7 @@ func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Cli
 		gitops.EnrichBuiltComponentSourceGitContext(&newSnapshotComponent.Source, &comp, newSnapshotComponent.Version)
 	}
 
-	snapshot, err := PrepareSnapshot(ctx, adapterClient, componentGroup, newSnapshotComponent, log)
+	snapshot, err := PrepareSnapshot(ctx, adapterClient, componentGroup, &newSnapshotComponent, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -98,6 +94,7 @@ func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Cli
 }
 
 // CreateSnapshotWithCollisionHandling attempts to create a snapshot, retrying with a random suffix if collision occurs
+// Uses pipelineRun.StartTime as a fallback for collision handling.  If pipelineRun is nil it will fallback on time.Now
 func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Client, pipelineRun *tektonv1.PipelineRun, snapshot *applicationapiv1alpha1.Snapshot, componentGroup v1beta2.ComponentGroup, logger helpers.IntegrationLogger) error {
 	originalName := snapshot.Name
 	maxRetries := 5
@@ -152,10 +149,13 @@ func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Clie
 
 // PrepareSnapshot prepares the Snapshot for a given componentGroup, components and the updated component (if any).
 // In case the Snapshot can't be created, an error will be returned.
-func PrepareSnapshot(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, newSnapshotComponent applicationapiv1alpha1.SnapshotComponent, log logr.Logger) (*applicationapiv1alpha1.Snapshot, error) {
+// If newSnapshotComponent is nil then PrepareSnapshot will return a snapshot whose components match the GCL
+func PrepareSnapshot(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, newSnapshotComponent *applicationapiv1alpha1.SnapshotComponent, logger helpers.IntegrationLogger) (*applicationapiv1alpha1.Snapshot, error) {
 
-	snapshotComponents, invalidComponents := getSnapshotComponentsFromGCL(componentGroup, log)
-	upsertNewComponentImage(&snapshotComponents, &invalidComponents, newSnapshotComponent, log)
+	snapshotComponents, invalidComponents := getSnapshotComponentsFromGCL(componentGroup, logger)
+	if newSnapshotComponent != nil {
+		upsertNewComponentImage(&snapshotComponents, &invalidComponents, *newSnapshotComponent, logger)
+	}
 
 	if len(snapshotComponents) == 0 {
 		return nil, helpers.NewMissingValidComponentError(joinInvalidComponentNamesAndVersions(invalidComponents))
@@ -163,7 +163,7 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, component
 	snapshot := NewSnapshot(componentGroup, &snapshotComponents)
 
 	// expose the source repo URL and SHA in the snapshot as annotation do we don't have to do lookup in integration tests
-	if newSnapshotComponent.Source.GitSource != nil {
+	if newSnapshotComponent != nil && newSnapshotComponent.Source.GitSource != nil {
 		if err := metadata.SetAnnotation(snapshot, gitops.SnapshotGitSourceRepoURLAnnotation, newSnapshotComponent.Source.GitSource.URL); err != nil {
 			return nil, fmt.Errorf("failed to set annotation %s: %w", gitops.SnapshotGitSourceRepoURLAnnotation, err)
 		}
@@ -185,7 +185,7 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, component
 }
 
 // This prevents race conditions if EnsureGCLAlignedWithSpecComponents runs late
-func getSnapshotComponentsFromGCL(componentGroup *v1beta2.ComponentGroup, log logr.Logger) ([]applicationapiv1alpha1.SnapshotComponent, []v1beta2.ComponentState) {
+func getSnapshotComponentsFromGCL(componentGroup *v1beta2.ComponentGroup, log helpers.IntegrationLogger) ([]applicationapiv1alpha1.SnapshotComponent, []v1beta2.ComponentState) {
 	var snapshotComponents []applicationapiv1alpha1.SnapshotComponent
 	var invalidComponents []v1beta2.ComponentState
 
@@ -245,7 +245,7 @@ func getSpecComponentsAndVersionsMap(componentGroup *v1beta2.ComponentGroup) map
 // Adds the updated Component to the list of snapshotComponents that will be added to the snapshot.  If a SnapshotComponent with
 // a matching name and version already exists in the snapshotComponents list then it will be replaced with the updated component.
 // Otherwise the updated component will be appended to the list.
-func upsertNewComponentImage(snapshotComponents *[]applicationapiv1alpha1.SnapshotComponent, invalidComponents *[]v1beta2.ComponentState, updatedComponent applicationapiv1alpha1.SnapshotComponent, log logr.Logger) {
+func upsertNewComponentImage(snapshotComponents *[]applicationapiv1alpha1.SnapshotComponent, invalidComponents *[]v1beta2.ComponentState, updatedComponent applicationapiv1alpha1.SnapshotComponent, log helpers.IntegrationLogger) {
 	for i, snapshotComponent := range *snapshotComponents {
 		if snapshotComponent.Name == updatedComponent.Name {
 			if snapshotComponent.Version == "" || snapshotComponent.Version == updatedComponent.Version {
@@ -320,7 +320,7 @@ func getComponentSourceFromGCLComponent(gclComponent v1beta2.ComponentState) app
 	return componentSource
 }
 
-func getSnapshotComponentFromBuildPLR(pipelineRun *tektonv1.PipelineRun, componentName string, log logr.Logger) (applicationapiv1alpha1.SnapshotComponent, error) {
+func getSnapshotComponentFromBuildPLR(pipelineRun *tektonv1.PipelineRun, componentName string, log helpers.IntegrationLogger) (applicationapiv1alpha1.SnapshotComponent, error) {
 	containerImage, err := tekton.GetImagePullSpecFromPipelineRun(pipelineRun)
 	if err != nil {
 		return applicationapiv1alpha1.SnapshotComponent{}, err
@@ -345,4 +345,36 @@ func getSnapshotComponentFromBuildPLR(pipelineRun *tektonv1.PipelineRun, compone
 		ContainerImage: containerImage,
 		Source:         *componentSource,
 	}, nil
+}
+
+func CreateDependentComponentGroupSnapshots(ctx context.Context, adapterClient client.Client, dependents []*v1beta2.ComponentGroup, parentSnapshot, originSnapshot string, logger helpers.IntegrationLogger) (createdSnapshots map[string]string, errorsForDependents error) {
+	createdSnapshots = make(map[string]string)
+	for _, dependent := range dependents {
+		snapshot, err := PrepareSnapshot(ctx, adapterClient, dependent, nil, logger)
+		if err != nil {
+			logger.Error(err, "Error preparing dependent snapshot for parent", "snapshot.Name", dependent.Name, "parentSnapshot.Name", parentSnapshot)
+			errorsForDependents = errors.Join(errorsForDependents, fmt.Errorf("error preparing dependent snapshot '%s' for parent '%s': %+v", dependent.Name, parentSnapshot, err))
+			continue
+		}
+
+		// NOTE: do we want to copy labels and annotations from parent snapshot?
+		// If so, do we want to include the build labels and annotations?
+		if err = metadata.SetAnnotation(snapshot, gitops.ParentSnapshotAnnotation, parentSnapshot); err != nil {
+			logger.Error(err, "Could not set parent snapshot annotation on snapshot", "snapshot.Name", snapshot.Name, "value", parentSnapshot)
+		}
+		if err = metadata.SetAnnotation(snapshot, gitops.OriginSnapshotAnnotation, originSnapshot); err != nil {
+			logger.Error(err, "Could not set origin snapshot annotation on snapshot", "snapshot.Name", snapshot.Name, "value", originSnapshot)
+		}
+
+		err = CreateSnapshotWithCollisionHandling(ctx, adapterClient, nil, snapshot, *dependent, logger)
+		if err != nil {
+			logger.Error(err, "Error creating dependent snapshot for parent", "snapshot.Name", dependent.Name, "parentSnapshot.Name", parentSnapshot)
+			errorsForDependents = errors.Join(errorsForDependents, fmt.Errorf("error creating dependent snapshot '%s' for parent '%s': %+v", dependent.Name, parentSnapshot, err))
+			continue
+		}
+
+		// add snapshot name to createdSnapshots[componentGroupName]
+		createdSnapshots[dependent.Name] = snapshot.Name
+	}
+	return
 }

--- a/snapshot/create_test.go
+++ b/snapshot/create_test.go
@@ -23,7 +23,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/go-logr/logr"
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
@@ -49,7 +48,8 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		hasCompGroup      *v1beta2.ComponentGroup
 		hasAppSample      *applicationapiv1alpha1.Application
 		hasCompSample     *applicationapiv1alpha1.Component
-		logger            logr.Logger
+		//logger            logr.Logger
+		logger helpers.IntegrationLogger
 	)
 	const (
 		SampleRepoLink           = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
@@ -278,7 +278,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		}
 		Expect(k8sClient.Status().Update(ctx, successfulTaskRun)).Should(Succeed())
 
-		logger = log.FromContext(ctx)
+		logger = helpers.IntegrationLogger{Logger: log.FromContext(ctx)}
 	})
 
 	AfterAll(func() {
@@ -294,7 +294,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 	Context("Testing PrepareSnapshotForPipelineRun()", func() {
 		It("ensures built component includes git context from Component CR", func() {
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 			var built *applicationapiv1alpha1.SnapshotComponent
@@ -310,7 +310,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures that snapshot has label pointing to build pipelinerun", func() {
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 
@@ -339,7 +339,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			buildPipelineRunNoStartTime := buildPipelineRun.DeepCopy()
 			buildPipelineRunNoStartTime.Status.StartTime = nil
 
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRunNoStartTime, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRunNoStartTime, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 
@@ -360,7 +360,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures that Labels and Annotations were copied to snapshot from pipelinerun", func() {
-			copyToSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			copyToSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(copyToSnapshot).NotTo(BeNil())
 
@@ -383,7 +383,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			mergeQueueBuildPipelineRun.Labels[tektonconsts.PipelineAsCodePullRequestLabel] = ""
 			mergeQueueBuildPipelineRun.Annotations[tektonconsts.PipelineAsCodePullRequestLabel] = ""
 			mergeQueueBuildPipelineRun.Name = buildPipelineRun.Name + "-merge"
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, mergeQueueBuildPipelineRun, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, mergeQueueBuildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 
@@ -430,7 +430,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 			messageError := "Missing info IMAGE_DIGEST from pipelinerun pipelinerun-build-sample"
 			var info map[string]string
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRunNoSource, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRunNoSource, componentName, hasCompGroup, logger)
 			Expect(expectedSnapshot).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			err = tekton.AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(ctx, buildPipelineRun, k8sClient, err)
@@ -443,7 +443,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures pipelines as code labels and annotations are propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 			annotation, found := snapshot.GetAnnotations()["pac.test.appstudio.openshift.io/on-target-branch"]
@@ -455,7 +455,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures non-pipelines as code labels and annotations are NOT propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -473,7 +473,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures build labels and annotations prefixed with 'build.appstudio' are propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -487,7 +487,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures build labels and annotations non-prefixed with 'build.appstudio' are NOT propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -506,7 +506,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 		It("ensures integration workflow annotation is set to 'pull-request' for pr events", func() {
 			// default buildPipelineRun already has event-type set to pull_request
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -522,7 +522,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			pushPipelineRun.Labels["pipelinesascode.tekton.dev/event-type"] = "push"
 			delete(pushPipelineRun.Labels, "pipelinesascode.tekton.dev/pull-request")
 
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, pushPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, pushPipelineRun, componentName, hasCompGroup, logger)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -536,7 +536,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 	Context("testing creation of snapshotComponentsList", func() {
 		It("Ensures valid and invalid snapshotComponents can be gathered from the GCL", func() {
 			var buf bytes.Buffer
-			readableLog := buflogr.NewWithBuffer(&buf)
+			readableLog := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 			snapshotComponents, invalidComponents := getSnapshotComponentsFromGCL(hasCompGroup, readableLog)
 
 			Expect(snapshotComponents).To(HaveLen(1))
@@ -614,12 +614,21 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			newSnapshotComponent, err := getSnapshotComponentFromBuildPLR(buildPipelineRun, componentName, logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			snapshot, err := PrepareSnapshot(ctx, k8sClient, hasCompGroup, newSnapshotComponent, logger)
+			snapshot, err := PrepareSnapshot(ctx, k8sClient, hasCompGroup, &newSnapshotComponent, logger)
 			Expect(snapshot).NotTo(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field or missing valid digest")
 			Expect(snapshot.Spec.Components[0].Name).To(Equal(componentName), "The built component should have been added to the snapshot")
 			Expect(snapshot.Annotations[helpers.CreateSnapshotAnnotationName]).To(Equal("Component(s) 'another-component-sample (version v1)' is(are) not included in snapshot due to missing valid containerImage or git source"))
+		})
+	})
+
+	Context("Testing CreateDependentComponentGroupSnapshots()", func() {
+		It("Can create dependent snapshots for a componentGroup with dependents", func() {
+			createdSnapshots, errorsForDependents := CreateDependentComponentGroupSnapshots(ctx, k8sClient, []*v1beta2.ComponentGroup{hasCompGroup}, "parent-snapshot-sample", "origin-snapshot-sample", logger)
+			Expect(createdSnapshots).To(HaveLen(1))
+			Expect(createdSnapshots[hasCompGroup.Name]).To(HavePrefix("component-group-sample-"))
+			Expect(errorsForDependents).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/snapshot/utils.go
+++ b/snapshot/utils.go
@@ -63,7 +63,7 @@ func snapshotComponentToComponentState(snapshotComponent applicationapiv1alpha1.
 }
 
 func getPipelineRunStartTimeMillis(pipelineRun *tektonv1.PipelineRun) int64 {
-	if pipelineRun.Status.StartTime != nil {
+	if pipelineRun != nil && pipelineRun.Status.StartTime != nil {
 		return pipelineRun.Status.StartTime.UnixMilli()
 	}
 	return time.Now().UnixMilli()


### PR DESCRIPTION
The ComponentGroup CR contains a spec.dependents field which contains a list of ComponentGroups that are dependent on the parent. When a snapshot for the parent is created, the code in this change gets a list of dependents and creates a snapshot for each of them based on the GCL.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
