### PR TITLE
feat(STONEINTG-1645): add AI skills for integration-service repo

### DIFF
--- a/.claude/skills/ci-cd-quirks
+++ b/.claude/skills/ci-cd-quirks
@@ -1,0 +1,1 @@
+../../skills/ci-cd-quirks

--- a/.claude/skills/debugging-running-instance
+++ b/.claude/skills/debugging-running-instance
@@ -1,0 +1,1 @@
+../../skills/debugging-running-instance

--- a/.claude/skills/kind-cluster-setup
+++ b/.claude/skills/kind-cluster-setup
@@ -1,0 +1,1 @@
+../../skills/kind-cluster-setup

--- a/.claude/skills/pr-definition-of-done
+++ b/.claude/skills/pr-definition-of-done
@@ -1,0 +1,1 @@
+../../skills/pr-definition-of-done

--- a/.claude/skills/running-e2e-tests
+++ b/.claude/skills/running-e2e-tests
@@ -1,0 +1,1 @@
+../../skills/running-e2e-tests

--- a/.claude/skills/running-unit-tests
+++ b/.claude/skills/running-unit-tests
@@ -1,0 +1,1 @@
+../../skills/running-unit-tests

--- a/skills/SKILLS.md
+++ b/skills/SKILLS.md
@@ -1,0 +1,33 @@
+# Integration Service AI Skills
+
+Repository-specific AI skills for the integration-service Kubernetes operator. These skills are tool-agnostic and can be used with any AI agent (Claude Code, Codex, Goose, etc.) via symlinks to the agent's skill directory.
+
+## Available Skills
+
+| Skill | Description |
+|-------|-------------|
+| [running-unit-tests](running-unit-tests/SKILL.md) | How to run, write, and troubleshoot unit tests (envtest, Ginkgo, mock loader, coverage) |
+| [running-e2e-tests](running-e2e-tests/SKILL.md) | How to build, configure, and run e2e tests against a real cluster (Kind or OpenShift) |
+| [pr-definition-of-done](pr-definition-of-done/SKILL.md) | Checklist for PR readiness: commits, code generation, tests, CI checks, documentation |
+| [debugging-running-instance](debugging-running-instance/SKILL.md) | How to debug the service on a cluster: logs, probes, metrics, webhooks, env vars |
+| [kind-cluster-setup](kind-cluster-setup/SKILL.md) | Local dev environment setup, CRD installation, deployment, and full Konflux stack |
+| [ci-cd-quirks](ci-cd-quirks/SKILL.md) | Non-obvious CI/CD behavior: vendoring, hermetic builds, security scans, gotchas |
+
+## Setup for Claude Code
+
+Skills are symlinked from `.claude/skills/` for automatic discovery:
+
+```
+.claude/skills/running-unit-tests -> ../../skills/running-unit-tests
+.claude/skills/running-e2e-tests -> ../../skills/running-e2e-tests
+...
+```
+
+## Setup for Other Agents
+
+Create symlinks from your agent's skill directory to `skills/`:
+
+```bash
+# Example for Codex
+ln -s ../../skills/running-unit-tests .agents/skills/running-unit-tests
+```

