### PR TITLE
fix(KONFLUX-13770): use optimistic lock for PLR finalizer patches

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -438,7 +438,7 @@ func RemoveFinalizerFromPipelineRun(ctx context.Context, adapterClient client.Cl
 		return nil
 	}
 
-	patch := client.MergeFrom(pipelineRun.DeepCopy())
+	patch := client.MergeFromWithOptions(pipelineRun.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	if ok := controllerutil.RemoveFinalizer(pipelineRun, finalizer); ok {
 		err := adapterClient.Patch(ctx, pipelineRun, patch)
 		if err != nil {
@@ -456,7 +456,10 @@ func RemoveFinalizerFromPipelineRun(ctx context.Context, adapterClient client.Cl
 // AddFinalizerToPipelineRun adds the finalizer to the PipelineRun.
 // If finalizer was not added successfully, a non-nil error is returned.
 func AddFinalizerToPipelineRun(ctx context.Context, adapterClient client.Client, logger IntegrationLogger, pipelineRun *tektonv1.PipelineRun, finalizer string) error {
-	patch := client.MergeFrom(pipelineRun.DeepCopy())
+	if controllerutil.ContainsFinalizer(pipelineRun, finalizer) {
+		return nil
+	}
+	patch := client.MergeFromWithOptions(pipelineRun.DeepCopy(), client.MergeFromWithOptimisticLock{})
 	if ok := controllerutil.AddFinalizer(pipelineRun, finalizer); ok {
 		err := adapterClient.Patch(ctx, pipelineRun, patch)
 		if err != nil {


### PR DESCRIPTION
Switch AddFinalizerToPipelineRun and 
RemoveFinalizerFromPipelineRun to use
MergeFromWithOptions with 
MergeFromWithOptimisticLock to include 
resourceVersion in finalizer patches. This ensures a 
409 conflict is returned if another controller has 
modified the PipelineRun since the last read, forcing 
a re-fetch before retry and preventing stale writes 
from silently wiping concurrently added finalizers.

Assisted-by: Gemini

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
