### PR TITLE
chore: standardize codecov coverage config

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,24 +1,28 @@
-# Documentation: https://docs.codecov.io/docs/codecov-yaml
+codecov:
+  require_ci_to_pass: false
+
 ignore:
-  - "api/v1alpha1/zz_generated.deepcopy.go" # generated file
-  - "api/v1beta1/zz_generated.deepcopy.go" # generated file
-  - "api/v1beta2/zz_generated.deepcopy.go" # generated file
-  - "gitops/integrationteststatus_enumer.go" # generated file
-  - "status/mock_reporter.go" # generated file
-  - "status/mock_status.go" # generated file
-  - "e2e-tests/**" # integration tests
-  - "vendor/**" # vendor files
+  - "api/v1alpha1/zz_generated.deepcopy.go"
+  - "api/v1beta1/zz_generated.deepcopy.go"
+  - "api/v1beta2/zz_generated.deepcopy.go"
+  - "gitops/integrationteststatus_enumer.go"
+  - "status/mock_reporter.go"
+  - "status/mock_status.go"
+  - "e2e-tests/**"
+  - "vendor/**"
 
 coverage:
-    status:
-        # Allows coverage to drop by a 3% when compared against the base commit.
-        project:
-            default:
-                target: auto
-                # this allows a 3% drop from the previous base commit coverage
-                threshold: 3%
-        # Sets the expected status for `codecov/patch` check.
-        # We set this to be only informational hence it does not cause the check to fail.
-        patch:
-            default:
-                informational: true
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        informational: true
+    patch:
+      default:
+        target: 80%
+        informational: true
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  require_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,23 +1,27 @@
+# Documentation: https://docs.codecov.io/docs/codecov-yaml
 codecov:
   require_ci_to_pass: false
 
 ignore:
-  - "api/v1alpha1/zz_generated.deepcopy.go"
-  - "api/v1beta1/zz_generated.deepcopy.go"
-  - "api/v1beta2/zz_generated.deepcopy.go"
-  - "gitops/integrationteststatus_enumer.go"
-  - "status/mock_reporter.go"
-  - "status/mock_status.go"
-  - "e2e-tests/**"
-  - "vendor/**"
+  - "api/v1alpha1/zz_generated.deepcopy.go" # generated file
+  - "api/v1beta1/zz_generated.deepcopy.go" # generated file
+  - "api/v1beta2/zz_generated.deepcopy.go" # generated file
+  - "gitops/integrationteststatus_enumer.go" # generated file
+  - "status/mock_reporter.go" # generated file
+  - "status/mock_status.go" # generated file
+  - "e2e-tests/**" # integration tests
+  - "vendor/**" # vendor files
 
 coverage:
   status:
+    # Allows coverage to drop by a 3% when compared against the base commit.
     project:
       default:
         target: auto
         threshold: 1%
         informational: true
+    # Sets the expected status for `codecov/patch` check.
+    # We set this to be only informational hence it does not cause the check to fail.
     patch:
       default:
         target: 80%


### PR DESCRIPTION
## Summary

Updates codecov configuration to Konflux standard:
- CI gate disabled (`require_ci_to_pass: false`)
- Patch coverage target: 80% (informational - won't block CI)
- Project coverage target: auto with 1% threshold (informational)
- Comment only on coverage changes

### Why 80% patch target?

The 80% patch coverage target is an org-wide standard being rolled out across all konflux-ci repositories as part of [KFLUXDP-1020](https://redhat.atlassian.net/browse/KFLUXDP-1020). It is set to `informational: true`, meaning it will **never block CI or prevent merging** — it only provides visibility into coverage trends on new/changed code. Teams can adjust the target in future PRs if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[KFLUXDP-1020]: https://redhat.atlassian.net/browse/KFLUXDP-1020?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