--- a/skills/ci-cd-quirks/SKILL.md
+++ b/skills/ci-cd-quirks/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: ci-cd-quirks
+description: Use when CI checks fail unexpectedly, when preparing code for CI, or when encountering non-obvious build and pipeline behavior. Covers vendoring, hermetic builds, security scans, code generation checks, coverage, and webhook validation gotchas.
+---
+
+# CI/CD Quirks and Gotchas
+
+## Overview
+
+Integration-service CI runs on Konflux (Tekton-based) for builds and GitHub Actions for linting/testing. Several non-obvious requirements catch developers off guard.
+
+## When to Use
+
+- CI failed and you don't understand why
+- Preparing a change that touches dependencies, CRDs, or RBAC
+- Understanding what the build pipeline actually does
+- Debugging webhook validation behavior
+
+## Must-Run Commands Before Push
+
+| When you changed... | Run this | Why |
+|---------------------|----------|-----|
+| Any `go.mod` / `go.sum` | `go mod tidy && go mod vendor` | Vendor dir is committed; CI fails on drift |
+| Types in `api/v1beta2/` | `make generate manifests` | DeepCopy and CRD/RBAC manifests must be in sync |
+| Any `.go` file | `make fmt` | CI fails on uncommitted gofmt changes |
+| `+kubebuilder:rbac` markers | `make manifests` | RBAC ClusterRole must reflect markers |
+
+## CI Checks That Surprise People
+
+### Vendoring (most common failure)
+Go vendoring prunes non-Go files. After `go mod vendor`, CRD YAML files from dependencies are gone. `make download-crds` re-downloads them for tests. CI runs this automatically, but if you updated deps and didn't vendor, CI fails.
+
+### RBAC Wildcard Check
+CI greps `config/` for RBAC wildcards (`*`) and fails if found. Never use wildcard verbs or resource names in `+kubebuilder:rbac` markers.
+
+### Code Generation Drift
+CI runs `make generate manifests` and diffs the result. Any uncommitted generated files = failure. Always commit generated output.
+
+### `go mod tidy` Drift
+CI runs `go mod tidy` and checks for changes. If your `go.mod`/`go.sum` differ after tidy, CI fails.
+
+## Build Pipeline Details
+
+### PR Pipeline (`.tekton/integration-service-pull-request.yaml`)
+- Injects `ENABLE_COVERAGE=true` — binary built with `-cover -covermode=atomic -tags=coverage`
+- Hermetic build (network-isolated), deps prefetched via Cachi2
+- Multi-platform: x86_64 + arm64
+- Image tag: `on-pr-{{revision}}`
+- Expires after 5 days, max 3 kept
+- Security scans: Clair, Roxctl, Snyk SAST, ClamAV, ShellCheck, Unicode, RPM signature
+
+### Push Pipeline (`.tekton/integration-service-push.yaml`)
+- Regular build (no coverage) + extra `build-instrumented-image` task (with coverage)
+- Image tag: `{{revision}}`
+- Same security scans as PR
+
+### Dockerfile Gotchas
+- Builds **two binaries**: `manager` (controller) and `snapshotgc` (garbage collector)
+- Both ship in the same image, entrypoint is `/manager`
+- `ENABLE_COVERAGE` build arg switches between instrumented and production builds
+- Base image: UBI9 minimal, runs as user 65532 (non-root)
+
+## Webhook Validation Gotchas
+
+| Rule | What happens if violated |
+|------|------------------------|
+| ITS name must be DNS-1035 | Webhook rejects with validation error (lowercase alphanumeric + hyphen, <63 chars) |
+| `SNAPSHOT` param in ITS | Cannot be set manually — auto-injected by the service. Webhook rejects. |
+| Git resolver: `url` vs `repo+org` | Must use one or the other, not both. Webhook rejects conflicting params. |
+| Snapshot validator | Has `failurePolicy: Ignore` — validation failures pass through silently (by design) |
+
+## Coverage
+
+- Tool: codecov, flag: `unit-tests`
+- Threshold: 3% drop from base commit allowed
+- Ignores: `**/zz_generated*`, `e2e-tests/**`, vendor
+- Patch coverage: informational only (non-blocking)
+
+## Common Mistakes
+
+| Problem | Root cause |
+|---------|-----------|
+| CI fails with "uncommitted changes" | Didn't run `make fmt`, `make generate manifests`, or `go mod tidy` |
+| Build fails on missing deps | Didn't run `go mod vendor` after dependency change |
+| RBAC check fails | Used wildcard `*` in kubebuilder RBAC marker |
+| Coverage dropped | New code paths not covered by tests (check `cover.out`) |
+| Webhook rejects valid-looking ITS | Name contains uppercase, underscore, or is >63 chars |

