### PR TITLE
fix: register spec.application index for ReleasePlan in snapshot controller

### DIFF
--- a/internal/controller/snapshot/snapshot_controller.go
+++ b/internal/controller/snapshot/snapshot_controller.go
@@ -207,6 +207,10 @@ func setupCache(mgr ctrl.Manager) error {
 	if err := cache.SetupReleasePlanCache(mgr); err != nil {
 		return err
 	}
+	// TODO: remove when we remove old application model
+	if err := cache.SetupReleasePlanCacheApplication(mgr); err != nil {
+		return err
+	}
 
 	return cache.SetupReleaseCache(mgr)
 }


### PR DESCRIPTION
## Summary
The snapshot controller's setupCache was missing the spec.application
field index for ReleasePlan, so any tenant still on the Application
(non-ComponentGroup) model couldn't progress past Snapshot creation:

    Index with name field:spec.application does not exist

The integrationpipeline controller already registers the matching
*Application variant; this brings the snapshot controller in line.

Introduced by ec4a2741 (#1409).

## Test plan
- [x] `make test` passes
- [x] Manual on CRC: build PR for an Application-model tenant, signed
  with `chains.tekton.dev/signed=true`, observed Snapshot -> Release ->
  release PipelineRun all reach Succeeded; `Index ... does not exist`
  no longer appears in the controller log.