### PR TITLE
feat: add snapshot options struct

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -108,7 +108,7 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 	if a.application != nil {
 		err = a.updateGCLForBuildPLR()
 	} else { // ComponentGroup behavior
-		err = snapshot.UpdateGCLForBuildPLR(a.context, a.client, a.loader, a.componentGroups, a.pipelineRun, a.component.Name)
+		err = snapshot.UpdateGCLForBuildPLR(a.componentGroups, a.pipelineRun, a.component.Name, snapshot.NewSnapshotOpts(a.context, a.client, a.logger, a.loader))
 	}
 	if err != nil {
 		// TODO: remove HandleLoaderError when we remove application-specific code
@@ -219,13 +219,14 @@ func (a *Adapter) EnsureSnapshotExists() (result controller.OperationResult, err
 	}
 
 	for _, componentGroup := range *a.componentGroups {
-		expectedSnapshot, err := snapshot.PrepareSnapshotForPipelineRun(a.context, a.client, a.pipelineRun, a.component.Name, &componentGroup)
+		snapshotOpts := snapshot.NewSnapshotOpts(a.context, a.client, a.logger, a.loader)
+		expectedSnapshot, err := snapshot.PrepareSnapshotForPipelineRun(a.pipelineRun, a.component.Name, &componentGroup, snapshotOpts)
 		if err != nil {
 			return a.updatePipelineRunWithCustomizedError(&canRemoveFinalizer, err, a.context, a.pipelineRun, a.client, a.logger)
 		}
 
 		// Try to create snapshot, retry with suffix on collision
-		err = snapshot.CreateSnapshotWithCollisionHandling(a.context, a.client, a.pipelineRun, expectedSnapshot, componentGroup, a.logger)
+		err = snapshot.CreateSnapshotWithCollisionHandling(a.pipelineRun, expectedSnapshot, componentGroup, snapshotOpts)
 		if err != nil {
 			result, err = a.handleSnapshotCreationFailure(&canRemoveFinalizer, err)
 			return result, err

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -742,7 +742,7 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 					},
 				},
 			})