--- a/skills/debugging-running-instance/SKILL.md
+++ b/skills/debugging-running-instance/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: debugging-running-instance
+description: Use when debugging integration-service running on a cluster. Covers pod logs, health probes, metrics, webhooks, network policies, environment variables, snapshot GC, and common failure modes.
+---
+
+# Debugging a Running Instance
+
+## Overview
+
+The integration-service runs as a Deployment in the `integration-service-system` namespace. It exposes health probes, Prometheus metrics, and optional webhooks. A separate CronJob handles snapshot garbage collection.
+
+## When to Use
+
+- Controller not reconciling resources as expected
+- Webhooks rejecting or silently ignoring mutations/validations
+- Metrics not being scraped
+- Status reports not appearing on PRs
+- Snapshot GC not cleaning up old snapshots
+
+## Quick Reference
+
+| What | How |
+|------|-----|
+| Controller logs | `kubectl logs -n integration-service-system deploy/controller-manager -f` |
+| Health check | `kubectl get -n integration-service-system deploy/controller-manager -o jsonpath='{.status.conditions}'` |
+| Readiness probe | HTTP GET `/readyz` on port 8081 |
+| Liveness probe | HTTP GET `/healthz` on port 8081 |
+| Metrics | Port 8080 (HTTPS, self-signed cert), scraped at `/metrics` |
+| Webhook port | 9443 (when enabled) |
+| Leader election | Lease-based, 15s lease duration, 10s renew deadline, 2s retry period |
+| Pod label | `control-plane: controller-manager` |
+
+## Environment Variables
+
+### Controller
+
+| Variable | Default | Effect if wrong |
+|----------|---------|----------------|
+| `CONSOLE_URL` | none | PR status comments show `CONSOLE_URL_NOT_AVAILABLE` |
+| `CONSOLE_URL_TASKLOG` | none | Task log links show `CONSOLE_URL_TASKLOG_NOT_AVAILABLE` |
+| `CONSOLE_NAME` | none | Console display name missing from PR comments |
+| `PIPELINE_TIMEOUT` | none | Invalid duration is logged as error and skipped |
+| `TASKS_TIMEOUT` | none | Invalid duration is logged as error and skipped |
+| `FINALLY_TIMEOUT` | none | Invalid duration is logged as error and skipped |
+| `INTEGRATION_NS` | `integration-service` | Wrong namespace for PAC secret lookup |
+| `PAC_SECRET` | `pipelines-as-code-secret` | Can't authenticate to git providers |
+
+## Network Policies
+
+Namespaces must be explicitly labeled for traffic to reach the controller:
+
+| Traffic | Required label |
+|---------|---------------|
+| Metrics scraping | `metrics: enabled` on source namespace |
+| Webhook calls | `webhook: enabled` on source namespace |
+
+Missing labels = silently blocked traffic. Check with: `kubectl get ns <name> --show-labels`
+
+## Webhook Behavior
+
+| Webhook | Type | Failure Policy | Effect |
+|---------|------|---------------|--------|
+| IntegrationTestScenario | Mutating | **Ignore** | Defaults applied silently on failure |
+| IntegrationTestScenario | Validating | **Fail** | Rejects invalid ITS (bad names, conflicting resolver params) |
+| ComponentGroup | Validating | **Fail** | Blocks invalid ComponentGroups |
+| Snapshot | Mutating + Validating | **Ignore** | Failures silently pass through (by design) |
+
+## Debugging Checklist
+
+1. **Controller not starting?** Check env var values and RBAC — timeout parsing errors are logged, not fatal
+2. **Not reconciling?** Check leader election lease, RBAC, and that CRDs are installed
+3. **PR status missing?** Check `CONSOLE_URL` env var and PAC secret availability
+4. **Webhooks not firing?** Check namespace labels (`webhook: enabled`) and cert-manager status
+5. **Metrics missing?** Check namespace labels (`metrics: enabled`) and ServiceMonitor exists
+6. **Snapshots piling up?** Check `snapshotgc` CronJob logs — runs every 6h with separate service account
+
+## Common Mistakes
+
+| Problem | Fix |
+|---------|-----|
+| `CONSOLE_URL_NOT_AVAILABLE` in PR comments | Set `CONSOLE_URL` env var with `{{NAMESPACE}}` and `{{PIPELINE_RUN_NAME}}` placeholders |
+| Controller crash loop | Check env var values — timeout vars must be valid Go durations (e.g., `2h`, `30m`) |
+| Webhook silently not validating Snapshots | By design — Snapshot webhook has `failurePolicy: Ignore` |
+| Metrics endpoint unreachable | Verify namespace label `metrics: enabled` and that ServiceMonitor target matches |

