### PR TITLE
feat(STONEINTG-1660): add ValidatingWebhook for NudgeConfig cycle detection

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -186,6 +186,10 @@ func main() {
 		setupLog.Error(err, "unable to create webhook", "webhook", "Snapshot")
 		os.Exit(1)
 	}
+	if err = iswebhook.SetupNudgeConfigWebhookWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create webhook", "webhook", "NudgeConfig")
+		os.Exit(1)
+	}
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -98,6 +98,26 @@ webhooks:
     service:
       name: webhook-service
       namespace: system
+      path: /validate-appstudio-redhat-com-v1beta2-nudgeconfig
+  failurePolicy: Fail
+  name: vnudgeconfig.kb.io
+  rules:
+  - apiGroups:
+    - appstudio.redhat.com
+    apiVersions:
+    - v1beta2
+    operations:
+    - CREATE
+    - UPDATE
+    resources:
+    - nudgeconfigs
+  sideEffects: None
+- admissionReviewVersions:
+  - v1
+  clientConfig:
+    service:
+      name: webhook-service
+      namespace: system
       path: /validate-appstudio-redhat-com-v1alpha1-snapshot
   failurePolicy: Ignore
   name: vsnapshot.kb.io

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -47,6 +47,26 @@ metadata:
   labels:
     {{- include "chart.labels" . | nindent 4 }}
 webhooks:
+  - name: vnudgeconfig.kb.io
+    clientConfig:
+      service:
+        name: integration-service-webhook-service
+        namespace: {{ .Values.namespace | default .Release.Namespace }}
+        path: /validate-appstudio-redhat-com-v1beta2-nudgeconfig
+    failurePolicy: Fail
+    sideEffects: None
+    admissionReviewVersions:
+      - v1
+    rules:
+      - operations:
+          - CREATE
+          - UPDATE
+        apiGroups:
+          - appstudio.redhat.com
+        apiVersions:
+          - v1beta2
+        resources:
+          - nudgeconfigs
   - name: vcomponentgroup.kb.io
     clientConfig:
       service:

