### PR TITLE
feat(STONEINTG-1668): create konflux-integration-runner SA if missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The service handles the complete lifecycle of integration testing including grou
 
 ## Architecture
 
-The Integration Service consists of six main controllers:
+The Integration Service consists of seven main controllers:
 
 ### Build Pipeline Controller
 
@@ -51,6 +51,13 @@ Monitors Snapshot CRs and manages the following:
 ### ComponentGroup Controller
 
 Ensures that the ComponentGroup/s Global Candidate List is aligned with its component list.
+
+### Scenario Controller
+
+Monitors IntegrationTestScenario CRs and manages the following:
+- Ensures the `konflux-integration-runner` ServiceAccount exists in the namespace
+- Ensures the `components-namespace-pull` image pull secret exists and is linked to the ServiceAccount
+- Ensures the RoleBinding for the ServiceAccount to the `konflux-integration-runner` ClusterRole exists
 
 ### Component Controller
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -9,9 +9,18 @@ rules:
   resources:
   - secrets
   verbs:
+  - create
   - get
   - list
   - watch
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - create
+  - get
+  - update
 - apiGroups:
   - appstudio.redhat.com
   resources:
@@ -84,6 +93,13 @@ rules:
   - get
   - list
   - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - rolebindings
+  verbs:
+  - create
+  - get
 - apiGroups:
   - resolution.tekton.dev
   resources:

--- a/docs/scenario-controller.md
+++ b/docs/scenario-controller.md
@@ -9,34 +9,36 @@ flowchart TD
   classDef Amber fill:#FFDEAD;
   classDef Green fill:#BDFFA4;
 
-  predicate((PREDICATE: <br>Monitor IntegratonTestScenario <br>& filter created/updated/deleted <br>events for the resource ))
-  %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureCreatedScenarioIsValid() function
+  predicate((PREDICATE: <br>Monitor IntegrationTestScenario <br>& filter created events))
 
   %% Node definitions
-  
-  application_exists{"Application for scenario <br>was found?"}
-  set_owner_reference(Set owner reference to <br>IntegrationTestScenario <br> if not already existing)
-  status_check{"IntegrationTestScenario <br>has status<br>IntegrationTestScenarioValid<br>condition undefined<br>or false"}
-  update_scenario_status_valid(Update IntegrationTestScenario <br>status to valid)
-  update_scenario_status_invalid(Update IntegrationTestScenario <br>status to invalid)
-  remove_historical_finalizer(Check for and remove<br>historical IntegrationTestScenario <br> finalizer)
-  complete_reconciliation(Complete reconciliation for <br>IntegrationTestScenario)
-  continue_reconciliation(Continue with next reconciliation)
-
+  check_sa{"ServiceAccount<br>konflux-integration-runner<br>exists?"}
+  create_sa(Create ServiceAccount<br>with ImagePullSecrets)
+  check_secret{"Secret<br>components-namespace-pull<br>exists?"}
+  create_secret(Create empty<br>dockerconfigjson Secret)
+  check_linked{"Secret linked to<br>SA ImagePullSecrets?"}
+  link_secret(Update SA to link Secret)
+  check_rb{"RoleBinding<br>konflux-integration-runner<br>exists?"}
+  create_rb(Create RoleBinding to<br>ClusterRole konflux-integration-runner)
+  complete(Complete reconciliation)
 
   %% Node connections
-  predicate                        ---->    |"EnsureCreatedScenarioIsValid()"| remove_historical_finalizer
-  remove_historical_finalizer      -->      application_exists
-  application_exists               --No-->  update_scenario_status_invalid
-  application_exists               --Yes--> set_owner_reference
-  set_owner_reference              -->      status_check
-  status_check                     --No-->  update_scenario_status_invalid
-  status_check                     --Yes--> update_scenario_status_valid
-  update_scenario_status_valid     -->      complete_reconciliation
-  complete_reconciliation          -->      continue_reconciliation
-  update_scenario_status_invalid   -->      continue_reconciliation
+  predicate                  ---->  |"EnsureIntegrationPipelineServiceAccount()"| check_sa
+  check_sa                   --No-->  create_sa
+  check_sa                   --Yes--> check_secret
+  create_sa                  -->      check_secret
+  check_secret               --No-->  create_secret
+  check_secret               --Yes--> check_linked
+  create_secret              -->      check_linked
+  check_linked               --No-->  link_secret
+  check_linked               --Yes--> check_rb
+  link_secret                -->      check_rb
+  check_rb                   --No-->  create_rb
+  check_rb                   --Yes--> complete
+  create_rb                  -->      complete
 
-   %% Assigning styles to nodes
+  %% Assigning styles to nodes
   class predicate Amber;
+  class create_sa,create_secret,link_secret,create_rb Green;
 
   ```

--- a/internal/controller/controllers.go
+++ b/internal/controller/controllers.go
@@ -22,6 +22,7 @@ import (
 	"github.com/konflux-ci/integration-service/internal/controller/component"
 	"github.com/konflux-ci/integration-service/internal/controller/componentgroup"
 	"github.com/konflux-ci/integration-service/internal/controller/integrationpipeline"
+	"github.com/konflux-ci/integration-service/internal/controller/scenario"
 	"github.com/konflux-ci/integration-service/internal/controller/snapshot"
 	"github.com/konflux-ci/integration-service/internal/controller/statusreport"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -33,7 +34,7 @@ var setupFunctions = []func(manager.Manager, *logr.Logger) error{
 	integrationpipeline.SetupController,
 	buildpipeline.SetupController,
 	snapshot.SetupController,
-	//scenario.SetupController,
+	scenario.SetupController,
 	statusreport.SetupController,
 	component.SetupController,
 	componentgroup.SetupController,

--- a/internal/controller/scenario/predicates.go
+++ b/internal/controller/scenario/predicates.go
@@ -1,0 +1,25 @@
+package scenario
+
+import (
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// ScenarioCreatedPredicate returns a predicate which filters out
+// only IntegrationTestScenarios that are the result of a create event.
+func ScenarioCreatedPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(createEvent event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(deleteEvent event.DeleteEvent) bool {
+			return false
+		},
+		GenericFunc: func(genericEvent event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return false
+		},
+	}
+}

--- a/internal/controller/scenario/predicates_test.go
+++ b/internal/controller/scenario/predicates_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scenario
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+)
+
+var _ = Describe("Predicates", func() {
+
+	var scenario *v1beta2.IntegrationTestScenario
+
+	BeforeEach(func() {
+		scenario = &v1beta2.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-scenario",
+				Namespace: "default",
+			},
+		}
+	})
+
+	Context("when testing ScenarioCreatedPredicate", func() {
+		instance := ScenarioCreatedPredicate()
+
+		It("should return true for create events", func() {
+			Expect(instance.Create(event.CreateEvent{
+				Object: scenario,
+			})).To(BeTrue())
+		})
+
+		It("should return false for delete events", func() {
+			Expect(instance.Delete(event.DeleteEvent{
+				Object: scenario,
+			})).To(BeFalse())
+		})
+
+		It("should return false for generic events", func() {
+			Expect(instance.Generic(event.GenericEvent{
+				Object: scenario,
+			})).To(BeFalse())
+		})
+
+		It("should return false for update events", func() {
+			Expect(instance.Update(event.UpdateEvent{
+				ObjectOld: scenario,
+				ObjectNew: scenario,
+			})).To(BeFalse())
+		})
+	})
+})

--- a/internal/controller/scenario/scenario_adapter.go
+++ b/internal/controller/scenario/scenario_adapter.go
@@ -22,11 +22,18 @@ import (
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
 	"github.com/konflux-ci/operator-toolkit/controller"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Adapter holds the objects needed to reconcile a Release.
+// Adapter holds the objects needed to reconcile an IntegrationTestScenario.
 type Adapter struct {
 	scenario *v1beta2.IntegrationTestScenario
 	logger   h.IntegrationLogger
@@ -47,6 +54,138 @@ func NewAdapter(context context.Context, scenario *v1beta2.IntegrationTestScenar
 	}
 }
 
-func (a *Adapter) EnsurePlaceholder() (controller.OperationResult, error) {
+// EnsureIntegrationPipelineServiceAccountCreated ensures the integration pipeline service account,
+// image pull secret, and role binding exist in the IntegrationTestScenario's namespace.
+func (a *Adapter) EnsureIntegrationPipelineServiceAccountCreated() (controller.OperationResult, error) {
+	namespace := a.scenario.Namespace
+	saName := tektonconsts.DefaultIntegrationPipelineServiceAccount
+	secretName := tektonconsts.DefaultIntegrationPipelineImagePullSecretName
+
+	sa := &corev1.ServiceAccount{}
+	err := a.client.Get(a.context, types.NamespacedName{Name: saName, Namespace: namespace}, sa)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			a.logger.Error(err, "Failed to get ServiceAccount", "serviceAccount", saName)
+			return controller.RequeueWithError(err)
+		}
+		sa = &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      saName,
+				Namespace: namespace,
+			},
+			ImagePullSecrets: []corev1.LocalObjectReference{
+				{Name: secretName},
+			},
+		}
+		if err := a.client.Create(a.context, sa); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				a.logger.Error(err, "Failed to create ServiceAccount", "serviceAccount", saName)
+				return controller.RequeueWithError(err)
+			}
+			// SA was created concurrently, re-fetch to get the current state
+			if err := a.client.Get(a.context, types.NamespacedName{Name: saName, Namespace: namespace}, sa); err != nil {
+				a.logger.Error(err, "Failed to re-fetch ServiceAccount after conflict", "serviceAccount", saName)
+				return controller.RequeueWithError(err)
+			}
+		} else {
+			a.logger.Info("Created ServiceAccount", "serviceAccount", saName)
+		}
+	}
+
+	secret := &corev1.Secret{}
+	err = a.client.Get(a.context, types.NamespacedName{Name: secretName, Namespace: namespace}, secret)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			a.logger.Error(err, "Failed to get Secret", "secret", secretName)
+			return controller.RequeueWithError(err)
+		}
+		secret = &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			Type: corev1.SecretTypeDockerConfigJson,
+			Data: map[string][]byte{
+				corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+			},
+		}
+		if err := a.client.Create(a.context, secret); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				a.logger.Error(err, "Failed to create Secret", "secret", secretName)
+				return controller.RequeueWithError(err)
+			}
+		} else {
+			a.logger.Info("Created image pull secret", "secret", secretName)
+		}
+	}
+
+	imagePullSecretLinked := false
+	for _, ref := range sa.ImagePullSecrets {
+		if ref.Name == secretName {
+			imagePullSecretLinked = true
+			break
+		}
+	}
+	if !imagePullSecretLinked {
+		updated := false
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			if err := a.client.Get(a.context, types.NamespacedName{Name: saName, Namespace: namespace}, sa); err != nil {
+				return err
+			}
+			for _, ref := range sa.ImagePullSecrets {
+				if ref.Name == secretName {
+					return nil
+				}
+			}
+			sa.ImagePullSecrets = append(sa.ImagePullSecrets, corev1.LocalObjectReference{Name: secretName})
+			updated = true
+			return a.client.Update(a.context, sa)
+		})
+		if err != nil {
+			a.logger.Error(err, "Failed to update ServiceAccount with secret link", "serviceAccount", saName, "secret", secretName)
+			return controller.RequeueWithError(err)
+		}
+		if updated {
+			a.logger.Info("Linked secret to ServiceAccount", "serviceAccount", saName, "secret", secretName)
+		}
+	}
+
+	// The ClusterRole is provisioned by the Konflux operator (konflux-ci/konflux-ci)
+	rbName := tektonconsts.DefaultIntegrationPipelineRoleBindingName
+	rb := &rbacv1.RoleBinding{}
+	err = a.client.Get(a.context, types.NamespacedName{Name: rbName, Namespace: namespace}, rb)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			a.logger.Error(err, "Failed to get RoleBinding", "roleBinding", rbName)
+			return controller.RequeueWithError(err)
+		}
+		rb = &rbacv1.RoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      rbName,
+				Namespace: namespace,
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: rbacv1.GroupName,
+				Kind:     "ClusterRole",
+				Name:     tektonconsts.DefaultIntegrationPipelineClusterRoleName,
+			},
+			Subjects: []rbacv1.Subject{
+				{
+					Kind:      rbacv1.ServiceAccountKind,
+					Name:      saName,
+					Namespace: namespace,
+				},
+			},
+		}
+		if err := a.client.Create(a.context, rb); err != nil {
+			if !errors.IsAlreadyExists(err) {
+				a.logger.Error(err, "Failed to create RoleBinding", "roleBinding", rbName)
+				return controller.RequeueWithError(err)
+			}
+		} else {
+			a.logger.Info("Created RoleBinding", "roleBinding", rbName)
+		}
+	}
+
 	return controller.ContinueProcessing()
 }

--- a/internal/controller/scenario/scenario_adapter_test.go
+++ b/internal/controller/scenario/scenario_adapter_test.go
@@ -20,6 +20,7 @@ import (
 	"reflect"
 
 	"github.com/konflux-ci/integration-service/loader"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -29,8 +30,11 @@ import (
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/helpers"
 
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var _ = Describe("Scenario Adapter", Ordered, func() {
@@ -38,12 +42,10 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 		adapter                 *Adapter
 		hasApp                  *applicationapiv1alpha1.Application
 		integrationTestScenario *v1beta2.IntegrationTestScenario
-		invalidScenario         *v1beta2.IntegrationTestScenario
 		logger                  helpers.IntegrationLogger
 	)
 
 	BeforeAll(func() {
-
 		logger = helpers.IntegrationLogger{Logger: ctrl.Log}
 
 		hasApp = &applicationapiv1alpha1.Application{
@@ -56,14 +58,12 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 				Description: "This is an example application",
 			},
 		}
-
 		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
 
 		integrationTestScenario = &v1beta2.IntegrationTestScenario{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "example-pass",
 				Namespace: "default",
-
 				Labels: map[string]string{
 					"test.appstudio.openshift.io/optional": "false",
 				},
@@ -73,61 +73,14 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 				ResolverRef: v1beta2.ResolverRef{
 					Resolver: "git",
 					Params: []v1beta2.ResolverParameter{
-						{
-							Name:  "url",
-							Value: "https://github.com/redhat-appstudio/integration-examples.git",
-						},
-						{
-							Name:  "revision",
-							Value: "main",
-						},
-						{
-							Name:  "pathInRepo",
-							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
-						},
+						{Name: "url", Value: "https://github.com/redhat-appstudio/integration-examples.git"},
+						{Name: "revision", Value: "main"},
+						{Name: "pathInRepo", Value: "pipelineruns/integration_pipelinerun_pass.yaml"},
 					},
 				},
 			},
 		}
 		Expect(k8sClient.Create(ctx, integrationTestScenario)).Should(Succeed())
-
-		invalidScenario = &v1beta2.IntegrationTestScenario{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "example-fail",
-				Namespace: "default",
-
-				Labels: map[string]string{
-					"test.appstudio.openshift.io/optional": "false",
-				},
-			},
-			Spec: v1beta2.IntegrationTestScenarioSpec{
-				Application: "perpetum-mobile",
-				ResolverRef: v1beta2.ResolverRef{
-					Resolver: "git",
-					Params: []v1beta2.ResolverParameter{
-						{
-							Name:  "url",
-							Value: "https://github.com/redhat-appstudio/integration-examples.git",
-						},
-						{
-							Name:  "revision",
-							Value: "main",
-						},
-						{
-							Name:  "pathInRepo",
-							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
-						},
-					},
-				},
-			},
-		}
-		Expect(k8sClient.Create(ctx, invalidScenario)).Should(Succeed())
-
-	})
-
-	JustBeforeEach(func() {
-		adapter = NewAdapter(ctx, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient)
-		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
 	AfterAll(func() {
@@ -135,16 +88,264 @@ var _ = Describe("Scenario Adapter", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, integrationTestScenario)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
-		err = k8sClient.Delete(ctx, invalidScenario)
-		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+	})
 
+	JustBeforeEach(func() {
+		adapter = NewAdapter(ctx, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient)
+		Expect(reflect.TypeOf(adapter)).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
 	It("can create a new Adapter instance", func() {
 		Expect(reflect.TypeOf(NewAdapter(ctx, integrationTestScenario, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
 	})
 
-	It("can create a new Adapter instance with invalid scenario", func() {
-		Expect(reflect.TypeOf(NewAdapter(ctx, invalidScenario, logger, loader.NewMockLoader(), k8sClient))).To(Equal(reflect.TypeOf(&Adapter{})))
+	When("ServiceAccount, Secret, and RoleBinding do not exist", func() {
+		AfterAll(func() {
+			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, sa)
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, secret)
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, rb)
+		})
+
+		It("creates the ServiceAccount, Secret, and RoleBinding", func() {
+			result, err := adapter.EnsureIntegrationPipelineServiceAccountCreated()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				}, sa)).To(Succeed())
+				g.Expect(sa.Name).To(Equal(tektonconsts.DefaultIntegrationPipelineServiceAccount))
+				g.Expect(sa.ImagePullSecrets).To(ContainElement(
+					corev1.LocalObjectReference{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName},
+				))
+			}, "5s").Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default",
+				}, secret)).To(Succeed())
+				g.Expect(secret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			}, "5s").Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default",
+				}, rb)).To(Succeed())
+				g.Expect(rb.RoleRef.Name).To(Equal(tektonconsts.DefaultIntegrationPipelineClusterRoleName))
+				g.Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+				g.Expect(rb.Subjects).To(HaveLen(1))
+				g.Expect(rb.Subjects[0].Name).To(Equal(tektonconsts.DefaultIntegrationPipelineServiceAccount))
+			}, "5s").Should(Succeed())
+		})
+	})
+
+	When("ServiceAccount exists but Secret does not", func() {
+		BeforeAll(func() {
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				},
+			}
+			Expect(k8sClient.Create(ctx, sa)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, sa)
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, secret)
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, rb)
+		})
+
+		It("creates the Secret and links it to the existing ServiceAccount", func() {
+			result, err := adapter.EnsureIntegrationPipelineServiceAccountCreated()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				}, sa)).To(Succeed())
+				g.Expect(sa.ImagePullSecrets).To(ContainElement(
+					corev1.LocalObjectReference{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName},
+				))
+			}, "5s").Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				secret := &corev1.Secret{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default",
+				}, secret)).To(Succeed())
+				g.Expect(secret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+			}, "5s").Should(Succeed())
+		})
+	})
+
+	When("ServiceAccount and Secret exist but Secret is not linked", func() {
+		BeforeAll(func() {
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				},
+			}
+			Expect(k8sClient.Create(ctx, sa)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, sa)
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, secret)
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, rb)
+		})
+
+		It("links the Secret to the ServiceAccount", func() {
+			result, err := adapter.EnsureIntegrationPipelineServiceAccountCreated()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				sa := &corev1.ServiceAccount{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				}, sa)).To(Succeed())
+				g.Expect(sa.ImagePullSecrets).To(ContainElement(
+					corev1.LocalObjectReference{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName},
+				))
+			}, "5s").Should(Succeed())
+		})
+	})
+
+	When("everything is already configured", func() {
+		BeforeAll(func() {
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				},
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sa)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+
+			rb := &rbacv1.RoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default",
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: rbacv1.GroupName,
+					Kind:     "ClusterRole",
+					Name:     tektonconsts.DefaultIntegrationPipelineClusterRoleName,
+				},
+				Subjects: []rbacv1.Subject{
+					{
+						Kind:      rbacv1.ServiceAccountKind,
+						Name:      tektonconsts.DefaultIntegrationPipelineServiceAccount,
+						Namespace: "default",
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, rb)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, sa)
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, secret)
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, rb)
+		})
+
+		It("is idempotent and does not error", func() {
+			result, err := adapter.EnsureIntegrationPipelineServiceAccountCreated()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			result, err = adapter.EnsureIntegrationPipelineServiceAccountCreated()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+		})
+	})
+
+	When("ServiceAccount and Secret exist and are linked but RoleBinding is missing", func() {
+		BeforeAll(func() {
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+				},
+				ImagePullSecrets: []corev1.LocalObjectReference{
+					{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName},
+				},
+			}
+			Expect(k8sClient.Create(ctx, sa)).Should(Succeed())
+
+			secret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default",
+				},
+				Type: corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: []byte(`{"auths":{}}`),
+				},
+			}
+			Expect(k8sClient.Create(ctx, secret)).Should(Succeed())
+		})
+
+		AfterAll(func() {
+			sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, sa)
+			secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, secret)
+			rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default"}}
+			_ = k8sClient.Delete(ctx, rb)
+		})
+
+		It("creates the RoleBinding", func() {
+			result, err := adapter.EnsureIntegrationPipelineServiceAccountCreated()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				rb := &rbacv1.RoleBinding{}
+				g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+					Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default",
+				}, rb)).To(Succeed())
+				g.Expect(rb.RoleRef.Name).To(Equal(tektonconsts.DefaultIntegrationPipelineClusterRoleName))
+				g.Expect(rb.RoleRef.Kind).To(Equal("ClusterRole"))
+			}, "5s").Should(Succeed())
+		})
 	})
 })

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -55,6 +55,9 @@ func NewScenarioReconciler(client client.Client, logger *logr.Logger, scheme *ru
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/status,verbs=get
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups/status,verbs=get
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create;update
+//+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -76,13 +79,13 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	adapter := NewAdapter(ctx, scenario, logger, loader, r.Client)
 
 	return controller.ReconcileHandler([]controller.Operation{
-		adapter.EnsurePlaceholder,
+		adapter.EnsureIntegrationPipelineServiceAccountCreated,
 	})
 }
 
 // AdapterInterface is an interface defining all the operations that should be defined in an Integration adapter.
 type AdapterInterface interface {
-	EnsurePlaceholder() (controller.OperationResult, error)
+	EnsureIntegrationPipelineServiceAccountCreated() (controller.OperationResult, error)
 }
 
 // SetupController creates a new Integration controller and adds it to the Manager.
@@ -91,8 +94,8 @@ func SetupController(manager ctrl.Manager, log *logr.Logger) error {
 }
 
 func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) error {
-
 	return ctrl.NewControllerManagedBy(manager).
 		For(&v1beta2.IntegrationTestScenario{}).
+		WithEventFilter(ScenarioCreatedPredicate()).
 		Complete(controller)
 }

--- a/internal/controller/scenario/scenario_controller_test.go
+++ b/internal/controller/scenario/scenario_controller_test.go
@@ -19,6 +19,9 @@ package scenario
 import (
 	"reflect"
 
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
+	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -52,7 +55,6 @@ var _ = Describe("ScenarioController", Ordered, func() {
 	)
 
 	BeforeAll(func() {
-
 		applicationName := "application-sample"
 
 		hasApp = &applicationapiv1alpha1.Application{
@@ -65,7 +67,6 @@ var _ = Describe("ScenarioController", Ordered, func() {
 				Description: "This is an example application",
 			},
 		}
-
 		Expect(k8sClient.Create(ctx, hasApp)).Should(Succeed())
 
 		scenarioName := "scenario-sample"
@@ -80,23 +81,13 @@ var _ = Describe("ScenarioController", Ordered, func() {
 				ResolverRef: v1beta2.ResolverRef{
 					Resolver: "git",
 					Params: []v1beta2.ResolverParameter{
-						{
-							Name:  "url",
-							Value: "https://github.com/redhat-appstudio/integration-examples.git",
-						},
-						{
-							Name:  "revision",
-							Value: "main",
-						},
-						{
-							Name:  "pathInRepo",
-							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
-						},
+						{Name: "url", Value: "https://github.com/redhat-appstudio/integration-examples.git"},
+						{Name: "revision", Value: "main"},
+						{Name: "pathInRepo", Value: "pipelineruns/integration_pipelinerun_pass.yaml"},
 					},
 				},
 			},
 		}
-
 		Expect(k8sClient.Create(ctx, hasScenario)).Should(Succeed())
 
 		failScenario = &v1beta2.IntegrationTestScenario{
@@ -109,23 +100,13 @@ var _ = Describe("ScenarioController", Ordered, func() {
 				ResolverRef: v1beta2.ResolverRef{
 					Resolver: "git",
 					Params: []v1beta2.ResolverParameter{
-						{
-							Name:  "url",
-							Value: "https://github.com/redhat-appstudio/integration-examples.git",
-						},
-						{
-							Name:  "revision",
-							Value: "main",
-						},
-						{
-							Name:  "pathInRepo",
-							Value: "pipelineruns/integration_pipelinerun_pass.yaml",
-						},
+						{Name: "url", Value: "https://github.com/redhat-appstudio/integration-examples.git"},
+						{Name: "revision", Value: "main"},
+						{Name: "pathInRepo", Value: "pipelineruns/integration_pipelinerun_pass.yaml"},
 					},
 				},
 			},
 		}
-
 		Expect(k8sClient.Create(ctx, failScenario)).Should(Succeed())
 
 		req = ctrl.Request{
@@ -155,11 +136,10 @@ var _ = Describe("ScenarioController", Ordered, func() {
 			LeaderElection: false,
 		})
 		Expect(err).NotTo(HaveOccurred())
-		Expect(err).ToNot(HaveOccurred())
 
 		scenarioReconciler = NewScenarioReconciler(k8sClient, &logf.Log, &scheme)
-
 	})
+
 	AfterAll(func() {
 		err := k8sClient.Delete(ctx, hasApp)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
@@ -167,17 +147,52 @@ var _ = Describe("ScenarioController", Ordered, func() {
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
 		err = k8sClient.Delete(ctx, failScenario)
 		Expect(err == nil || errors.IsNotFound(err)).To(BeTrue())
+
+		sa := &corev1.ServiceAccount{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default"}}
+		_ = k8sClient.Delete(ctx, sa)
+		secret := &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default"}}
+		_ = k8sClient.Delete(ctx, secret)
+		rb := &rbacv1.RoleBinding{ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default"}}
+		_ = k8sClient.Delete(ctx, rb)
 	})
 
 	It("can create and return a new Reconciler object", func() {
 		Expect(reflect.TypeOf(scenarioReconciler)).To(Equal(reflect.TypeOf(&Reconciler{})))
-		klog.Info("Test First Logic")
 	})
 
-	It("can Reconcile function prepare the adapter and return the result of the reconcile handling operation", func() {
+	It("can Reconcile and creates the integration pipeline ServiceAccount, Secret, and RoleBinding", func() {
 		result, err := scenarioReconciler.Reconcile(ctx, req)
 		Expect(reflect.TypeOf(result)).To(Equal(reflect.TypeOf(reconcile.Result{})))
 		Expect(err).ToNot(HaveOccurred())
+
+		sa := &corev1.ServiceAccount{}
+		err = k8sClient.Get(ctx, types.NamespacedName{
+			Name: tektonconsts.DefaultIntegrationPipelineServiceAccount, Namespace: "default",
+		}, sa)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sa.ImagePullSecrets).To(ContainElement(
+			corev1.LocalObjectReference{Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName},
+		))
+
+		secret := &corev1.Secret{}
+		err = k8sClient.Get(ctx, types.NamespacedName{
+			Name: tektonconsts.DefaultIntegrationPipelineImagePullSecretName, Namespace: "default",
+		}, secret)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(secret.Type).To(Equal(corev1.SecretTypeDockerConfigJson))
+
+		Eventually(func() error {
+			rb := &rbacv1.RoleBinding{}
+			return k8sClient.Get(ctx, types.NamespacedName{
+				Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default",
+			}, rb)
+		}, "5s").Should(Succeed())
+
+		rb := &rbacv1.RoleBinding{}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name: tektonconsts.DefaultIntegrationPipelineRoleBindingName, Namespace: "default",
+		}, rb)).To(Succeed())
+		Expect(rb.RoleRef.Name).To(Equal(tektonconsts.DefaultIntegrationPipelineClusterRoleName))
 	})
 
 	It("can setup a new controller manager with the given reconciler", func() {

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -61,6 +61,15 @@ const (
 	// DefaultIntegrationPipelineServiceAccount denotes the service account which is used by default in integration pipelines
 	DefaultIntegrationPipelineServiceAccount = "konflux-integration-runner"
 
+	// DefaultIntegrationPipelineImagePullSecretName is the namespace-scoped image pull secret linked to the integration pipeline service account
+	DefaultIntegrationPipelineImagePullSecretName = "components-namespace-pull"
+
+	// DefaultIntegrationPipelineRoleBindingName is the RoleBinding that grants the integration pipeline service account its permissions
+	DefaultIntegrationPipelineRoleBindingName = "konflux-integration-runner"
+
+	// DefaultIntegrationPipelineClusterRoleName is the ClusterRole referenced by the integration pipeline RoleBinding
+	DefaultIntegrationPipelineClusterRoleName = "konflux-integration-runner"
+
 	/*
 	 * Build PipelineConstants
 	 */


### PR DESCRIPTION
Enable the scenario controller to ensure the integration pipeline ServiceAccount, components-namespace-pull Secret, and RoleBinding exist in the namespace when an IntegrationTestScenario is created.

- Re-enable the scenario controller with a create-only event predicate
- Create konflux-integration-runner SA if not present
- Create empty dockerconfigjson secret if not present and link it to the SA via ImagePullSecrets
- Create RoleBinding to the konflux-integration-runner ClusterRole
- Add RBAC permissions for serviceaccounts, secrets, and rolebindings
- Unit tests for all creation, linking, and idempotency scenarios

Assisteb-By: Claude Opus 4.6
For more info in [STONEINTG-1668](https://redhat.atlassian.net/browse/STONEINTG-1668)

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


[STONEINTG-1668]: https://redhat.atlassian.net/browse/STONEINTG-1668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