--- a/skills/debugging-running-instance/SKILL.md
+++ b/skills/debugging-running-instance/SKILL.md
@@ -7,7 +7,7 @@ description: Use when debugging integration-service running on a cluster. Covers
 
 ## Overview
 
-The integration-service runs as a Deployment in the `integration-service-system` namespace. It exposes health probes, Prometheus metrics, and optional webhooks. A separate CronJob handles snapshot garbage collection.
+The integration-service runs as a Deployment in the `integration-service` namespace. It exposes health probes, Prometheus metrics, and optional webhooks. A separate CronJob handles snapshot garbage collection.
 
 ## When to Use
 
@@ -21,8 +21,8 @@ The integration-service runs as a Deployment in the `integration-service-system`
 
 | What | How |
 |------|-----|
-| Controller logs | `kubectl logs -n integration-service-system deploy/controller-manager -f` |
-| Health check | `kubectl get -n integration-service-system deploy/controller-manager -o jsonpath='{.status.conditions}'` |
+| Controller logs | `kubectl logs -n integration-service deploy/controller-manager -f` |
+| Health check | `kubectl get -n integration-service deploy/controller-manager -o jsonpath='{.status.conditions}'` |
 | Readiness probe | HTTP GET `/readyz` on port 8081 |
 | Liveness probe | HTTP GET `/healthz` on port 8081 |
 | Metrics | Port 8080 (HTTPS, self-signed cert), scraped at `/metrics` |

--- a/skills/kind-cluster-setup/SKILL.md
+++ b/skills/kind-cluster-setup/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: kind-cluster-setup
+description: Use when setting up a local development environment, deploying integration-service to a cluster, installing CRDs, or tearing down a Kind cluster. Covers make targets, kustomize deployment, and full Konflux stack setup.
+---
+
+# Kind Cluster Setup
+
+## Overview
+
+For local development you can run the controller against any cluster via `make run`, or deploy it fully with `make deploy`. The CI pipeline provisions Kind clusters on AWS for e2e tests using MAPT.
+
+## When to Use
+
+- Setting up a local dev environment
+- Installing/uninstalling CRDs on a cluster
+- Deploying/undeploying the full controller
+- Understanding how CI provisions test clusters
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `make install` | Install CRDs into current cluster (from `config/crd/`) |
+| `make uninstall` | Remove CRDs from cluster |
+| `make run` | Run controller locally against current kubeconfig |
+| `make deploy` | Deploy controller + RBAC + webhooks to cluster via kustomize |
+| `make undeploy` | Remove deployed controller from cluster |
+| `make img-build` | Build container image (default: docker) |
+| `make img-push` | Push image to registry |
+| `CONT_ENGINE=podman make img-build` | Build with podman instead of docker |
+
+## Local Development (make run)
+
+1. Ensure kubeconfig points to your target cluster
+2. Install CRDs: `make install`
+3. Install dependency CRDs (application-api, release-service, Tekton, PAC) — these must be on the cluster
+4. Run: `make run` — starts controller with local binary, no container needed
+5. Controller connects to cluster via kubeconfig, reconciles resources
+
+## Full Deployment (make deploy)
+
+1. Build and push image:
+   ```
+   make img-build IMG=quay.io/youruser/integration-service:dev
+   make img-push IMG=quay.io/youruser/integration-service:dev
+   ```
+2. Deploy: `make deploy IMG=quay.io/youruser/integration-service:dev`
+3. This creates namespace `integration-service-system` and deploys via kustomize
+4. Teardown: `make undeploy`
+
+## Required Dependency CRDs
+
+The controller needs these CRDs on the cluster (not just locally for tests):
+
+| Source | CRDs |
+|--------|------|
+| `konflux-ci/application-api` | Application, Component, Snapshot, ReleasePlan, Release |
+| `konflux-ci/release-service` | Release, ReleasePlan, ReleasePlanAdmission |
+| `tektoncd/pipeline` | PipelineRun, TaskRun, Pipeline, Task |
+| `openshift-pipelines/pipelines-as-code` | Repository |
+| This repo | IntegrationTestScenario, ComponentGroup |
+
+## Webhook Considerations
+
+- Webhooks require TLS certificates — cert-manager must be installed
+- Cert-manager config is in `config/certmanager/` (commented out by default in kustomization)
+- Without webhooks, the controller still works but won't validate ITS names or reject invalid resources
+- Toggle via `ENABLE_WEBHOOKS` env var in deployment
+
+## Common Mistakes
+
+| Problem | Fix |
+|---------|-----|
+| Missing dependency CRDs | Install application-api, release-service, and Tekton CRDs on the cluster first |
+| `make deploy` fails on image pull | Push image to accessible registry, or use `imagePullPolicy: IfNotPresent` for local images |
+| Webhooks fail with TLS errors | Install cert-manager or disable webhooks |
+| `make run` can't connect | Check `KUBECONFIG` env var or `~/.kube/config` points to correct cluster |

--- a/skills/pr-definition-of-done/SKILL.md
+++ b/skills/pr-definition-of-done/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: pr-definition-of-done
+description: Use when preparing a pull request for review, before pushing, or when reviewing someone else's PR. Checklist of CI checks, commit conventions, code generation, testing, and documentation requirements.
+---
+
+# PR Definition of Done
+
+## Overview
+
+Every PR must pass CI checks, follow commit conventions, include tests, and keep generated code in sync. This checklist covers what CI enforces and what reviewers expect.
+
+## When to Use
+
+- Before pushing a PR for review
+- When CI checks fail and you need to understand why
+- When reviewing someone else's PR
+
+## Pre-Push Checklist
+
+### Commits
+- [ ] Conventional format: `type(JIRA-ID): description` (e.g., `feat(STONEINTG-1519): create PR group snapshots`)
+- [ ] Types: `feat`, `fix`, `chore`, `refactor`, `test`, `docs`
+- [ ] Signed off (DCO): `git commit -s`
+- [ ] Title < 72 chars, description lines < 72 chars
+- [ ] AI-assisted work: add `Assisted-by: <tool-name>` trailer
+
+### Code Generation (CI will fail if stale — see [ci-cd-quirks](../ci-cd-quirks/SKILL.md) for details)
+- [ ] After API type changes in `api/v1beta2/`: `make generate manifests`
+- [ ] After dependency changes: `go mod tidy && go mod vendor`
+- [ ] Run `make fmt` — CI fails on uncommitted formatting changes
+- [ ] Run `make vet` — catches common Go mistakes
+
+### Testing
+- [ ] Unit tests alongside code changes (Ginkgo + envtest)
+- [ ] Cover: happy path, error conditions, edge cases, idempotency
+- [ ] `make test` passes locally
+- [ ] Coverage does not decrease (codecov allows 3% drop threshold)
+
+### Security & RBAC
+- [ ] No secrets, keys, or credentials committed
+- [ ] No RBAC wildcards in `config/` (CI checks this)
+- [ ] New resource types: add `+kubebuilder:rbac` markers
+
+### Documentation
+- [ ] PR description explains the "why", not just the "what"
+- [ ] PR title < 72 chars
+- [ ] Controller diagram in `docs/` updated if controller logic changed
+
+## What CI Checks
+
+| Check | Workflow | What fails it |
+|-------|----------|---------------|
+| Go tests | `pr.yaml` | `make test` failures |
+| Formatting | `pr.yaml` | Uncommitted `make fmt` changes |
+| Code generation | `pr.yaml` | Uncommitted `make generate manifests` output |
+| `go mod tidy` | `pr.yaml` | Uncommitted tidy changes |
+| RBAC wildcards | `pr.yaml` | Wildcard `*` in config RBAC files |
+| Dockerfile lint | `pr.yaml` | hadolint violations |
+| Go linters | `pr.yaml` | gosec, golangci-lint, staticcheck failures |
+| CodeQL | `codeql.yml` | Security vulnerabilities |
+| PR size | `size.yaml` | Oversized PRs (informational) |
+| Coverage | `codecov.yml` | >3% coverage drop from base |
+| Tekton build | `.tekton/` | Image build failure, security scans |
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Forgot `go mod vendor` | Run `go mod tidy && go mod vendor` after any dep change |
+| Stale deepcopy | Run `make generate` after editing types in `api/v1beta2/` |
+| Stale RBAC/CRD manifests | Run `make manifests` after changing `+kubebuilder` markers |
+| Unsigned commit | Use `git commit -s` or amend with `git commit --amend -s` |
+| Coverage dropped | Add tests for new code paths — check `cover.out` for uncovered lines |

--- a/skills/running-e2e-tests/SKILL.md
+++ b/skills/running-e2e-tests/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: running-e2e-tests
+description: Use when building, configuring, or running e2e tests for integration-service against a real cluster (Kind or OpenShift). Covers environment variables, test framework, Ginkgo flags, CI pipeline, and test repos.
+---
+
+# Running E2E Tests
+
+## Overview
+
+E2E tests run against a real Kubernetes cluster (Kind for upstream, OpenShift for downstream). They use a custom framework in `e2e-tests/pkg/framework/` with specialized controllers for managing Konflux resources during tests.
+
+## When to Use
+
+- Running e2e tests locally or in CI
+- Adding new e2e test cases
+- Debugging e2e test failures
+- Understanding the CI pipeline that provisions clusters and runs tests
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `make e2e-build` | Build test binary: `./e2e-tests/bin/e2e-appstudio` (build tag: `e2e`) |
+| `make e2e-run` | Build and run with `--ginkgo.focus="integration-service" --ginkgo.vv` |
+| `./e2e-tests/bin/e2e-appstudio --ginkgo.focus="test name"` | Run specific tests |
+| `--ginkgo.label-filter="!slow"` | Filter by Ginkgo labels |
+| `--ginkgo.junit-report=report.xml` | Generate JUnit report |
+
+## Required Environment Variables
+
+| Variable | Purpose |
+|----------|---------|
+| `GITHUB_TOKEN` | GitHub API access for test repos |
+| `MY_GITHUB_ORG` | GitHub org containing test repos |
+| `KUBECONFIG` | Path to cluster kubeconfig |
+
+## Optional Environment Variables
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `TEST_ENVIRONMENT` | `downstream` | `upstream` (Kind) or `downstream` (OpenShift) |
+| `E2E_APPLICATIONS_NAMESPACE_ENV` | auto-created | Test namespace |
+| `SKIP_PAC_TESTS` | `false` | Skip Pipelines-as-Code tests |
+| `KLOG_VERBOSITY` | `1` | Log verbosity (1-5) |
+| `GITLAB_BOT_TOKEN` | - | GitLab API access |
+| `GITLAB_QE_ORG` / `GITLAB_API_URL` | - | GitLab org and endpoint |
+| `CODEBERG_BOT_TOKEN` / `CODEBERG_QE_ORG` | - | Codeberg access |
+
+## Test Framework
+
+The framework (`e2e-tests/pkg/framework/framework.go`) provides:
+
+- **`AsKubeAdmin` / `AsKubeDeveloper`** — permission contexts with specialized controllers
+- **ControllerHub** — `HasController` (apps/components), `TektonController` (PipelineRuns), `IntegrationController` (ITS), `ReleaseController`, `CommonController` (namespaces)
+- Auto-detects cluster type and domain from OpenShift console route
+- Auto-creates test namespace if `E2E_APPLICATIONS_NAMESPACE_ENV` not set
+
+## CI Pipeline
+
+`integration-tests/pipelines/konflux-e2e-tests.yaml` runs the full flow:
+
+1. Extract snapshot/component metadata
+2. Provision Kind cluster on AWS via MAPT
+3. Deploy full Konflux stack using `konflux-ci` deployment scripts
+4. Run e2e tests (2h timeout, 10 parallel Ginkgo procs)
+5. Collect coverage, report status, deprovision cluster
+
+## Test Files
+
+Tests live in `e2e-tests/tests/integration-service/`:
+- `integration.go` — core integration test scenarios
+- `status-reporting-to-pullrequest.go` — PR status reporting tests
+- `group-snapshots-tests.go` — ComponentGroup snapshot tests
+- `gitlab-integration-reporting.go` / `forgejo-integration-reporting.go` — multi-platform git provider tests
+
+## Common Mistakes
+
+| Problem | Fix |
+|---------|-----|
+| `GITHUB_TOKEN` rate limited | CI rotates tokens for highest rate limit — locally, use a PAT with sufficient scope |
+| Tests hang waiting for PipelineRun | Check cluster has Tekton installed and ITS configured correctly |
+| `TEST_ENVIRONMENT` wrong | Use `upstream` for Kind, `downstream` for OpenShift — affects cluster discovery |
+| Namespace not cleaned up | Framework auto-cleans on success; failed runs may leave namespaces behind |

