### PR TITLE
fix(STONEINTG-1591): Bug fix for release not created…

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -771,6 +771,7 @@ func CanSnapshotBePromoted(snapshot *applicationapiv1alpha1.Snapshot) (bool, []s
 			reasons = append(reasons, "the Snapshot was created for a PaC pull request event")
 		}
 		if IsSnapshotAutoReleaseDisabled(snapshot) {
+			canBePromoted = false
 			reasons = append(reasons, fmt.Sprintf("the Snapshot '%s' label is 'false'", AutoReleaseLabel))
 		}
 		if IsGroupSnapshot(snapshot) {

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -733,6 +733,20 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 		Expect(reasons).To(BeEmpty())
 	})
 
+	It("ensures CanSnapshotBePromoted returns false when auto-release label is 'false', even if tests pass", func() {
+		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
+		Expect(err).ToNot(HaveOccurred())
+
+		err = gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasSnapshot, "Test message")
+		Expect(err).ToNot(HaveOccurred())
+
+		hasSnapshot.Labels[gitops.AutoReleaseLabel] = "false"
+		canBePromoted, reasons := gitops.CanSnapshotBePromoted(hasSnapshot)
+		Expect(canBePromoted).To(BeFalse())
+		Expect(reasons).To(HaveLen(1))
+		Expect(reasons[0]).To(ContainSubstring(gitops.AutoReleaseLabel))
+	})
+
 	It("ensures the a decision can be made to NOT promote the Snapshot based on its status", func() {
 		err := gitops.MarkSnapshotIntegrationStatusAsFinished(ctx, k8sClient, hasSnapshot, "Test message")
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
despite autorelease enabled

The IsSnapshotAutoReleaseDisabled check was appending to reasons but
never setting canBePromoted=false, causing Snapshots with the
auto-release: "false" label to be released anyway.

Assisted-by: Cursor AI

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