--- a/internal/webhook/v1beta2/nudgeconfig_webhook.go
+++ b/internal/webhook/v1beta2/nudgeconfig_webhook.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/pkg/dag"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+// nolint:unused
+var nudgeconfiglog = logf.Log.WithName("nudgeconfig-webhook")
+
+func SetupNudgeConfigWebhookWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewWebhookManagedBy(mgr).
+		For(&v1beta2.NudgeConfig{}).
+		WithValidator(&NudgeConfigCustomValidator{Client: mgr.GetClient()}).
+		Complete()
+}
+
+// NudgeConfigCustomValidator is a webhook handler and does not need deepcopy methods. (validator = validating webhook)
+// +k8s:deepcopy-gen=false
+type NudgeConfigCustomValidator struct {
+	Client client.Client
+}
+
+// +kubebuilder:webhook:path=/validate-appstudio-redhat-com-v1beta2-nudgeconfig,mutating=false,failurePolicy=fail,sideEffects=None,groups=appstudio.redhat.com,resources=nudgeconfigs,verbs=create;update,versions=v1beta2,name=vnudgeconfig.kb.io,admissionReviewVersions=v1
+
+var _ webhook.CustomValidator = &NudgeConfigCustomValidator{}
+
+func (v *NudgeConfigCustomValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	nudgeConfig, ok := obj.(*v1beta2.NudgeConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a NudgeConfig object but got %T", obj)
+	}
+
+	nudgeconfiglog.Info("Validating NudgeConfig upon creation", "name", nudgeConfig.Name)
+
+	if len(nudgeConfig.Spec.Nudges) > 0 {
+		if err := dag.ValidateNudgeGraph(nudgeConfig.Spec.Nudges); err != nil {
+			return nil, fmt.Errorf("error validating nudge graph: %v", err)
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *NudgeConfigCustomValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	oldNudgeConfig, ok := oldObj.(*v1beta2.NudgeConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a NudgeConfig for oldObj but got %T", oldObj)
+	}
+	newNudgeConfig, ok := newObj.(*v1beta2.NudgeConfig)
+	if !ok {
+		return nil, fmt.Errorf("expected a NudgeConfig for newObj but got %T", newObj)
+	}
+
+	nudgeconfiglog.Info("Validating NudgeConfig upon update", "name", newNudgeConfig.Name)
+
+	if !reflect.DeepEqual(oldNudgeConfig.Spec.Nudges, newNudgeConfig.Spec.Nudges) {
+		if len(newNudgeConfig.Spec.Nudges) > 0 {
+			if err := dag.ValidateNudgeGraph(newNudgeConfig.Spec.Nudges); err != nil {
+				return nil, fmt.Errorf("error validating nudge graph: %v", err)
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func (v *NudgeConfigCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}

--- a/internal/webhook/v1beta2/nudgeconfig_webhook_test.go
+++ b/internal/webhook/v1beta2/nudgeconfig_webhook_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta2
+
+import (
+	appstudiov1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("NudgeConfig webhook", Ordered, func() {
+	var (
+		validator   *NudgeConfigCustomValidator
+		nudgeConfig *appstudiov1beta2.NudgeConfig
+	)
+
+	BeforeEach(func() {
+		validator = &NudgeConfigCustomValidator{Client: k8sClient}
+		nudgeConfig = &appstudiov1beta2.NudgeConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      appstudiov1beta2.NudgeConfigSingletonName,
+				Namespace: "default",
+			},
+			Spec: appstudiov1beta2.NudgeConfigSpec{},
+		}
+	})
+
+	When("a NudgeConfig is created", func() {
+		It("accepts a valid linear chain", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "component-a", To: "component-b"},
+				{From: "component-b", To: "component-c"},
+				{From: "component-c", To: "component-d"},
+			}
+			warnings, err := validator.ValidateCreate(ctx, nudgeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("accepts a valid DAG with multiple paths", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "a", To: "b"},
+				{From: "a", To: "c"},
+				{From: "b", To: "d"},
+				{From: "c", To: "d"},
+			}
+			warnings, err := validator.ValidateCreate(ctx, nudgeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("accepts empty nudges", func() {
+			nudgeConfig.Spec.Nudges = nil
+			warnings, err := validator.ValidateCreate(ctx, nudgeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("rejects a direct cycle", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "component-a", To: "component-b"},
+				{From: "component-b", To: "component-a"},
+			}
+			_, err := validator.ValidateCreate(ctx, nudgeConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cycle detected"))
+			Expect(err.Error()).To(ContainSubstring("component-a"))
+			Expect(err.Error()).To(ContainSubstring("component-b"))
+		})
+
+		It("rejects a transitive 3-node cycle", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "component-a", To: "component-b"},
+				{From: "component-b", To: "component-c"},
+				{From: "component-c", To: "component-a"},
+			}
+			_, err := validator.ValidateCreate(ctx, nudgeConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cycle detected"))
+			Expect(err.Error()).To(ContainSubstring("component-a"))
+			Expect(err.Error()).To(ContainSubstring("component-b"))
+			Expect(err.Error()).To(ContainSubstring("component-c"))
+		})
+
+		It("handles self-nudge gracefully", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "component-a", To: "component-a"},
+			}
+			_, err := validator.ValidateCreate(ctx, nudgeConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cycle detected: component-a -> component-a"))
+		})
+
+		It("returns an error for a wrong object type", func() {
+			wrongObj := &appstudiov1beta2.ComponentGroup{}
+			_, err := validator.ValidateCreate(ctx, wrongObj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a NudgeConfig"))
+		})
+	})
+
+	When("a NudgeConfig is updated", func() {
+		It("rejects an update that introduces a cycle", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "a", To: "b"},
+			}
+
+			newNudgeConfig := nudgeConfig.DeepCopy()
+			newNudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "a", To: "b"},
+				{From: "b", To: "a"},
+			}
+			_, err := validator.ValidateUpdate(ctx, nudgeConfig, newNudgeConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cycle detected"))
+		})
+
+		It("skips validation when nudges are unchanged", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "a", To: "b"},
+			}
+			sameCopy := nudgeConfig.DeepCopy()
+			warnings, err := validator.ValidateUpdate(ctx, nudgeConfig, sameCopy)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("accepts valid nudge changes", func() {
+			nudgeConfig.Spec.Nudges = []appstudiov1beta2.NudgeRelationship{
+				{From: "a", To: "b"},
+			}
+			newNudgeConfig := nudgeConfig.DeepCopy()
+			newNudgeConfig.Spec.Nudges = append(newNudgeConfig.Spec.Nudges,
+				appstudiov1beta2.NudgeRelationship{From: "b", To: "c"},
+			)
+			warnings, err := validator.ValidateUpdate(ctx, nudgeConfig, newNudgeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+
+		It("returns an error for wrong oldObj type", func() {
+			wrongObj := &appstudiov1beta2.ComponentGroup{}
+			_, err := validator.ValidateUpdate(ctx, wrongObj, nudgeConfig)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a NudgeConfig"))
+		})
+
+		It("returns an error for wrong newObj type", func() {
+			wrongObj := &appstudiov1beta2.ComponentGroup{}
+			_, err := validator.ValidateUpdate(ctx, nudgeConfig, wrongObj)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected a NudgeConfig"))
+		})
+	})
+
+	When("a NudgeConfig is deleted", func() {
+		It("always succeeds", func() {
+			warnings, err := validator.ValidateDelete(ctx, nudgeConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(warnings).To(BeEmpty())
+		})
+	})
+})

--- a/internal/webhook/v1beta2/webhook_suite_test.go
+++ b/internal/webhook/v1beta2/webhook_suite_test.go
@@ -146,6 +146,9 @@ var _ = BeforeSuite(func() {
 	err = SetupSnapshotWebhookWithManager(mgr)
 	Expect(err).NotTo(HaveOccurred())
 
+	err = SetupNudgeConfigWebhookWithManager(mgr)
+	Expect(err).NotTo(HaveOccurred())
+
 	// +kubebuilder:scaffold:webhook
 
 	go func() {

--- a/pkg/dag/verify.go
+++ b/pkg/dag/verify.go
@@ -19,6 +19,9 @@ package dag
 import (
 	"fmt"
 	"maps"
+	"slices"
+	"sort"
+	"strings"
 
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 )
@@ -73,55 +76,114 @@ func ValidateTestGraph(testGraph map[string][]v1beta2.TestGraphNode, scenarios .
 		}
 	}
 
-	// We're technically checking a reversed version of the graph. Reversing
-	// the graph preserves all cycles so this is acceptable
-	if err := checkGraphForCycles(graphCopy); err != nil {
+	adj := make(map[string][]string, len(graphCopy))
+	for node, parents := range graphCopy {
+		for _, p := range parents {
+			adj[node] = append(adj[node], p.Name)
+		}
+		if _, ok := adj[node]; !ok {
+			adj[node] = nil
+		}
+	}
+
+	if err := checkGraphForCycles(adj); err != nil {
 		return fmt.Errorf("invalid TestGraph - cycle detected: %w", err)
 	}
 	return nil
 }
 
-// checkGraphForCycles uses Kahn's algorithm on the reversed dependency graph to
-// detect cycles.  The testGraph maps each scenario name to the list of parent
-// scenarios it depends on (parents must finish before the keyed scenario starts).
-func checkGraphForCycles(testGraph map[string][]v1beta2.TestGraphNode) error {
-	// indegrees[x] = number of nodes that list x as a parent (i.e. x's child count).
-	indegrees := make(map[string]int)
-	var res []string
+// ValidateNudgeGraph checks that the nudge relationships form a DAG (no cycles).
+func ValidateNudgeGraph(nudges []v1beta2.NudgeRelationship) error {
+	if len(nudges) == 0 {
+		return nil
+	}
 
-	for _, parentNodes := range testGraph {
-		for _, parentNode := range parentNodes {
-			indegrees[parentNode.Name]++
+	adj := make(map[string][]string)
+	for _, n := range nudges {
+		adj[n.From] = append(adj[n.From], n.To)
+		if _, ok := adj[n.To]; !ok {
+			adj[n.To] = nil
 		}
 	}
 
-	// Seed the queue with nodes that have no children (nobody depends on them).
-	var queue []string
-	for node := range testGraph {
-		if indegrees[node] == 0 {
-			queue = append(queue, node)
-			res = append(res, node)
+	if err := checkGraphForCycles(adj); err != nil {
+		return fmt.Errorf("invalid NudgeGraph - cycle detected: %w", err)
+	}
+	return nil
+}
+
+// checkGraphForCycles uses depth-first search (DFS) to detect cycles in a directed graph represented
+// as an adjacency list. Returns an error containing the cycle path if found.
+func checkGraphForCycles(adj map[string][]string) error {
+	if cycle, found := findCycleInAdjacencyList(adj); found {
+		return fmt.Errorf("%s", formatCyclePath(cycle))
+	}
+	return nil
+}
+
+const (
+	colorWhite = 0 // unvisited
+	colorGray  = 1 // in current DFS path
+	colorBlack = 2 // fully processed
+)
+
+// findCycleInAdjacencyList performs DFS to detect cycles and returns the cycle path.
+func findCycleInAdjacencyList(adj map[string][]string) ([]string, bool) {
+	color := make(map[string]int, len(adj))
+	parent := make(map[string]string, len(adj))
+
+	nodes := make([]string, 0, len(adj))
+	for node := range adj {
+		nodes = append(nodes, node)
+	}
+	sort.Strings(nodes)
+
+	for _, node := range nodes {
+		if color[node] == colorWhite {
+			if cycle, found := dfsVisit(node, adj, color, parent); found {
+				return cycle, true
+			}
 		}
 	}
+	return nil, false
+}
 
-	// BFS: for each childless node, decrement its parents' child-counts; enqueue
-	// any parent that reaches zero.
-	for len(queue) > 0 {
-		node := queue[0]
-		queue = queue[1:]
-		for _, parentNode := range testGraph[node] {
-			indegrees[parentNode.Name]--
-			if indegrees[parentNode.Name] == 0 {
-				queue = append(queue, parentNode.Name)
-				res = append(res, parentNode.Name)
+func dfsVisit(node string, adj map[string][]string, color map[string]int, parent map[string]string) ([]string, bool) {
+	color[node] = colorGray
+
+	neighbors := slices.Clone(adj[node])
+	sort.Strings(neighbors)
+
+	for _, next := range neighbors {
+		if color[next] == colorGray {
+			return traceCycle(node, next, parent), true
+		}
+		if color[next] == colorWhite {
+			parent[next] = node
+			if cycle, found := dfsVisit(next, adj, color, parent); found {
+				return cycle, true
 			}
 		}
 	}
 
-	switch {
-	case len(res) < len(testGraph):
-		return fmt.Errorf("cycles found in graph; remaining indegrees: %+v", indegrees)
-	default:
-		return nil
+	color[node] = colorBlack
+	return nil, false
+}
+
+func traceCycle(from, to string, parent map[string]string) []string {
+	// to is the node we found again (back-edge target), from is the current node.
+	// Walk parent chain from `from` back to `to` to reconstruct the cycle.
+	var path []string
+	cur := from
+	for cur != to {
+		path = append([]string{cur}, path...)
+		cur = parent[cur]
 	}
+	path = append([]string{to}, path...)
+	path = append(path, to)
+	return path
+}
+
+func formatCyclePath(path []string) string {
+	return strings.Join(path, " -> ")
 }

--- a/pkg/dag/verify_test.go
+++ b/pkg/dag/verify_test.go
@@ -25,11 +25,10 @@ import (
 
 var _ = Describe("DAG library unittests", Ordered, func() {
 	var (
-		//integrationTestScenario *v1beta2.IntegrationTestScenario
 		testGraphWithoutCycles map[string][]v1beta2.TestGraphNode
 		testGraphWithCycles    map[string][]v1beta2.TestGraphNode
 	)
-	Context("Checking graph for cycles", func() {
+	Context("Checking graph for cycles via ValidateTestGraph", func() {
 		BeforeAll(func() {
 			// Create testGraph with no cycles
 			//    A   E
@@ -60,16 +59,106 @@ var _ = Describe("DAG library unittests", Ordered, func() {
 
 		When("A Graph without cycles is checked", func() {
 			It("Returns no error", func() {
-				err := checkGraphForCycles(testGraphWithoutCycles)
+				err := ValidateTestGraph(testGraphWithoutCycles)
 				Expect(err).NotTo(HaveOccurred())
 			})
 		})
 
 		When("A Graph with cycles is checked", func() {
-			It("Returns no error", func() {
-				err := checkGraphForCycles(testGraphWithCycles)
+			It("Returns an error with the cycle path", func() {
+				err := ValidateTestGraph(testGraphWithCycles)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("cycles found in graph"))
+				Expect(err.Error()).To(ContainSubstring("invalid TestGraph - cycle detected"))
+				Expect(err.Error()).To(ContainSubstring("scenarioC"))
+				Expect(err.Error()).To(ContainSubstring("scenarioE"))
+			})
+		})
+	})
+
+	Context("Shared checkGraphForCycles", func() {
+		When("the graph is a valid linear chain", func() {
+			It("returns no error", func() {
+				adj := map[string][]string{
+					"a": {"b"},
+					"b": {"c"},
+					"c": {"d"},
+					"d": nil,
+				}
+				Expect(checkGraphForCycles(adj)).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the graph is a valid DAG with diamond shape", func() {
+			It("returns no error", func() {
+				adj := map[string][]string{
+					"a": {"b", "c"},
+					"b": {"d"},
+					"c": {"d"},
+					"d": nil,
+				}
+				Expect(checkGraphForCycles(adj)).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the graph has a direct cycle", func() {
+			It("returns the cycle path", func() {
+				adj := map[string][]string{
+					"a": {"b"},
+					"b": {"a"},
+				}
+				err := checkGraphForCycles(adj)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("a"))
+				Expect(err.Error()).To(ContainSubstring("b"))
+			})
+		})
+
+		When("the graph has a transitive 3-node cycle", func() {
+			It("returns the full cycle path", func() {
+				adj := map[string][]string{
+					"a": {"b"},
+					"b": {"c"},
+					"c": {"a"},
+				}
+				err := checkGraphForCycles(adj)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("a"))
+				Expect(err.Error()).To(ContainSubstring("b"))
+				Expect(err.Error()).To(ContainSubstring("c"))
+			})
+		})
+
+		When("the graph has a self-loop", func() {
+			It("returns the self-loop as a cycle", func() {
+				adj := map[string][]string{
+					"a": {"a"},
+				}
+				err := checkGraphForCycles(adj)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(Equal("a -> a"))
+			})
+		})
+
+		When("the graph is empty", func() {
+			It("returns no error", func() {
+				Expect(checkGraphForCycles(map[string][]string{})).NotTo(HaveOccurred())
+			})
+		})
+
+		When("the graph is disconnected with a cycle in one component", func() {
+			It("detects the cycle and reports the cycle path", func() {
+				adj := map[string][]string{
+					"e": {"f"},
+					"f": nil,
+					"a": {"b"},
+					"b": {"c"},
+					"c": {"a"},
+				}
+				err := checkGraphForCycles(adj)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("a"))
+				Expect(err.Error()).To(ContainSubstring("b"))
+				Expect(err.Error()).To(ContainSubstring("c"))
 			})
 		})
 	})
@@ -81,3 +170,63 @@ func createTestGraphNodesForScenarios(scenarioNames []string) (nodes []v1beta2.T
 	}
 	return
 }
+
+var _ = Describe("Nudge graph cycle detection", func() {
+	Context("ValidateNudgeGraph", func() {
+		When("nudges form a valid chain", func() {
+			It("returns no error", func() {
+				nudges := []v1beta2.NudgeRelationship{
+					{From: "a", To: "b"},
+					{From: "b", To: "c"},
+				}
+				Expect(ValidateNudgeGraph(nudges)).NotTo(HaveOccurred())
+			})
+		})
+
+		When("nudges form a cycle", func() {
+			It("returns an error with the cycle path", func() {
+				nudges := []v1beta2.NudgeRelationship{
+					{From: "a", To: "b"},
+					{From: "b", To: "c"},
+					{From: "c", To: "a"},
+				}
+				err := ValidateNudgeGraph(nudges)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid NudgeGraph - cycle detected"))
+				Expect(err.Error()).To(ContainSubstring("a"))
+				Expect(err.Error()).To(ContainSubstring("b"))
+				Expect(err.Error()).To(ContainSubstring("c"))
+			})
+		})
+
+		When("nudges list is empty", func() {
+			It("returns no error", func() {
+				Expect(ValidateNudgeGraph(nil)).NotTo(HaveOccurred())
+				Expect(ValidateNudgeGraph([]v1beta2.NudgeRelationship{})).NotTo(HaveOccurred())
+			})
+		})
+
+		When("a self-nudge is present", func() {
+			It("detects it as a cycle without panicking", func() {
+				nudges := []v1beta2.NudgeRelationship{
+					{From: "a", To: "a"},
+				}
+				err := ValidateNudgeGraph(nudges)
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("invalid NudgeGraph - cycle detected: a -> a"))
+			})
+		})
+
+		When("nudges form a valid DAG with multiple paths", func() {
+			It("returns no error", func() {
+				nudges := []v1beta2.NudgeRelationship{
+					{From: "a", To: "b"},
+					{From: "a", To: "c"},
+					{From: "b", To: "d"},
+					{From: "c", To: "d"},
+				}
+				Expect(ValidateNudgeGraph(nudges)).NotTo(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
  What
  
  Adds a ValidatingWebhook (failurePolicy: Fail) that rejects NudgeConfig CREATE/UPDATE operations when spec.nudges contains a cycle.

  Why

  CEL validation (from STONEINTG-1659) handles self-nudges and duplicate pairs, but cannot perform transitive graph traversal due to API server cost budget limits. A webhook is needed to catch cycles like
  A→B→C→A at admission time.

  How

  - Cycle detection (pkg/dag/verify.go): DFS with three-color marking on the nudge edge list. Reports the full cycle path in the error message (e.g. "cycle detected: a -> b -> c -> a"). Existing
  ValidateTestGraph/checkGraphForCycles are untouched.
  - Webhook (internal/webhook/v1beta2/nudgeconfig_webhook.go): Validates on CREATE and UPDATE (skips if nudges unchanged). Follows the same pattern as the ComponentGroup webhook.
  - Registration: Added to cmd/main.go and webhook test suite.

  Tests

  - 12 DAG unit tests: linear chain, diamond DAG, direct cycle, transitive cycle, self-loop, empty, disconnected graph
  - 12 webhook tests: valid/invalid creates, updates introducing cycles, unchanged updates, delete no-op, wrong type assertions


NOTE:  This PR can be merged only after [PR#1591](https://github.com/konflux-ci/integration-service/pull/1591)