--- a/skills/running-unit-tests/SKILL.md
+++ b/skills/running-unit-tests/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: running-unit-tests
+description: Use when running, writing, or troubleshooting unit tests for integration-service. Covers make test, envtest setup, suite patterns, mock loader, CRD discovery, coverage, and common test failures.
+---
+
+# Running Unit Tests
+
+## Overview
+
+Unit tests use Ginkgo v2 + Gomega with envtest (a local K8s API server). Every package has a `*_suite_test.go` that bootstraps envtest with CRDs, registers schemes, and starts a controller manager.
+
+## When to Use
+
+- Running or debugging unit tests
+- Adding tests to a new or existing package
+- Troubleshooting envtest or CRD-related test failures
+- Understanding the mock loader pattern
+
+## Quick Reference
+
+| Command | What it does |
+|---------|-------------|
+| `make test` | Full pipeline: manifests, generate, fmt, vet, envtest, download-crds, then `go test ./... -coverprofile cover.out` |
+| `make download-crds` | Downloads CRD YAMLs from dependency modules (vendoring prunes non-Go files) |
+| `make envtest` | Downloads setup-envtest tool |
+| `go test ./internal/controller/snapshot/...` | Run tests for a single package |
+| `go test ./... -run TestName` | Run a specific test by name |
+
+## Suite Setup Pattern
+
+Every suite follows this structure (see any `*_suite_test.go`):
+
+1. **CRD paths** via `CRDDirectoryPaths` — local CRDs from `config/crd/bases` plus dependency CRDs found via `toolkit.GetRelativeDependencyPath()`
+2. **Scheme registration** — add all API types (`applicationapiv1alpha1`, `tektonv1`, `releasev1alpha1`, `v1beta2`)
+3. **Manager creation** — `ctrl.NewManager()` with `Metrics.BindAddress: "0"` (disables metrics to avoid port conflicts) and `LeaderElection: false`
+4. **Cache setup** — call `cache.Setup*Cache(k8sManager)` functions before starting manager
+5. **Start manager in goroutine** — `go func() { defer GinkgoRecover(); k8sManager.Start(ctx) }()`
+6. **Cleanup** — `cancel()` context and `testEnv.Stop()` in `AfterSuite`
+
+CRD directory paths are relative to the suite file location. Adjust depth (`..`, `../..`) based on package nesting.
+
+## Mock Loader Pattern
+
+`loader/loader_mock.go` intercepts resource loading via context keys:
+
+```go
+mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+    {ContextKey: loader.SnapshotContextKey, Resource: mySnapshot},
+})
+result, err := adapter.loader.GetSnapshot(mockContext, client, name, namespace)
+```
+
+Each resource type has a corresponding `*ContextKey` constant (34 keys available).
+
+## Test Conventions
+
+- BDD structure: `Describe` > `Context("When...")` > `It("should...")`
+- Use `Eventually` for async assertions, never `time.Sleep`
+- Always `Get()` after `Create()`/`Update()` to ensure server-side state
+- Test idempotency: calling Reconcile twice must produce the same result
+- `ginkgolinter` is enabled — follow its conventions
+
+## Common Mistakes
+
+| Problem | Fix |
+|---------|-----|
+| `no matches for kind "X"` | Missing CRD in `CRDDirectoryPaths` — add the dependency path |
+| Port conflict on metrics | Ensure `Metrics.BindAddress: "0"` in manager options |
+| `make test` fails on missing CRDs | Run `make download-crds` — vendoring prunes YAML files |
+| Stale generated code | Run `make generate manifests` before testing |
+| Tests pass locally, fail in CI | Check `go mod tidy` and `make fmt` — CI fails on uncommitted changes |
+
+## Coverage
+
+- Tool: codecov with flag `unit-tests`
+- Threshold: 3% drop allowed from base commit
+- Ignores: `**/zz_generated*`, `e2e-tests/**`, vendor


