### PR TITLE
test(stoneintg-1666): lint testing do not merge

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,9 @@
 version: "2"
 linters:
   enable:
+    - gosec
+    - staticcheck
+    - errcheck
     - ginkgolinter
   exclusions:
     generated: lax

--- a/lint_smoke.go
+++ b/lint_smoke.go
@@ -1,0 +1,21 @@
+// TEMPORARY: CI lint smoke test — delete after verifying linters. Do not merge.
+//
+// Verification plan (two pushes to the same PR):
+//
+//	Push A — restore gosec triggers below (md5 + unchecked errors), delete lint_smoke_test.go
+//	         → expect standalone gosec to FAIL (already verified on PR #1602).
+//	Push B — this file + lint_smoke_test.go as committed now
+//	         → gosec passes (no violations in non-test files)
+//	         → golangci-lint runs (errcheck, gosec, staticcheck, ginkgolinter via .golangci.yml)
+//	         → staticcheck standalone runs
+package lintsmoke
+
+// --- staticcheck SA4006: ineffectual assignment ---
+func ineffectualAssignment() int {
+	x := 1
+	x = 2 // first value of x is never used
+	return x
+}
+
+// Unused export keeps the compiler from dropping the function during analysis.
+var _ = ineffectualAssignment

--- a/lint_smoke_test.go
+++ b/lint_smoke_test.go
@@ -1,0 +1,25 @@
+// TEMPORARY: CI lint smoke test — delete after verifying linters. Do not merge.
+package lintsmoke
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+)
+
+// --- errcheck (+ golangci gosec G104 on test files): unchecked error return ---
+// Standalone gosec skips *_test.go, so these are visible to golangci-lint only.
+func uncheckedErrors() {
+	os.Remove("/tmp/lint-smoke-delete-me")
+	http.Get("http://example.com")
+}
+
+// --- ginkgolinter: focused containers are forbidden (must live in *_test.go) ---
+var _ = FDescribe("lint smoke focused container", func() {
+	FIt("should be flagged by ginkgolinter", func() {})
+})
+
+// Compile-only test; does not call uncheckedErrors() to avoid network/filesystem side effects.
+func TestLintSmoke(t *testing.T) {}


### PR DESCRIPTION
 - testing what linters fire
 - do not merge

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
