### PR TITLE
fix(STONEINTG-1633): integration service skips some single-component releases

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1231,6 +1231,9 @@ func (a *Adapter) cancelAllPipelineRunsForSnapshot(snapshot *applicationapiv1alp
 	return gitops.CancelPipelineRuns(a.client, a.context, a.logger, integrationTestPipelineRuns)
 }
 
+// isSnapshotOlderThanLastBuild queries sibling push snapshots instead of comparing against
+// the component's BuildPipelineLastBuiltTime annotation because that annotation stores seconds
+// while BuildPipelineRunStartTime stores milliseconds, causing false supersession for single-component releases.
 func (a *Adapter) isSnapshotOlderThanLastBuild(snapshot *applicationapiv1alpha1.Snapshot) bool {
 	componentName := snapshot.Labels[gitops.SnapshotComponentLabel]
 	if componentName == "" {
@@ -1240,34 +1243,44 @@ func (a *Adapter) isSnapshotOlderThanLastBuild(snapshot *applicationapiv1alpha1.
 	if snapshotBuildStartTime == "" {
 		return false
 	}
-	component, err := a.loader.GetComponent(a.context, a.client, componentName, a.snapshot.Namespace)
+	snapshotBuildStartTimeInt, err := strconv.ParseInt(snapshotBuildStartTime, 10, 64)
 	if err != nil {
-		a.logger.Error(err, "Failed to get component from snapshot", "snapshot.Name", snapshot.Name)
+		a.logger.Error(err, "Failed to parse BuildPipelineRunStartTime",
+			"snapshot.Name", snapshot.Name, "value", snapshotBuildStartTime)
 		return false
 	}
-	componentlastBuiltTime := component.Annotations[gitops.BuildPipelineLastBuiltTime]
-	if componentlastBuiltTime == "" {
-		return false
-	}
-	snapshotBuildStartTimeInt, snapshotBuildStartTimeIntErr := strconv.ParseInt(snapshotBuildStartTime, 10, 64)
-	if snapshotBuildStartTimeIntErr != nil {
-		return false
-	}
-	componentlastBuiltTimeInt, componentlastBuiltTimeIntErr := strconv.ParseInt(componentlastBuiltTime, 10, 64)
-	if componentlastBuiltTimeIntErr != nil {
-		return false
-	}
-
-	// Normalize BuildPipelineRunStartTime to seconds if it's in milliseconds
+	// Normalize BuildPipelineRunStartTime to milliseconds if it's in seconds
 	// Millisecond timestamps are > 1000000000000 (year 2001 in milliseconds)
 	// Second timestamps are < 10000000000 (year 2286 in seconds)
-	if snapshotBuildStartTimeInt > 10000000000 {
-		// It's in milliseconds, convert to seconds for comparison
-		snapshotBuildStartTimeInt = snapshotBuildStartTimeInt / 1000
+	if snapshotBuildStartTimeInt <= 10000000000 {
+		snapshotBuildStartTimeInt = snapshotBuildStartTimeInt * 1000
 	}
 
-	if snapshotBuildStartTimeInt < componentlastBuiltTimeInt {
-		return true
+	pushSnapshots, err := a.loader.GetPushComponentSnapshotsForComponent(a.context, a.client, snapshot)
+	if err != nil {
+		a.logger.Error(err, "Failed to get push component snapshots for component",
+			"snapshot.Name", snapshot.Name, "componentName", componentName)
+		return false
+	}
+
+	for _, ps := range *pushSnapshots {
+		if ps.Name == snapshot.Name && ps.Namespace == snapshot.Namespace {
+			continue
+		}
+		otherBuildStartTime := ps.Annotations[gitops.BuildPipelineRunStartTime]
+		if otherBuildStartTime == "" {
+			continue
+		}
+		otherBuildStartTimeInt, parseErr := strconv.ParseInt(otherBuildStartTime, 10, 64)
+		if parseErr != nil {
+			continue
+		}
+		if otherBuildStartTimeInt <= 10000000000 {
+			otherBuildStartTimeInt = otherBuildStartTimeInt * 1000
+		}
+		if otherBuildStartTimeInt > snapshotBuildStartTimeInt {
+			return true
+		}
 	}
 	return false
 }

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -95,6 +95,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		hasOldGroupSnapshot                       *applicationapiv1alpha1.Snapshot
 		hasNewGroupSnapshot                       *applicationapiv1alpha1.Snapshot
 		hasOldSnapshot                            *applicationapiv1alpha1.Snapshot
+		hasNewerPushSnapshot                      *applicationapiv1alpha1.Snapshot
 		hasCompWithNewerBuild                     *applicationapiv1alpha1.Component
 		hasReleasePlan                            *releasev1alpha1.ReleasePlan
 		hasOverRideSnapshot                       *applicationapiv1alpha1.Snapshot
@@ -653,6 +654,31 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			},
 		}
 
+		hasNewerPushSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "newer-push-snapshot-test",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotComponentLabel:       "test-component-older",
+					gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+				},
+				Annotations: map[string]string{
+					gitops.BuildPipelineRunStartTime: "1703124000000",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				Application:    hasApp.Name,
+				ComponentGroup: hasCompGroup.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "test-component-older",
+						ContainerImage: sample_image + "@" + sampleDigest,
+					},
+				},
+			},
+		}
+
 		hasOverRideSnapshot = &applicationapiv1alpha1.Snapshot{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "snapshotpr-sample-override",
@@ -944,6 +970,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		err = k8sClient.Delete(ctx, hasOverRideSnapshot)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasOldSnapshot)
+		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+		err = k8sClient.Delete(ctx, hasNewerPushSnapshot)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, hasCompWithNewerBuild)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
@@ -1824,6 +1852,7 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		BeforeEach(func() {
 			hasOldSnapshot.Labels[gitops.SnapshotTypeLabel] = gitops.SnapshotComponentType
 			Expect(k8sClient.Create(ctx, hasOldSnapshot)).Should(Succeed())
+			Expect(k8sClient.Create(ctx, hasNewerPushSnapshot)).Should(Succeed())
 
 			err := gitops.MarkSnapshotAsPassed(ctx, k8sClient, hasOldSnapshot, "test passed")
 			Expect(err).To(Succeed())
@@ -1856,8 +1885,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Resource:   hasCompGroup,
 				},
 				{
-					ContextKey: loader.GetComponentContextKey,
-					Resource:   hasCompWithNewerBuild,
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{*hasNewerPushSnapshot},
 				},
 				{
 					ContextKey: loader.SnapshotContextKey,
@@ -1922,8 +1951,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Resource:   hasCompGroup,
 				},
 				{
-					ContextKey: loader.GetComponentContextKey,
-					Resource:   hasCompWithNewerBuild,
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{*hasNewerPushSnapshot},
 				},
 				{
 					ContextKey: loader.SnapshotContextKey,
@@ -1941,7 +1970,6 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			// Execute function under test
 			result, err := adapter.EnsureAllReleasesExist()
-			//Verify that the annotation exists
 
 			// Verify execution results
 			Expect(result.CancelRequest).To(BeFalse())
@@ -1994,8 +2022,8 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					Resource:   hasCompGroup,
 				},
 				{
-					ContextKey: loader.GetComponentContextKey,
-					Resource:   hasCompWithNewerBuild,
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{*hasNewerPushSnapshot},
 				},
 				{
 					ContextKey: loader.SnapshotContextKey,
@@ -2031,6 +2059,288 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			condition := meta.FindStatusCondition(hasOldSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
 			Expect(condition).ToNot(BeNil())
 			Expect(condition.Message).To(Equal("Released in newer Snapshot"))
+		})
+
+		It("ensures snapshot is NOT superseded when no newer push snapshots exist for the same component", func() {
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.HaveAppStudioTestsFinished(hasOldSnapshot) &&
+					gitops.HaveAppStudioTestsSucceeded(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			adapter = NewAdapter(ctx, hasOldSnapshot, hasCompGroup, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupContextKey,
+					Resource:   hasCompGroup,
+				},
+				{
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{},
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasOldSnapshot,
+				},
+				{
+					ContextKey: loader.AutoReleasePlansContextKey,
+					Resource:   []releasev1alpha1.ReleasePlan{*hasReleasePlan},
+				},
+				{
+					ContextKey: loader.ReleaseContextKey,
+					Resource:   &releasev1alpha1.Release{},
+				},
+			})
+
+			result, err := adapter.EnsureAllReleasesExist()
+
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.IsSnapshotMarkedAsAutoReleased(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			condition := meta.FindStatusCondition(hasOldSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
+		})
+
+		It("ensures snapshot is NOT superseded when sibling has an older timestamp", func() {
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.HaveAppStudioTestsFinished(hasOldSnapshot) &&
+					gitops.HaveAppStudioTestsSucceeded(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			olderSibling := applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "older-sibling-snap",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotComponentLabel:       "test-component-older",
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime: "1703122000000",
+					},
+				},
+			}
+
+			adapter = NewAdapter(ctx, hasOldSnapshot, hasCompGroup, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupContextKey,
+					Resource:   hasCompGroup,
+				},
+				{
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{olderSibling},
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasOldSnapshot,
+				},
+				{
+					ContextKey: loader.AutoReleasePlansContextKey,
+					Resource:   []releasev1alpha1.ReleasePlan{*hasReleasePlan},
+				},
+				{
+					ContextKey: loader.ReleaseContextKey,
+					Resource:   &releasev1alpha1.Release{},
+				},
+			})
+
+			result, err := adapter.EnsureAllReleasesExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.IsSnapshotMarkedAsAutoReleased(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			condition := meta.FindStatusCondition(hasOldSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
+		})
+
+		It("normalizes seconds to milliseconds: sibling in seconds that is genuinely newer supersedes", func() {
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.HaveAppStudioTestsFinished(hasOldSnapshot) &&
+					gitops.HaveAppStudioTestsSucceeded(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			// hasOldSnapshot has "1703123000000" (ms) = Unix second 1703123000.
+			// Sibling in SECONDS: 1703124000 → normalizes to 1703124000000 > 1703123000000.
+			newerSiblingInSeconds := applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "newer-sibling-seconds",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotComponentLabel:       "test-component-older",
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime: "1703124000",
+					},
+				},
+			}
+
+			adapter = NewAdapter(ctx, hasOldSnapshot, hasCompGroup, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupContextKey,
+					Resource:   hasCompGroup,
+				},
+				{
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{newerSiblingInSeconds},
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasOldSnapshot,
+				},
+				{
+					ContextKey: loader.AutoReleasePlansContextKey,
+					Resource:   []releasev1alpha1.ReleasePlan{*hasReleasePlan},
+				},
+			})
+
+			result, err := adapter.EnsureAllReleasesExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.IsSnapshotMarkedAsAutoReleased(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			condition := meta.FindStatusCondition(hasOldSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Message).To(Equal("Released in newer Snapshot"))
+		})
+
+		It("does not supersede itself when the candidate appears in the sibling list", func() {
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.HaveAppStudioTestsFinished(hasOldSnapshot) &&
+					gitops.HaveAppStudioTestsSucceeded(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			olderSibling := applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "older-sibling-for-self-skip",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotComponentLabel:       "test-component-older",
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime: "1703122000000",
+					},
+				},
+			}
+
+			selfCopy := *hasOldSnapshot
+			adapter = NewAdapter(ctx, hasOldSnapshot, hasCompGroup, log, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupContextKey,
+					Resource:   hasCompGroup,
+				},
+				{
+					ContextKey: loader.GetPushComponentSnapshotsForComponentContextKey,
+					Resource:   []applicationapiv1alpha1.Snapshot{selfCopy, olderSibling},
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasOldSnapshot,
+				},
+				{
+					ContextKey: loader.AutoReleasePlansContextKey,
+					Resource:   []releasev1alpha1.ReleasePlan{*hasReleasePlan},
+				},
+				{
+					ContextKey: loader.ReleaseContextKey,
+					Resource:   &releasev1alpha1.Release{},
+				},
+			})
+
+			result, err := adapter.EnsureAllReleasesExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return false
+				}
+				return gitops.IsSnapshotMarkedAsAutoReleased(hasOldSnapshot)
+			}, time.Second*10).Should(BeTrue())
+
+			condition := meta.FindStatusCondition(hasOldSnapshot.Status.Conditions, gitops.SnapshotAutoReleasedCondition)
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Message).To(Equal("The Snapshot was auto-released"))
 		})
 	})
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -80,6 +80,7 @@ type ObjectLoader interface {
 	GetResolutionRequest(ctx context.Context, c client.Client, namespace, name string) (resolutionv1beta1.ResolutionRequest, error)
 	GetPRComponentSnapshotsForComponentApplication(ctx context.Context, c client.Client, namespace, applicationName, componentName, prNumber string) (*[]applicationapiv1alpha1.Snapshot, error)
 	GetPRComponentSnapshotsForComponent(ctx context.Context, c client.Client, componentGroupNames []string, namespace, componentName, prNumber string) (*[]applicationapiv1alpha1.Snapshot, error)
+	GetPushComponentSnapshotsForComponent(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Snapshot, error)
 }
 
 type loader struct{}