### PR DESCRIPTION
  ## Summary                                                                                                                                                                                                       
   
  Adds 6 repository-specific AI skills to help developers automate repeatable tasks using AI agents (Claude Code, Codex, etc.).                                                                                    
                                                            
  Skills are stored in a tool-agnostic `skills/` directory and symlinked to `.claude/skills/` for automatic Claude Code discovery.                                                                                 
                                                            
  ### Skills added:                                                                                                                                                                                                
  - **running-unit-tests** — `make test`, envtest setup, suite patterns, mock loader, coverage
  - **running-e2e-tests** — build/run e2e tests, required env vars, test framework, CI pipeline                                                                                                                    
  - **pr-definition-of-done** — pre-push checklist covering commits, codegen, tests, CI checks                                                                                                                     
  - **debugging-running-instance** — controller logs, health probes, metrics, webhooks, env vars, snapshot GC                                                                                                      
  - **kind-cluster-setup** — local dev environment, CRD installation, deploy/undeploy                                                                                                                              
  - **ci-cd-quirks** — vendoring gotchas, hermetic builds, security scans, webhook validation quirks 

Assisteb-by: Claude code

Ticket :  [STONEINTG-1645](https://redhat.atlassian.net/browse/STONEINTG-1645)

  ## Test plan                                                                                                                                                                                                     
  - [ ] Verify `skills/SKILLS.md` index exists and lists all 6 skills                                                                                                                                              
  - [ ] Verify all `.claude/skills/` symlinks resolve correctly                                                                                                                                                    
  - [ ] Verify each `SKILL.md` has valid frontmatter with `name` and `description`                                                                                                                                 
  - [ ] Confirm skills appear in Claude Code's available skills list in a new session  


[STONEINTG-1616]: https://redhat.atlassian.net/browse/STONEINTG-1616?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[STONEINTG-1645]: https://redhat.atlassian.net/browse/STONEINTG-1645?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