-			_, err := snapshot.PrepareSnapshotForPipelineRun(adapter.context, adapter.client, adapter.pipelineRun, adapter.component.Name, hasCompGroup)
+			_, err := snapshot.PrepareSnapshotForPipelineRun(adapter.pipelineRun, adapter.component.Name, hasCompGroup, snapshot.NewSnapshotOpts(adapter.context, adapter.client, adapter.logger, adapter.loader))
 			Expect(helpers.IsInvalidImageDigestError(err)).To(BeTrue())
 			Eventually(func() bool {
 				result, err := adapter.EnsureSnapshotExists()

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -491,7 +491,7 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 	if a.application != nil {
 		err = a.updateGCLForOverrideSnapshot()
 	} else {
-		err = snapshot.UpdateGCLForOverrideSnapshot(a.context, a.client, a.loader, a.componentGroup, a.snapshot, a.logger)
+		err = snapshot.UpdateGCLForOverrideSnapshot(a.componentGroup, a.snapshot, snapshot.NewSnapshotOpts(a.context, a.client, a.logger, a.loader))
 	}
 	if err != nil {
 		return controller.RequeueWithError(err)
@@ -687,7 +687,7 @@ func (a *Adapter) EnsureOverrideSnapshotValid() (controller.OperationResult, err
 	if a.application != nil {
 		errsForSnapshot = a.validateOverrideSnapshotComponents()
 	} else {
-		errsForSnapshot = snapshot.ValidateOverrideSnapshotComponents(a.context, a.snapshot, a.componentGroup)
+		errsForSnapshot = snapshot.ValidateOverrideSnapshotComponents(a.snapshot, a.componentGroup, snapshot.NewSnapshotOpts(a.context, a.client, a.logger, a.loader))
 	}
 
 	if errsForSnapshot != nil {

--- a/snapshot/create.go
+++ b/snapshot/create.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapshot
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -36,25 +35,22 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // PrepareSnapshotForPipelineRun prepares the Snapshot for a given PipelineRun,
 // component and application. In case the Snapshot can't be created, an error will be returned.
-func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun, componentName string, componentGroup *v1beta2.ComponentGroup) (*applicationapiv1alpha1.Snapshot, error) {
-	log := log.FromContext(ctx)
-
-	newSnapshotComponent, err := getSnapshotComponentFromBuildPLR(pipelineRun, componentName, log)
+func PrepareSnapshotForPipelineRun(pipelineRun *tektonv1.PipelineRun, componentName string, componentGroup *v1beta2.ComponentGroup, opts SnapshotOpts) (*applicationapiv1alpha1.Snapshot, error) {
+	newSnapshotComponent, err := getSnapshotComponentFromBuildPLR(pipelineRun, componentName, opts.logger.Logger)
 	if err != nil {
 		return nil, err
 	}
 
 	var comp applicationapiv1alpha1.Component
-	if err := adapterClient.Get(ctx, client.ObjectKey{Namespace: componentGroup.Namespace, Name: componentName}, &comp); err == nil {
+	if err := opts.client.Get(opts.ctx, client.ObjectKey{Namespace: componentGroup.Namespace, Name: componentName}, &comp); err == nil {
 		gitops.EnrichBuiltComponentSourceGitContext(&newSnapshotComponent.Source, &comp, newSnapshotComponent.Version)
 	}
 
-	snapshot, err := PrepareSnapshot(ctx, adapterClient, componentGroup, newSnapshotComponent, log)
+	snapshot, err := PrepareSnapshot(componentGroup, newSnapshotComponent, opts)
 	if err != nil {
 		return nil, err
 	}
@@ -98,16 +94,16 @@ func PrepareSnapshotForPipelineRun(ctx context.Context, adapterClient client.Cli
 }
 
 // CreateSnapshotWithCollisionHandling attempts to create a snapshot, retrying with a random suffix if collision occurs
-func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Client, pipelineRun *tektonv1.PipelineRun, snapshot *applicationapiv1alpha1.Snapshot, componentGroup v1beta2.ComponentGroup, logger helpers.IntegrationLogger) error {
+func CreateSnapshotWithCollisionHandling(pipelineRun *tektonv1.PipelineRun, snapshot *applicationapiv1alpha1.Snapshot, componentGroup v1beta2.ComponentGroup, opts SnapshotOpts) error {
 	originalName := snapshot.Name
 	maxRetries := 5
 
 	for attempt := 0; attempt < maxRetries; attempt++ {
-		err := client.Create(ctx, snapshot)
+		err := opts.client.Create(opts.ctx, snapshot)
 		if err == nil {
 			// Success
 			if attempt > 0 {
-				logger.Info("Successfully created snapshot after collision retry",
+				opts.logger.Info("Successfully created snapshot after collision retry",
 					"originalName", originalName,
 					"finalName", snapshot.Name,
 					"attempts", attempt+1)
@@ -125,7 +121,7 @@ func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Clie
 		if attempt < maxRetries-1 {
 			suffix, suffixErr := generateRandomSuffix()
 			if suffixErr != nil {
-				logger.Error(suffixErr, "Failed to generate random suffix for snapshot name collision")
+				opts.logger.Error(suffixErr, "Failed to generate random suffix for snapshot name collision")
 				return err // Return original collision error
 			}
 
@@ -133,14 +129,14 @@ func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Clie
 
 			// Regenerate name with suffix
 			snapshot.Name = gitops.GenerateSnapshotNameWithTimestamp(componentGroup.Name, timestampMillis, suffix)
-			logger.Info("Snapshot name collision detected, retrying with suffix",
+			opts.logger.Info("Snapshot name collision detected, retrying with suffix",
 				"originalName", originalName,
 				"newName", snapshot.Name,
 				"attempt", attempt+1,
 				"maxRetries", maxRetries)
 		} else {
 			// Max retries reached
-			logger.Error(err, "Failed to create snapshot after max retries due to collisions",
+			opts.logger.Error(err, "Failed to create snapshot after max retries due to collisions",
 				"originalName", originalName,
 				"attempts", maxRetries)
 			return err
@@ -152,7 +148,8 @@ func CreateSnapshotWithCollisionHandling(ctx context.Context, client client.Clie
 
 // PrepareSnapshot prepares the Snapshot for a given componentGroup, components and the updated component (if any).
 // In case the Snapshot can't be created, an error will be returned.
-func PrepareSnapshot(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, newSnapshotComponent applicationapiv1alpha1.SnapshotComponent, log logr.Logger) (*applicationapiv1alpha1.Snapshot, error) {
+func PrepareSnapshot(componentGroup *v1beta2.ComponentGroup, newSnapshotComponent applicationapiv1alpha1.SnapshotComponent, opts SnapshotOpts) (*applicationapiv1alpha1.Snapshot, error) {
+	log := opts.logger.Logger
 
 	snapshotComponents, invalidComponents := getSnapshotComponentsFromGCL(componentGroup, log)
 	upsertNewComponentImage(&snapshotComponents, &invalidComponents, newSnapshotComponent, log)
@@ -176,7 +173,7 @@ func PrepareSnapshot(ctx context.Context, adapterClient client.Client, component
 		}
 	}
 
-	err := ctrl.SetControllerReference(componentGroup, snapshot, adapterClient.Scheme())
+	err := ctrl.SetControllerReference(componentGroup, snapshot, opts.client.Scheme())
 	if err != nil {
 		return nil, err
 	}

--- a/snapshot/create_test.go
+++ b/snapshot/create_test.go
@@ -50,6 +50,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		hasAppSample      *applicationapiv1alpha1.Application
 		hasCompSample     *applicationapiv1alpha1.Component
 		logger            logr.Logger
+		opts              SnapshotOpts
 	)
 	const (
 		SampleRepoLink           = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
@@ -279,6 +280,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		Expect(k8sClient.Status().Update(ctx, successfulTaskRun)).Should(Succeed())
 
 		logger = log.FromContext(ctx)
+		opts = NewSnapshotOpts(ctx, k8sClient, helpers.IntegrationLogger{Logger: logger}, nil)
 	})
 
 	AfterAll(func() {
@@ -294,7 +296,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 	Context("Testing PrepareSnapshotForPipelineRun()", func() {
 		It("ensures built component includes git context from Component CR", func() {
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 			var built *applicationapiv1alpha1.SnapshotComponent
@@ -310,7 +312,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures that snapshot has label pointing to build pipelinerun", func() {
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 
@@ -339,7 +341,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			buildPipelineRunNoStartTime := buildPipelineRun.DeepCopy()
 			buildPipelineRunNoStartTime.Status.StartTime = nil
 
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRunNoStartTime, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRunNoStartTime, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 
@@ -360,7 +362,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures that Labels and Annotations were copied to snapshot from pipelinerun", func() {
-			copyToSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			copyToSnapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(copyToSnapshot).NotTo(BeNil())
 
@@ -383,7 +385,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			mergeQueueBuildPipelineRun.Labels[tektonconsts.PipelineAsCodePullRequestLabel] = ""
 			mergeQueueBuildPipelineRun.Annotations[tektonconsts.PipelineAsCodePullRequestLabel] = ""
 			mergeQueueBuildPipelineRun.Name = buildPipelineRun.Name + "-merge"
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, mergeQueueBuildPipelineRun, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(mergeQueueBuildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(expectedSnapshot).NotTo(BeNil())
 
@@ -430,7 +432,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 			messageError := "Missing info IMAGE_DIGEST from pipelinerun pipelinerun-build-sample"
 			var info map[string]string
-			expectedSnapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRunNoSource, componentName, hasCompGroup)
+			expectedSnapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRunNoSource, componentName, hasCompGroup, opts)
 			Expect(expectedSnapshot).To(BeNil())
 			Expect(err).To(HaveOccurred())
 			err = tekton.AnnotateBuildPipelineRunWithCreateSnapshotAnnotation(ctx, buildPipelineRun, k8sClient, err)
@@ -443,7 +445,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures pipelines as code labels and annotations are propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 			annotation, found := snapshot.GetAnnotations()["pac.test.appstudio.openshift.io/on-target-branch"]
@@ -455,7 +457,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures non-pipelines as code labels and annotations are NOT propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -473,7 +475,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures build labels and annotations prefixed with 'build.appstudio' are propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -487,7 +489,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 		})
 
 		It("ensures build labels and annotations non-prefixed with 'build.appstudio' are NOT propagated to the snapshot", func() {
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -506,7 +508,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 
 		It("ensures integration workflow annotation is set to 'pull-request' for pr events", func() {
 			// default buildPipelineRun already has event-type set to pull_request
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, buildPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(buildPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -522,7 +524,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			pushPipelineRun.Labels["pipelinesascode.tekton.dev/event-type"] = "push"
 			delete(pushPipelineRun.Labels, "pipelinesascode.tekton.dev/pull-request")
 
-			snapshot, err := PrepareSnapshotForPipelineRun(ctx, k8sClient, pushPipelineRun, componentName, hasCompGroup)
+			snapshot, err := PrepareSnapshotForPipelineRun(pushPipelineRun, componentName, hasCompGroup, opts)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot).ToNot(BeNil())
 
@@ -614,7 +616,7 @@ var _ = Describe("Snapshot creation functions", Ordered, func() {
 			newSnapshotComponent, err := getSnapshotComponentFromBuildPLR(buildPipelineRun, componentName, logger)
 			Expect(err).NotTo(HaveOccurred())
 
-			snapshot, err := PrepareSnapshot(ctx, k8sClient, hasCompGroup, newSnapshotComponent, logger)
+			snapshot, err := PrepareSnapshot(hasCompGroup, newSnapshotComponent, opts)
 			Expect(snapshot).NotTo(BeNil())
 			Expect(err).ToNot(HaveOccurred())
 			Expect(snapshot.Spec.Components).To(HaveLen(1), "One component should have been added to snapshot.  Other component should have been omited due to empty ContainerImage field or missing valid digest")

--- a/snapshot/gcl.go
+++ b/snapshot/gcl.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapshot
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"slices"
@@ -25,16 +24,14 @@ import (
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/helpers"
-	"github.com/konflux-ci/integration-service/loader"
 	"github.com/konflux-ci/integration-service/tekton"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-// updateGCLForBuildPLR updates global candidate list for component snapshots
-func UpdateGCLForBuildPLR(ctx context.Context, client client.Client, objectLoader loader.ObjectLoader, componentGroups *[]v1beta2.ComponentGroup, pipelineRun *tektonv1.PipelineRun, componentName string) error {
+// UpdateGCLForBuildPLR updates global candidate list for component snapshots
+func UpdateGCLForBuildPLR(componentGroups *[]v1beta2.ComponentGroup, pipelineRun *tektonv1.PipelineRun, componentName string, opts SnapshotOpts) error {
 	containerImage, err := tekton.GetImagePullSpecFromPipelineRun(pipelineRun)
 	if err != nil {
 		return nil
@@ -63,11 +60,11 @@ func UpdateGCLForBuildPLR(ctx context.Context, client client.Client, objectLoade
 
 	for _, componentGroup := range *componentGroups {
 		retryError := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-			cg, err := objectLoader.GetComponentGroup(ctx, client, componentGroup.Name, componentGroup.Namespace)
+			cg, err := opts.loader.GetComponentGroup(opts.ctx, opts.client, componentGroup.Name, componentGroup.Namespace)
 			if err != nil {
 				return err
 			}
-			err = UpdateGCLEntry(ctx, client, cg, entry)
+			err = UpdateGCLEntry(cg, entry, opts)
 			return err
 		})
 		err = errors.Join(err, retryError)
@@ -75,9 +72,9 @@ func UpdateGCLForBuildPLR(ctx context.Context, client client.Client, objectLoade
 	return err
 }
 
-// Updates a single GCL entry for a given componentGroup
-func UpdateGCLEntry(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, newEntry v1beta2.ComponentState) error {
-	log := log.FromContext(ctx)
+// UpdateGCLEntry updates a single GCL entry for a given componentGroup
+func UpdateGCLEntry(componentGroup *v1beta2.ComponentGroup, newEntry v1beta2.ComponentState, opts SnapshotOpts) error {
+	log := opts.logger.Logger
 	patch := client.MergeFromWithOptions(componentGroup.DeepCopy(), client.MergeFromWithOptimisticLock{})
 
 	// TODO: add mutating webhook for ComponentGroups that adds blank GCL item when component is added to components list and removes existing GCL entry when component is removed from components list
@@ -105,7 +102,7 @@ func UpdateGCLEntry(ctx context.Context, adapterClient client.Client, componentG
 	}
 
 	// TODO: support optimistic locking
-	err := adapterClient.Status().Patch(ctx, componentGroup, patch)
+	err := opts.client.Status().Patch(opts.ctx, componentGroup, patch)
 	if err != nil {
 		log.Error(err, "Failed to updated GCL entry for ComponentVersion", "componentGroup", componentGroup.Name, "component.Name", newEntry.Name, "component.Version", newEntry.Version)
 		return err
@@ -115,8 +112,8 @@ func UpdateGCLEntry(ctx context.Context, adapterClient client.Client, componentG
 	return nil
 }
 
-// Updates the GCL for a componentGroup with a list of entries
-func UpdateMultipleGCLEntries(ctx context.Context, adapterClient client.Client, componentGroup *v1beta2.ComponentGroup, componentsToUpdate map[string]v1beta2.ComponentState, logger helpers.IntegrationLogger) error {
+// UpdateMultipleGCLEntries updates the GCL for a componentGroup with a list of entries
+func UpdateMultipleGCLEntries(componentGroup *v1beta2.ComponentGroup, componentsToUpdate map[string]v1beta2.ComponentState, opts SnapshotOpts) error {
 	patch := client.MergeFromWithOptions(componentGroup.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	for i, entry := range componentGroup.Status.GlobalCandidateList {
 		entryKey := helpers.GetComponentVersionString(entry.Name, entry.Version)
@@ -130,16 +127,16 @@ func UpdateMultipleGCLEntries(ctx context.Context, adapterClient client.Client, 
 		componentGroup.Status.GlobalCandidateList = slices.Replace(componentGroup.Status.GlobalCandidateList, i, i+1, newEntry)
 	}
 
-	err := adapterClient.Status().Patch(ctx, componentGroup, patch)
+	err := opts.client.Status().Patch(opts.ctx, componentGroup, patch)
 	if err != nil {
-		logger.Error(err, "Failed to updated GCL entry for ComponentVersion with components", "componentGroup", componentGroup.Name, "snapshotComponents", componentsToUpdate)
+		opts.logger.Error(err, "Failed to updated GCL entry for ComponentVersion with components", "componentGroup", componentGroup.Name, "snapshotComponents", componentsToUpdate)
 		return err
 	}
 	return nil
 }
 
-// Update GCL for all Components in snapshot
-func UpdateGCLForOverrideSnapshot(ctx context.Context, adapterClient client.Client, objectLoader loader.ObjectLoader, componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot, logger helpers.IntegrationLogger) error {
+// UpdateGCLForOverrideSnapshot updates the GCL for all Components in snapshot
+func UpdateGCLForOverrideSnapshot(componentGroup *v1beta2.ComponentGroup, snapshot *applicationapiv1alpha1.Snapshot, opts SnapshotOpts) error {
 	componentsToAdd := map[string]v1beta2.ComponentState{}
 	for _, component := range snapshot.Spec.Components {
 		component := component //G601
@@ -150,13 +147,13 @@ func UpdateGCLForOverrideSnapshot(ctx context.Context, adapterClient client.Clie
 	}
 
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		cg, err := objectLoader.GetComponentGroup(ctx, adapterClient, componentGroup.Name, componentGroup.Namespace)
+		cg, err := opts.loader.GetComponentGroup(opts.ctx, opts.client, componentGroup.Name, componentGroup.Namespace)
 		if err != nil {
 			return err
 		}
-		err = UpdateMultipleGCLEntries(ctx, adapterClient, cg, componentsToAdd, logger)
+		err = UpdateMultipleGCLEntries(cg, componentsToAdd, opts)
 		if err == nil {
-			logger.Info("Updated Global Candidate List with override snapshot", "componentGroup.Name", componentGroup.Name, "componentGroup.Namespace", componentGroup.Namespace, "snapshot.Name", snapshot.Name)
+			opts.logger.Info("Updated Global Candidate List with override snapshot", "componentGroup.Name", componentGroup.Name, "componentGroup.Namespace", componentGroup.Namespace, "snapshot.Name", snapshot.Name)
 		}
 		return err
 	})

--- a/snapshot/gcl_test.go
+++ b/snapshot/gcl_test.go
@@ -227,7 +227,7 @@ var _ = Describe("GCL manipulation functions", Ordered, func() {
 					LastPromotedImage:     newImageWithDigest,
 					LastPromotedBuildTime: &metav1.Time{Time: time.Now()},
 				}
-				err := UpdateGCLEntry(ctx, k8sClient, updatedComponentGroup, newEntry)
+				err := UpdateGCLEntry(updatedComponentGroup, newEntry, NewSnapshotOpts(ctx, k8sClient, helpers.IntegrationLogger{}, nil))
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(func() error {
@@ -278,7 +278,7 @@ var _ = Describe("GCL manipulation functions", Ordered, func() {
 					GlobalCandidateList: []v1beta2.ComponentState{},
 				}
 
-				err := UpdateGCLEntry(ctx, k8sClient, compGroupNoGCL, newEntry)
+				err := UpdateGCLEntry(compGroupNoGCL, newEntry, NewSnapshotOpts(ctx, k8sClient, helpers.IntegrationLogger{}, nil))
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("could not find ComponentVersion"))
 			})
@@ -289,7 +289,7 @@ var _ = Describe("GCL manipulation functions", Ordered, func() {
 				newEntryOldBuild := newEntry.DeepCopy()
 				newEntryOldBuild.LastPromotedBuildTime = &metav1.Time{Time: time.Date(2025, 12, 31, 12, 0, 0, 0, time.UTC)}
 
-				err := UpdateGCLEntry(ctx, k8sClient, hasCompGroup, *newEntryOldBuild)
+				err := UpdateGCLEntry(hasCompGroup, *newEntryOldBuild, NewSnapshotOpts(ctx, k8sClient, helpers.IntegrationLogger{}, nil))
 				Expect(err).NotTo(HaveOccurred())
 				for _, component := range hasCompGroup.Status.GlobalCandidateList {
 					if component.Name == newEntry.Name && component.Version == newEntry.Version {
@@ -415,14 +415,18 @@ var _ = Describe("GCL manipulation functions", Ordered, func() {
 					return err
 				}, time.Second*10).ShouldNot(HaveOccurred())
 
-				log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&bytes.Buffer{})}
-				mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
-					{
-						ContextKey: loader.ComponentGroupContextKey,
-						Resource:   hasCompGroup,
-					},
-				})
-				err := UpdateGCLForOverrideSnapshot(mockContext, k8sClient, loader.NewLoader(), hasCompGroup, overrideSnapshot, log)
+				overrideOpts := NewSnapshotOpts(
+					toolkit.GetMockedContext(ctx, []toolkit.MockData{
+						{
+							ContextKey: loader.ComponentGroupContextKey,
+							Resource:   hasCompGroup,
+						},
+					}),
+					k8sClient,
+					helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&bytes.Buffer{})},
+					loader.NewLoader(),
+				)
+				err := UpdateGCLForOverrideSnapshot(hasCompGroup, overrideSnapshot, overrideOpts)
 				Expect(err).NotTo(HaveOccurred())
 				time.Sleep(3 * time.Second)
 				Expect(k8sClient.Get(ctx, types.NamespacedName{

--- a/snapshot/opts.go
+++ b/snapshot/opts.go
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package snapshot
+
+import (
+	"context"
+
+	"github.com/konflux-ci/integration-service/helpers"
+	"github.com/konflux-ci/integration-service/loader"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type SnapshotOpts struct {
+	ctx    context.Context
+	client client.Client
+	logger helpers.IntegrationLogger
+	loader loader.ObjectLoader
+}
+
+func NewSnapshotOpts(ctx context.Context, client client.Client, logger helpers.IntegrationLogger, loader loader.ObjectLoader) SnapshotOpts {
+	return SnapshotOpts{
+		ctx:    ctx,
+		client: client,
+		logger: logger,
+		loader: loader,
+	}
+}

--- a/snapshot/validation.go
+++ b/snapshot/validation.go
@@ -17,7 +17,6 @@ limitations under the License.
 package snapshot
 
 import (
-	"context"
 	"errors"
 	"fmt"
 
@@ -25,15 +24,14 @@ import (
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 // ValidateOverrideSnapshotComponents checks that every component in an override
 // snapshot is a known (name, version) member of the given ComponentGroup, has a valid image
 // digest, and has git source fields defined. All validation failures are collected and returned
 // as a single joined error so the caller receives a complete picture in one pass.
-func ValidateOverrideSnapshotComponents(ctx context.Context, snapshot *applicationapiv1alpha1.Snapshot, componentGroup *v1beta2.ComponentGroup) error {
-	log := log.FromContext(ctx)
+func ValidateOverrideSnapshotComponents(snapshot *applicationapiv1alpha1.Snapshot, componentGroup *v1beta2.ComponentGroup, opts SnapshotOpts) error {
+	log := opts.logger.Logger
 
 	// Build a set of known (name, version) pairs from the ComponentGroup spec in O(n)
 	knownComponents := make(map[string]bool, len(componentGroup.Spec.Components))

--- a/snapshot/validation_test.go
+++ b/snapshot/validation_test.go
@@ -26,6 +26,7 @@ import (
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/gitops"
+	"github.com/konflux-ci/integration-service/helpers"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -142,7 +143,7 @@ var _ = Describe("Snapshot validation function", Ordered, func() {
 
 	When("A valid override snapshot is created", func() {
 		It("Does not return an error", func() {
-			err := ValidateOverrideSnapshotComponents(ctx, hasSnapshot, hasCompGroup)
+			err := ValidateOverrideSnapshotComponents(hasSnapshot, hasCompGroup, NewSnapshotOpts(ctx, k8sClient, helpers.IntegrationLogger{}, nil))
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -167,7 +168,7 @@ var _ = Describe("Snapshot validation function", Ordered, func() {
 			hasSnapshot.Spec.Components = append(hasSnapshot.Spec.Components, nonexistentComponent)
 		})
 		It("Returns an error", func() {
-			err := ValidateOverrideSnapshotComponents(ctx, hasSnapshot, hasCompGroup)
+			err := ValidateOverrideSnapshotComponents(hasSnapshot, hasCompGroup, NewSnapshotOpts(ctx, k8sClient, helpers.IntegrationLogger{}, nil))
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("doesn't exist in componentGroup"))
 		})


### PR DESCRIPTION
Abstracts commonly-used function parameters for the snapshot package into a shared opts struct. This is a commonly-used pattern in kubernetes libraries and decreases the number of values passed to each function, making the headers and calls easier to understand

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