@@ -901,6 +902,74 @@ func (l *loader) GetPRComponentSnapshotsForComponent(ctx context.Context, c clie
 		return nil, err
 	}
 	return &snapshots.Items, nil
+}
+
+// GetPushComponentSnapshotsForComponent returns all push component snapshots for the same component
+// as the given snapshot, scoped to the same application or component group.
+func (l *loader) GetPushComponentSnapshotsForComponent(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Snapshot, error) {
+	componentName := snapshot.Labels[gitops.SnapshotComponentLabel]
+	if componentName == "" {
+		empty := []applicationapiv1alpha1.Snapshot{}
+		return &empty, nil
+	}
+
+	componentLabelRequirement, err := labels.NewRequirement(
+		gitops.SnapshotComponentLabel, selection.In, []string{componentName})
+	if err != nil {
+		return nil, err
+	}
+	snapshotTypeLabelRequirement, err := labels.NewRequirement(
+		gitops.SnapshotTypeLabel, selection.In, []string{gitops.SnapshotComponentType})
+	if err != nil {
+		return nil, err
+	}
+
+	labelSelector := labels.NewSelector().
+		Add(*componentLabelRequirement).
+		Add(*snapshotTypeLabelRequirement)
+
+	appName := snapshot.Labels[gitops.ApplicationNameLabel]
+	cgName := snapshot.Labels[gitops.ComponentGroupNameLabel]
+
+	// TODO: remove application scoping when we remove old application-specific code
+	if appName != "" {
+		applicationLabelRequirement, err := labels.NewRequirement(
+			gitops.ApplicationNameLabel, selection.In, []string{appName})
+		if err != nil {
+			return nil, err
+		}
+		labelSelector = labelSelector.Add(*applicationLabelRequirement)
+	} else if cgName != "" {
+		componentGroupLabelRequirement, err := labels.NewRequirement(
+			gitops.ComponentGroupNameLabel, selection.In, []string{cgName})
+		if err != nil {
+			return nil, err
+		}
+		labelSelector = labelSelector.Add(*componentGroupLabelRequirement)
+	} else {
+		empty := []applicationapiv1alpha1.Snapshot{}
+		return &empty, nil
+	}
+
+	snapshotList := &applicationapiv1alpha1.SnapshotList{}
+	listOpts := &client.ListOptions{
+		Namespace:     snapshot.Namespace,
+		LabelSelector: labelSelector,
+	}
+
+	err = c.List(ctx, snapshotList, listOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	pushSnapshots := make([]applicationapiv1alpha1.Snapshot, 0, len(snapshotList.Items))
+	for i := range snapshotList.Items {
+		if gitops.IsSnapshotCreatedByPACPushEvent(&snapshotList.Items[i]) {
+			pushSnapshots = append(pushSnapshots, snapshotList.Items[i])
+		}
+	}
+
+	return &pushSnapshots, nil
 }
 
 // TODO: delete this function when we remove old application-specific code

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -73,6 +73,7 @@ const (
 	GetPRComponentSnapshotsForComponentContextKey
 	ComponentGroupsContextKey
 	RequiredIntegrationTestScenariosForSnapshotContextKey
+	GetPushComponentSnapshotsForComponentContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -410,5 +411,13 @@ func (l *mockLoader) GetPRComponentSnapshotsForComponentApplication(ctx context.
 		return l.loader.GetPRComponentSnapshotsForComponentApplication(ctx, c, namespace, applicationName, componentName, prNumber)
 	}
 	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPRComponentSnapshotsForComponentContextKey, []applicationapiv1alpha1.Snapshot{})
+	return &snapshots, err
+}
+
+func (l *mockLoader) GetPushComponentSnapshotsForComponent(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]applicationapiv1alpha1.Snapshot, error) {
+	if ctx.Value(GetPushComponentSnapshotsForComponentContextKey) == nil {
+		return l.loader.GetPushComponentSnapshotsForComponent(ctx, c, snapshot)
+	}
+	snapshots, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, GetPushComponentSnapshotsForComponentContextKey, []applicationapiv1alpha1.Snapshot{})
 	return &snapshots, err
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1330,4 +1330,193 @@ var _ = Describe("Loader", Ordered, func() {
 			Expect((*snapshots)[0].Spec).To(Equal(hasSnapshot.Spec))
 		})
 	})
+
+	When("GetPushComponentSnapshotsForComponent is called", func() {
+		const (
+			pushComp   = "push-test-component"
+			pushApp    = "push-test-app"
+			pushCGName = "push-test-cg"
+		)
+
+		var (
+			pushSnapApp      *applicationapiv1alpha1.Snapshot
+			pushSnapCG       *applicationapiv1alpha1.Snapshot
+			inputSnapApp     *applicationapiv1alpha1.Snapshot
+			inputSnapCG      *applicationapiv1alpha1.Snapshot
+			inputSnapNoComp  *applicationapiv1alpha1.Snapshot
+			inputSnapNoScope *applicationapiv1alpha1.Snapshot
+			pushCG           *v1beta2.ComponentGroup
+		)
+
+		BeforeAll(func() {
+			pushCG = &v1beta2.ComponentGroup{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      pushCGName,
+					Namespace: namespace,
+				},
+				Spec: v1beta2.ComponentGroupSpec{
+					Components: []v1beta2.ComponentReference{
+						{Name: pushComp, ComponentVersion: v1beta2.ComponentVersionReference{Name: "main"}},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pushCG)).Should(Succeed())
+
+			pushSnapApp = &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "push-snap-app",
+					Namespace: namespace,
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:       pushComp,
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.ApplicationNameLabel:         pushApp,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					Application: pushApp,
+					Components:  []applicationapiv1alpha1.SnapshotComponent{{Name: pushComp, ContainerImage: sample_image}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pushSnapApp)).Should(Succeed())
+
+			pushSnapCG = &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "push-snap-cg",
+					Namespace: namespace,
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:       pushComp,
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.ComponentGroupNameLabel:      pushCGName,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					ComponentGroup: pushCGName,
+					Components:     []applicationapiv1alpha1.SnapshotComponent{{Name: pushComp, ContainerImage: sample_image}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, pushSnapCG)).Should(Succeed())
+
+			inputSnapApp = &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "input-snap-app",
+					Namespace: namespace,
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:       pushComp,
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.ApplicationNameLabel:         pushApp,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					Application: pushApp,
+					Components:  []applicationapiv1alpha1.SnapshotComponent{{Name: pushComp, ContainerImage: sample_image}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, inputSnapApp)).Should(Succeed())
+
+			inputSnapCG = &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "input-snap-cg",
+					Namespace: namespace,
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:       pushComp,
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+						gitops.ComponentGroupNameLabel:      pushCGName,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					ComponentGroup: pushCGName,
+					Components:     []applicationapiv1alpha1.SnapshotComponent{{Name: pushComp, ContainerImage: sample_image}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, inputSnapCG)).Should(Succeed())
+
+			inputSnapNoComp = &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "input-snap-no-comp",
+					Namespace: namespace,
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:    gitops.SnapshotComponentType,
+						gitops.ApplicationNameLabel: pushApp,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					Application: pushApp,
+					Components:  []applicationapiv1alpha1.SnapshotComponent{{Name: pushComp, ContainerImage: sample_image}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, inputSnapNoComp)).Should(Succeed())
+
+			inputSnapNoScope = &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "input-snap-no-scope",
+					Namespace: namespace,
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:       pushComp,
+						gitops.PipelineAsCodeEventTypeLabel: gitops.PipelineAsCodePushType,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					Components: []applicationapiv1alpha1.SnapshotComponent{{Name: pushComp, ContainerImage: sample_image}},
+				},
+			}
+			Expect(k8sClient.Create(ctx, inputSnapNoScope)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, pushSnapApp)
+			_ = k8sClient.Delete(ctx, pushSnapCG)
+			_ = k8sClient.Delete(ctx, inputSnapApp)
+			_ = k8sClient.Delete(ctx, inputSnapCG)
+			_ = k8sClient.Delete(ctx, inputSnapNoComp)
+			_ = k8sClient.Delete(ctx, inputSnapNoScope)
+			_ = k8sClient.Delete(ctx, pushCG)
+		})
+
+		It("[APPLICATION] returns push component snapshots scoped by application", func() {
+			snapshots, err := loader.GetPushComponentSnapshotsForComponent(ctx, k8sClient, inputSnapApp)
+			Expect(err).To(Succeed())
+			Expect(snapshots).ToNot(BeNil())
+
+			names := make([]string, len(*snapshots))
+			for i, s := range *snapshots {
+				names[i] = s.Name
+			}
+			Expect(names).To(ContainElement(pushSnapApp.Name))
+			Expect(names).To(ContainElement(inputSnapApp.Name))
+			Expect(names).ToNot(ContainElement(pushSnapCG.Name))
+		})
+
+		It("returns push component snapshots scoped by component group", func() {
+			snapshots, err := loader.GetPushComponentSnapshotsForComponent(ctx, k8sClient, inputSnapCG)
+			Expect(err).To(Succeed())
+			Expect(snapshots).ToNot(BeNil())
+
+			names := make([]string, len(*snapshots))
+			for i, s := range *snapshots {
+				names[i] = s.Name
+			}
+			Expect(names).To(ContainElement(pushSnapCG.Name))
+			Expect(names).To(ContainElement(inputSnapCG.Name))
+			Expect(names).ToNot(ContainElement(pushSnapApp.Name))
+		})
+
+		It("returns empty non-nil slice when snapshot has no SnapshotComponentLabel", func() {
+			snapshots, err := loader.GetPushComponentSnapshotsForComponent(ctx, k8sClient, inputSnapNoComp)
+			Expect(err).To(Succeed())
+			Expect(snapshots).ToNot(BeNil())
+			Expect(*snapshots).To(BeEmpty())
+		})
+
+		It("returns empty non-nil slice when snapshot has neither application nor component-group label", func() {
+			snapshots, err := loader.GetPushComponentSnapshotsForComponent(ctx, k8sClient, inputSnapNoScope)
+			Expect(err).To(Succeed())
+			Expect(snapshots).ToNot(BeNil())
+			Expect(*snapshots).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
Replace annotation-based supersession check with a a snapshot query that finds newer push component snapshots for the same component preventing incorrect supersession in single-component release mode.

Assisted-by: Claude Opus 4.6 
