### PR TITLE
fix(STONEINTG-1586): allow tekton bundles via admission webhook

### DIFF
--- a/internal/webhook/v1beta2/integrationtestscenario_webhook.go
+++ b/internal/webhook/v1beta2/integrationtestscenario_webhook.go
@@ -104,10 +104,14 @@ func (v *IntegrationTestScenarioCustomValidator) ValidateCreate(ctx context.Cont
 			integrationtestscenariolog.Info(errString)
 			return nil, field.Invalid(field.NewPath("Spec").Child("Params"), param.Name, errString)
 		}
-		// we won't enable ITS if git resolver with url & repo+org
+	}
+
+	// we won't enable ITS if git resolver with url & repo+org
+	if scenario.Spec.ResolverRef.Resolver == "git" {
 		urlResolverExist := false
 		repoResolverExist := false
 		orgResolverExist := false
+		var paramErrors error
 
 		for _, gitResolverParam := range scenario.Spec.ResolverRef.Params {
 			if gitResolverParam.Name == "url" && gitResolverParam.Value != "" {
@@ -119,44 +123,37 @@ func (v *IntegrationTestScenarioCustomValidator) ValidateCreate(ctx context.Cont
 			if gitResolverParam.Name == "org" && gitResolverParam.Value != "" {
 				orgResolverExist = true
 			}
+
+			switch key := gitResolverParam.Name; key {
+			case "url", "serverURL":
+				paramErrors = errors.Join(paramErrors, validateUrl(key, gitResolverParam.Value))
+			case "token":
+				paramErrors = errors.Join(paramErrors, validateToken(gitResolverParam.Value))
+			default:
+				paramErrors = errors.Join(paramErrors, validateNoWhitespace(key, gitResolverParam.Value))
+			}
 		}
 
 		if urlResolverExist {
 			if repoResolverExist || orgResolverExist {
-				return nil, field.Invalid(field.NewPath("Spec").Child("ResolverRef").Child("Params"), param.Name,
+				return nil, field.Invalid(field.NewPath("Spec").Child("ResolverRef").Child("Params"), scenario.Spec.ResolverRef.Params,
 					"an IntegrationTestScenario resource can only have one of the gitResolver parameters,"+
 						"either url or repo (with org), but not both.")
-
 			}
 		} else {
 			if !repoResolverExist || !orgResolverExist {
-				return nil, field.Invalid(field.NewPath("Spec").Child("ResolverRef").Child("Params"), param.Name,
+				return nil, field.Invalid(field.NewPath("Spec").Child("ResolverRef").Child("Params"), scenario.Spec.ResolverRef.Params,
 					"IntegrationTestScenario is invalid: missing mandatory repo or org parameters."+
 						"If both are absent, a valid url is highly recommended.")
-
 			}
 		}
 
-	}
-
-	integrationtestscenariolog.Info("Validated params")
-
-	if scenario.Spec.ResolverRef.Resolver == "git" {
-		var paramErrors error
-		for _, param := range scenario.Spec.ResolverRef.Params {
-			switch key := param.Name; key {
-			case "url", "serverURL":
-				paramErrors = errors.Join(paramErrors, validateUrl(key, param.Value))
-			case "token":
-				paramErrors = errors.Join(paramErrors, validateToken(param.Value))
-			default:
-				paramErrors = errors.Join(paramErrors, validateNoWhitespace(key, param.Value))
-			}
-		}
 		if paramErrors != nil {
 			return nil, paramErrors
 		}
 	}
+
+	integrationtestscenariolog.Info("Validated params")
 
 	// Ensure the ownerReference was set by the mutating webhook
 	if ref := scenario.GetOwnerReferences(); len(ref) == 0 {

--- a/internal/webhook/v1beta2/integrationtestscenario_webhook_test.go
+++ b/internal/webhook/v1beta2/integrationtestscenario_webhook_test.go
@@ -223,6 +223,84 @@ var _ = Describe("IntegrationTestScenario webhook", Ordered, func() {
 		}, time.Second*10).Should(Succeed())
 	})
 
+	It("should succeed to create scenario with bundle resolver and pipeline params", func() {
+		bundleScenario := &v1beta2.IntegrationTestScenario{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "appstudio.redhat.com/v1beta2",
+				Kind:       "IntegrationTestScenario",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bundle-scenario",
+				Namespace: "default",
+			},
+			Spec: v1beta2.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				Params: []v1beta2.PipelineParameter{
+					{
+						Name:  "POLICY_CONFIGURATION",
+						Value: "some-policy",
+					},
+				},
+				ResolverRef: v1beta2.ResolverRef{
+					Resolver: "bundles",
+					Params: []v1beta2.ResolverParameter{
+						{
+							Name:  "bundle",
+							Value: "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass",
+						},
+						{
+							Name:  "name",
+							Value: "integration-pipeline-pass",
+						},
+						{
+							Name:  "kind",
+							Value: "pipeline",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bundleScenario)).Should(Succeed())
+		err := k8sClient.Delete(ctx, bundleScenario)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
+	It("should succeed to create scenario with bundle resolver and no pipeline params", func() {
+		bundleScenario := &v1beta2.IntegrationTestScenario{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "appstudio.redhat.com/v1beta2",
+				Kind:       "IntegrationTestScenario",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bundle-scenario-no-params",
+				Namespace: "default",
+			},
+			Spec: v1beta2.IntegrationTestScenarioSpec{
+				Application: "application-sample",
+				ResolverRef: v1beta2.ResolverRef{
+					Resolver: "bundles",
+					Params: []v1beta2.ResolverParameter{
+						{
+							Name:  "bundle",
+							Value: "quay.io/redhat-appstudio/example-tekton-bundle:integration-pipeline-pass",
+						},
+						{
+							Name:  "name",
+							Value: "integration-pipeline-pass",
+						},
+						{
+							Name:  "kind",
+							Value: "pipeline",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, bundleScenario)).Should(Succeed())
+		err := k8sClient.Delete(ctx, bundleScenario)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
+
 	It("should fail to create scenario when in git resolver params url+repo", func() {
 
 		integrationTestScenarioInvalidGitResolver.Spec.ResolverRef.Params = append(integrationTestScenarioInvalidGitResolver.Spec.ResolverRef.Params, v1beta2.ResolverParameter{Name: "repo", Value: "my-repository-name"})


### PR DESCRIPTION
The admission webhook for IntegrationTestScenario rejected bundle resolver configurations because the url/repo/org param validation assumed all resolvers are git resolvers.
Also fixes a bug where validation was nested inside the pipeline params loop which would be silently skipped when no pipeline params were present.
