### PR TITLE
fix(KONFLUX-141173): remove footnotes on git reporters

### DIFF
--- a/status/format.go
+++ b/status/format.go
@@ -51,7 +51,6 @@ const summaryTemplate = `
 | <a href="{{ formatTaskLogURL $tr $pipelineRunName $namespace $logger }}">{{ formatTaskName $tr }}</a> | {{ $tr.GetDuration.String }} | {{ formatNamespace $tr }} | {{ formatStatus $tr }} | {{ formatDetails $tr }} | {{ formatNote $tr }} |
 {{- end }}
 
-{{ formatFootnotes .TaskRuns }}
 {{ if .ComponentSnapshotInfos}}
 The group snapshot is generated for pr group {{ .PRGroup }} and the component snasphots as below:
 | Component | Snapshot | BuildPipelineRun | PullRequest |
@@ -103,7 +102,6 @@ func FormatTestsSummary(taskRuns []*helpers.TaskRun, pipelineRunName string, nam
 		"formatNote":           FormatNote,
 		"formatPipelineURL":    FormatPipelineURL,
 		"formatTaskLogURL":     FormatTaskLogURL,
-		"formatFootnotes":      FormatFootnotes,
 		"formatPullRequestURL": FormatPullRequestURL,
 		"formatRepoURL":        FormatRepoURL,
 	}
@@ -123,7 +121,6 @@ func FormatShortTestsSummary(pipelineRunName string, namespace string, component
 		"formatStatus":         FormatStatus,
 		"formatDetails":        FormatDetails,
 		"formatPipelineURL":    FormatPipelineURL,
-		"formatFootnotes":      FormatFootnotes,
 		"formatPullRequestURL": FormatPullRequestURL,
 		"formatRepoURL":        FormatRepoURL,
 	}
@@ -197,24 +194,9 @@ func FormatStatus(taskRun *helpers.TaskRun) (string, error) {
 	return emoji + " " + result.TestOutput.Result, nil
 }
 
-// FormatTaskName accepts a TaskRun and returns a Markdown friendly representation of its name.
+// FormatTaskName accepts a TaskRun and returns its name.
 func FormatTaskName(taskRun *helpers.TaskRun) (string, error) {
-	result, err := taskRun.GetTestResult()
-	if err != nil {
-		return "", err
-	}
-
-	name := taskRun.GetPipelineTaskName()
-
-	if result == nil || result.TestOutput == nil {
-		return name, nil
-	}
-
-	if result.TestOutput.Note == "" {
-		return name, nil
-	}
-
-	return name + "[^" + name + "]", nil
+	return taskRun.GetPipelineTaskName(), nil
 }
 
 // FormatNamespace accepts a TaskRun and returns a Markdown friendly representation of its test suite, if any.
@@ -283,26 +265,6 @@ func FormatNote(taskRun *helpers.TaskRun) (string, error) {
 	}
 
 	return result.TestOutput.Note, nil
-}
-
-// FormatResults accepts a list of TaskRuns and returns a Markdown friendly representation of their footnotes, if any.
-func FormatFootnotes(taskRuns []*helpers.TaskRun) (string, error) {
-	footnotes := []string{}
-	for _, tr := range taskRuns {
-		result, err := tr.GetTestResult()
-		if err != nil {
-			return "", err
-		}
-
-		if result == nil || result.TestOutput == nil {
-			continue
-		}
-
-		if result.TestOutput.Note != "" {
-			footnotes = append(footnotes, "[^"+tr.GetPipelineTaskName()+"]: "+result.TestOutput.Note)
-		}
-	}
-	return strings.Join(footnotes, "\n"), nil
 }
 
 // Console URL env vars (CONSOLE_URL, CONSOLE_URL_TASKLOG) use literal placeholder substitution only.

--- a/status/format_test.go
+++ b/status/format_test.go
@@ -41,13 +41,11 @@ const expectedSummary = `<ul>
 | --- | --- | --- | --- | --- | --- |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-1">example-task-1</a> | 5m30s | example-namespace-1 | :heavy_check_mark: SUCCESS | :heavy_check_mark: 2 success(es)<br>:warning: 1 warning(s) |  |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-2">example-task-2</a> | 2m0s |  | :heavy_check_mark: Reason: Succeeded | :heavy_check_mark: Reason: Succeeded |  |
-| <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-3">example-task-3[^example-task-3]</a> | 1s | example-namespace-3 | :x: FAILURE | :x: 1 failure(s) | example note 3 |
-| <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-4">example-task-4[^example-task-4]</a> | 1s | example-namespace-4 | :warning: WARNING | :warning: 1 warning(s) | example note 4 |
+| <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-3">example-task-3</a> | 1s | example-namespace-3 | :x: FAILURE | :x: 1 failure(s) | example note 3 |
+| <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-4">example-task-4</a> | 1s | example-namespace-4 | :warning: WARNING | :warning: 1 warning(s) | example note 4 |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-5">example-task-5</a> | 5m0s | example-namespace-5 | :white_check_mark: SKIPPED |  |  |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-6">example-task-6</a> | 1s | example-namespace-6 | :heavy_exclamation_mark: ERROR |  |  |
 
-[^example-task-3]: example note 3
-[^example-task-4]: example note 4
 `
 
 const expectedTaskLogURL = `https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/pipelinerun-component-sample/logs/example-task-1`

--- a/status/status_test.go
+++ b/status/status_test.go
@@ -715,7 +715,6 @@ var _ = Describe("Status Adapter", func() {
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun/logs/pipeline1-task1">pipeline1-task1</a> | 5m0s |  | :heavy_check_mark: SUCCESS | :heavy_check_mark: 10 success(es) |  |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun/logs/pipeline1-task2">pipeline1-task2</a> | 5m0s |  | :white_check_mark: SKIPPED |  |  |
 
-
 `
 		expectedTestReport := status.TestReport{
 			FullName:            "Red Hat Konflux / scenario1 / component-sample",
@@ -753,7 +752,6 @@ var _ = Describe("Status Adapter", func() {
 | Task | Duration | Test Suite | Status | Details | Note |
 | --- | --- | --- | --- | --- | --- |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun-warning/logs/pipeline2-task1">pipeline2-task1</a> | 5m0s |  | :warning: WARNING | :heavy_check_mark: 10 success(es)<br>:warning: 1 warning(s) |  |
-
 
 `
 		expectedTestReport := status.TestReport{
@@ -793,7 +791,6 @@ var _ = Describe("Status Adapter", func() {
 | --- | --- | --- | --- | --- | --- |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun/logs/pipeline1-task1">pipeline1-task1</a> | 5m0s |  | :heavy_check_mark: SUCCESS | :heavy_check_mark: 10 success(es) |  |
 | <a href="https://definetly.not.prod/preview/application-pipeline/ns/default/pipelinerun/test-pipelinerun/logs/pipeline1-task2">pipeline1-task2</a> | 5m0s |  | :white_check_mark: SKIPPED |  |  |
-
 
 `
 		expectedTestReport := status.TestReport{


### PR DESCRIPTION
 - notes column now displays TEST_OUTPUT.note
 - footnotes are now duplicating this data
 - footnotes are misleading in some git reporters
 - removing them as they are no longer required

assisted by ai: Cursor

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
