### PR TITLE
feat(STONEINTG-1281): run dependents chain generated by DAG

### DIFF
--- a/config/samples/appstudio_v1beta2_componentgroup.yaml
+++ b/config/samples/appstudio_v1beta2_componentgroup.yaml
@@ -25,12 +25,12 @@ spec:
         name: "main"
     - name: second-component
       kind: component
-      componentBranch:
+      componentVersion:
         name: "v1"
         revision: "v1branch"
         context: "components/second-component"
     - name: python-component
-      componentBranch:
+      componentVersion:
         name: "3.12.4"
     - name: child-cg
       kind: componentGroup
@@ -42,14 +42,14 @@ spec:
     verify:
       - name: clamav-scan
       - name: dast-tests
-        onFail: skip
+        failFast: true
       - name: operator-scorecard
     e2e-test:
       - name: clamav-scan
-        onFail: run
+        failFast: false
     operator-scorecard:
       - name: deployment
-        onFail: skip
+        failFast: true
 status:
   globalCandidateList:
     - name: first-component

--- a/config/samples/appstudio_v1beta2_componentgroup_minimal.yaml
+++ b/config/samples/appstudio_v1beta2_componentgroup_minimal.yaml
@@ -17,13 +17,13 @@ metadata:
 spec:
   components:
     - name: first-component
-      componentBranch:
+      componentVersion:
         name: "main"
     - name: second-component
-      componentBranch:
+      componentVersion:
         name: "v1"
     - name: third-component
-      componentBranch:
+      componentVersion:
         name: "main"
 status:
   globalCandidateList:

--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -8,13 +8,13 @@ flowchart TD
     classDef Amber fill:#FFDEAD;
     classDef Green fill:#BDFFA4;
 
-  predicate((PREDICATE: <br>Snapshot got created OR <br> changed to Finished OR <br> re-run label added AND <br> it's not restored from backup))
+  predicate((PREDICATE: <br>Snapshot got created OR <br> changed to Finished OR <br> re-run label added <OR> status annotation changed AND <br> it's not restored from backup))
 
   %%%%%%%%%%%%%%%%%%%%%%% Drawing EnsureIntegrationPipelineRunsExist() function
 
   %% Node definitions
   ensure1(Process further if: Snapshot testing <br>is not finished yet)
-  are_there_any_ITS{"Are there any <br>IntegrationTestScenario <br>present for the given <br>Application/ComponentGroup?"}
+  are_there_any_ITS{"Are there any <br>IntegrationTestScenarios <br>present for the given <br>Application/ComponentGroup <br> which do not depend on <br> other unfinished scenarios?"}
   create_new_test_PLR(<b>Create a new Test PipelineRun</b> for each <br>of the above ITS, if it doesn't exists already)
   mark_snapshot_InProgress(<b>Mark</b> Snapshot's Integration-testing <br>status as 'InProgress')
   fetch_all_required_ITS("Fetch all the required <br>(non-optional) IntegrationTestScenario <br>for the given Application/ComponentGroup <br> filtered by ITS context(s)")

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -25,6 +25,7 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
+	"github.com/konflux-ci/integration-service/pkg/dag"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
 	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/status"
@@ -97,6 +98,13 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		statuses.UpdateTestStatusIfChanged(a.pipelineRun.Labels[tektonconsts.ScenarioNameLabel], pipelinerunStatus, detail)
 		if err = statuses.UpdateTestPipelineRunName(a.pipelineRun.Labels[tektonconsts.ScenarioNameLabel], a.pipelineRun.Name); err != nil {
 			return err
+		}
+
+		if h.HasPipelineRunFinished(a.pipelineRun) && !h.HasPipelineRunSucceeded(a.pipelineRun) {
+			err := a.updateStatusForDependentTestsIfTestFailed(a.context, a.client, a.pipelineRun, statuses)
+			if err != nil {
+				return err
+			}
 		}
 
 		// don't return wrapped err for retries
@@ -220,6 +228,38 @@ func (a *Adapter) annotateIntegrationPipelineRunLogURL(ctx context.Context, adap
 		}
 		return err
 	})
+}
+
+// updateStatusForDependentTestsIfTestFailed updates the test status for any dependent tests if this pipelineRun failed
+func (a *Adapter) updateStatusForDependentTestsIfTestFailed(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun, testDetails *intgteststat.SnapshotIntegrationTestStatuses) error {
+	// We only run this logic in case the test scenario finished and failed
+	scenarioName := pipelineRun.Labels[tektonconsts.ScenarioNameLabel]
+	componentGroup, err := a.loader.GetComponentGroupFromSnapshot(ctx, adapterClient, a.snapshot)
+	if err != nil {
+		return err
+	}
+	if componentGroup == nil || componentGroup.Spec.TestGraph == nil {
+		return nil
+	}
+
+	for _, testDetail := range testDetails.GetStatuses() {
+		if testDetail.ScenarioName == scenarioName {
+			continue
+		}
+		if testDetail.RunAfter == nil || len(testDetail.RunAfter) == 0 {
+			continue
+		}
+		for _, parentScenario := range testDetail.RunAfter {
+			if parentScenario != scenarioName {
+				continue
+			}
+			if dag.ShouldFailFastForScenariosParent(componentGroup.Spec.TestGraph, testDetail.ScenarioName, scenarioName) {
+				testDetail.Status = intgteststat.IntegrationTestStatusTestFail
+				testDetail.Details = fmt.Sprintf("Cancelled on account of required %s failing", scenarioName)
+			}
+		}
+	}
+	return nil
 }
 
 // emitTestTimingSpans emits timing spans for the integration test PipelineRun if not already emitted.

--- a/internal/controller/integrationpipeline/integrationpipeline_adapter.go
+++ b/internal/controller/integrationpipeline/integrationpipeline_adapter.go
@@ -25,7 +25,6 @@ import (
 	"github.com/konflux-ci/integration-service/gitops"
 	h "github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/loader"
-	"github.com/konflux-ci/integration-service/pkg/dag"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
 	"github.com/konflux-ci/integration-service/pkg/tracing"
 	"github.com/konflux-ci/integration-service/status"
@@ -98,13 +97,6 @@ func (a *Adapter) EnsureStatusReportedInSnapshot() (controller.OperationResult, 
 		statuses.UpdateTestStatusIfChanged(a.pipelineRun.Labels[tektonconsts.ScenarioNameLabel], pipelinerunStatus, detail)
 		if err = statuses.UpdateTestPipelineRunName(a.pipelineRun.Labels[tektonconsts.ScenarioNameLabel], a.pipelineRun.Name); err != nil {
 			return err
-		}
-
-		if h.HasPipelineRunFinished(a.pipelineRun) && !h.HasPipelineRunSucceeded(a.pipelineRun) {
-			err := a.updateStatusForDependentTestsIfTestFailed(a.context, a.client, a.pipelineRun, statuses)
-			if err != nil {
-				return err
-			}
 		}
 
 		// don't return wrapped err for retries
@@ -228,38 +220,6 @@ func (a *Adapter) annotateIntegrationPipelineRunLogURL(ctx context.Context, adap
 		}
 		return err
 	})
-}
-
-// updateStatusForDependentTestsIfTestFailed updates the test status for any dependent tests if this pipelineRun failed
-func (a *Adapter) updateStatusForDependentTestsIfTestFailed(ctx context.Context, adapterClient client.Client, pipelineRun *tektonv1.PipelineRun, testDetails *intgteststat.SnapshotIntegrationTestStatuses) error {
-	// We only run this logic in case the test scenario finished and failed
-	scenarioName := pipelineRun.Labels[tektonconsts.ScenarioNameLabel]
-	componentGroup, err := a.loader.GetComponentGroupFromSnapshot(ctx, adapterClient, a.snapshot)
-	if err != nil {
-		return err
-	}
-	if componentGroup == nil || componentGroup.Spec.TestGraph == nil {
-		return nil
-	}
-
-	for _, testDetail := range testDetails.GetStatuses() {
-		if testDetail.ScenarioName == scenarioName {
-			continue
-		}
-		if testDetail.RunAfter == nil || len(testDetail.RunAfter) == 0 {
-			continue
-		}
-		for _, parentScenario := range testDetail.RunAfter {
-			if parentScenario != scenarioName {
-				continue
-			}
-			if dag.ShouldFailFastForScenariosParent(componentGroup.Spec.TestGraph, testDetail.ScenarioName, scenarioName) {
-				testDetail.Status = intgteststat.IntegrationTestStatusTestFail
-				testDetail.Details = fmt.Sprintf("Cancelled on account of required %s failing", scenarioName)
-			}
-		}
-	}
-	return nil
 }
 
 // emitTestTimingSpans emits timing spans for the integration test PipelineRun if not already emitted.

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -27,6 +27,7 @@ import (
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
+	"github.com/konflux-ci/integration-service/pkg/dag"
 	clienterrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -378,8 +379,12 @@ func (a *Adapter) initializeTestStatusesWithDefer(integrationTestScenarios *[]v1
 	if err != nil {
 		return nil, nil, err
 	}
+	runAfterMap := make(map[string][]string)
 
-	testStatuses.InitStatuses(integrationTestScenarios)
+	if a.componentGroup != nil && a.componentGroup.Spec.TestGraph != nil {
+		runAfterMap = dag.GetRunAfterMapForTestGraphNodes(a.componentGroup.Spec.TestGraph, integrationTestScenarios)
+	}
+	testStatuses.InitStatuses(integrationTestScenarios, runAfterMap)
 
 	err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
 	if err != nil {
@@ -448,7 +453,7 @@ func (a *Adapter) processSingleScenario(
 	return nil
 }
 
-// processAllScenarios iterates through all scenarios and creates pipelines
+// processAllScenarios iterates through all scenarios and creates pipelines.
 func (a *Adapter) processAllScenarios(
 	integrationTestScenarios *[]v1beta2.IntegrationTestScenario,
 	testStatuses *intgteststat.SnapshotIntegrationTestStatuses,
@@ -517,9 +522,15 @@ func (a *Adapter) markSnapshotPassedIfNoRequiredScenarios() (controller.Operatio
 
 // EnsureIntegrationPipelineRunsExist is an operation that will ensure that all Integration pipeline runs
 // associated with the Snapshot and the Application's IntegrationTestScenarios exist.
+// If a testGraph is defined in the componentGroup, then only root nodes are processed and started.
 func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResult, error) {
 	if gitops.HaveAppStudioTestsFinished(a.snapshot) {
 		a.logger.Info("The Snapshot has finished testing.")
+		return controller.ContinueProcessing()
+	}
+
+	if metadata.HasAnnotation(a.snapshot, gitops.SnapshotTestsStatusAnnotation) {
+		a.logger.Info("The Snapshot has its test.appstudio.openshift.io/status annotation already defined and has already started testing.")
 		return controller.ContinueProcessing()
 	}
 
@@ -534,6 +545,10 @@ func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResu
 			return controller.RequeueWithError(err)
 		}
 		defer deferFunc()
+
+		if a.componentGroup != nil && a.componentGroup.Spec.TestGraph != nil {
+			integrationTestScenarios = dag.FilterRootIntegrationTestScenarios(a.componentGroup.Spec.TestGraph, integrationTestScenarios)
+		}
 
 		// Process all scenarios
 		errsForPLRCreation = a.processAllScenarios(integrationTestScenarios, testStatuses)
@@ -945,6 +960,85 @@ func (a *Adapter) EnsureGroupSnapshotExist() (controller.OperationResult, error)
 		return controller.RequeueWithError(err)
 	}
 	return controller.ContinueProcessing()
+}
+
+// EnsureDependentPipelineRunsExist ensures any dependent integration tests that are supposed to run after other test pipelines
+// and have their requirements satisfied are started.
+func (a *Adapter) EnsureDependentPipelineRunsExist() (controller.OperationResult, error) {
+	if gitops.HaveAppStudioTestsFinished(a.snapshot) {
+		a.logger.Info("The Snapshot has finished testing.")
+		return controller.ContinueProcessing()
+	}
+
+	// This logic only applies to Snapshots associated with componentGroups which have spec.testGraph defined
+	if a.componentGroup == nil || a.componentGroup.Spec.TestGraph == nil {
+		return controller.ContinueProcessing()
+	}
+
+	var err error
+	var errsForPLRCreation error
+
+	allIntegrationScenariosForComponentGroup, err := a.loader.GetAllIntegrationTestScenariosForComponentGroup(a.context, a.client, a.componentGroup)
+	if err != nil {
+		return controller.RequeueWithError(err)
+	}
+	testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(a.snapshot)
+	if err != nil {
+		return controller.RequeueWithError(err)
+	}
+
+	// Find and process dependent scenarios which have runAfter requirements satisfied
+	dependentIntegrationScenariosToRun := a.findPendingScenariosWithSatisfiedRunAfter(allIntegrationScenariosForComponentGroup, testStatuses)
+	if dependentIntegrationScenariosToRun != nil {
+		// Process all scenarios
+		errsForPLRCreation = a.processAllScenarios(dependentIntegrationScenariosToRun, testStatuses)
+
+		// Persist final status
+		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
+		if err != nil {
+			a.logger.Error(err, "Failed to update test status in snapshot annotation")
+			errsForPLRCreation = errors.Join(errsForPLRCreation, err)
+		}
+	}
+
+	// Return any pipeline creation errors
+	if errsForPLRCreation != nil {
+		return controller.RequeueWithError(errsForPLRCreation)
+	}
+
+	return controller.ContinueProcessing()
+}
+
+// findPendingScenariosWithSatisfiedRunAfter finds all pending IntegrationTestScenarios which have all of the scenarios
+// listed in their runAfter map finished and satisfied the requirements to run the scenario.
+func (a *Adapter) findPendingScenariosWithSatisfiedRunAfter(allIntegrationTestScenarios *[]v1beta2.IntegrationTestScenario, testStatuses *intgteststat.SnapshotIntegrationTestStatuses) *[]v1beta2.IntegrationTestScenario {
+	var dependentIntegrationScenariosToRun []v1beta2.IntegrationTestScenario
+	for _, scenario := range *allIntegrationTestScenarios {
+		scenarioDetail, found := testStatuses.GetScenarioStatus(scenario.Name)
+		// Check if pending test scenarios have runAfter requirements
+		if found && scenarioDetail.Status == intgteststat.IntegrationTestStatusPending && scenarioDetail.RunAfter != nil && len(scenarioDetail.RunAfter) > 0 {
+			numRunAfter := 0
+			// Check if all runAfter scenarios have finished
+			for _, runAfterScenario := range scenarioDetail.RunAfter {
+				testDetails, ok := testStatuses.GetScenarioStatus(runAfterScenario)
+				if ok && testDetails.Status.IsFinal() {
+					if testDetails.Status == intgteststat.IntegrationTestStatusTestPassed {
+						numRunAfter++
+					} else {
+						// Consider the runAfter scenario as finished if failFast option isn't set to true
+						if !dag.ShouldFailFastForScenariosParent(a.componentGroup.Spec.TestGraph, scenario.Name, runAfterScenario) {
+							numRunAfter++
+						}
+					}
+				}
+			}
+			// Iff all runAfter scenarios have finished in the required manner, add it to the list
+			if numRunAfter >= len(scenarioDetail.RunAfter) {
+				dependentIntegrationScenariosToRun = append(dependentIntegrationScenariosToRun, scenario)
+			}
+		}
+	}
+	return &dependentIntegrationScenariosToRun
 }
 
 // createMissingReleasesForReleasePlans checks if there's existing Releases for a given list of ReleasePlans and creates

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -26,8 +26,8 @@ import (
 	"strings"
 	"time"
 
-	"go.opentelemetry.io/otel/attribute"
 	"github.com/konflux-ci/integration-service/pkg/dag"
+	"go.opentelemetry.io/otel/attribute"
 	clienterrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -372,41 +372,6 @@ func (a *Adapter) loadAndFilterIntegrationTestScenarios() *[]v1beta2.Integration
 	return integrationTestScenarios
 }
 
-// initializeTestStatusesWithDefer creates and initializes test status tracking with deferred update setup
-// Returns the testStatuses and a cleanup function that should be deferred
-func (a *Adapter) initializeTestStatusesWithDefer(integrationTestScenarios *[]v1beta2.IntegrationTestScenario) (*intgteststat.SnapshotIntegrationTestStatuses, func(), error) {
-	testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(a.snapshot)
-	if err != nil {
-		return nil, nil, err
-	}
-	runAfterMap := make(map[string][]string)
-
-	if a.componentGroup != nil && a.componentGroup.Spec.TestGraph != nil {
-		runAfterMap = dag.GetRunAfterMapForTestGraphNodes(a.componentGroup.Spec.TestGraph, integrationTestScenarios)
-	}
-	testStatuses.InitStatuses(integrationTestScenarios, runAfterMap)
-
-	err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Create the deferred function
-	deferFunc := func() {
-		// Try to update status of test if something failed, because test loop can stop prematurely on error,
-		// we should record current status.
-		// This is only best effort update
-		//
-		// When update of statuses worked fine at the end of function, this is just a no-op
-		err := gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
-		if err != nil {
-			a.logger.Error(err, "Defer: Updating statuses of tests in snapshot failed")
-		}
-	}
-
-	return testStatuses, deferFunc, nil
-}
-
 // processSingleScenario handles pipeline creation for a single test scenario
 func (a *Adapter) processSingleScenario(
 	integrationTestScenario *v1beta2.IntegrationTestScenario,
@@ -520,61 +485,179 @@ func (a *Adapter) markSnapshotPassedIfNoRequiredScenarios() (controller.Operatio
 	return controller.ContinueProcessing()
 }
 
-// EnsureIntegrationPipelineRunsExist is an operation that will ensure that all Integration pipeline runs
-// associated with the Snapshot and the Application's IntegrationTestScenarios exist.
-// If a testGraph is defined in the componentGroup, then only root nodes are processed and started.
+// areRunAfterRequirementsSatisfiedForScenario returns true if the run requirements are satisfied for a scenario
+// It checks the scenario's runAfter list to see if the scenarios are finished and checks if it should fail fast if they failed.
+func (a *Adapter) areRunAfterRequirementsSatisfiedForScenario(
+	scenarioName string,
+	testStatuses *intgteststat.SnapshotIntegrationTestStatuses,
+) bool {
+	detail, ok := testStatuses.GetScenarioStatus(scenarioName)
+	if !ok || len(detail.RunAfter) == 0 {
+		return ok // empty runAfter => root / no DAG edge
+	}
+	numSatisfied := 0
+	for _, parentName := range detail.RunAfter {
+		parentDetail, ok := testStatuses.GetScenarioStatus(parentName)
+		if !ok {
+			a.logger.Info(fmt.Sprintf("Failed to get scenario status for parent %s in the runAfter list of the %s scenario", parentName, scenarioName))
+			return false
+		}
+		if !parentDetail.Status.IsFinal() {
+			return false
+		}
+		if parentDetail.Status.IsPassed() {
+			numSatisfied++
+		} else {
+			if a.componentGroup == nil || a.componentGroup.Spec.TestGraph == nil {
+				return false
+			}
+			if !dag.ShouldFailFastForScenariosParent(
+				a.componentGroup.Spec.TestGraph, scenarioName, parentName,
+			) {
+				numSatisfied++
+			}
+		}
+	}
+	return numSatisfied >= len(detail.RunAfter)
+}
+
+// isScenarioPendingWithoutPLR returns true if the scenario is in a pending state and does not have
+// an associated test pipelineRun name defined
+func (a *Adapter) isScenarioPendingWithoutPLR(
+	scenarioName string,
+	testStatuses *intgteststat.SnapshotIntegrationTestStatuses,
+) bool {
+	detail, ok := testStatuses.GetScenarioStatus(scenarioName)
+	if !ok {
+		return true
+	}
+	return detail.Status == intgteststat.IntegrationTestStatusPending &&
+		detail.TestPipelineRunName == ""
+}
+
+// findScenariosReadyToRunWithoutPLR returns all applicable scenarios that should
+// have a PipelineRun created now but do not yet.
+func (a *Adapter) findScenariosReadyToRunWithoutPLR(
+	integrationTestScenarios *[]v1beta2.IntegrationTestScenario,
+	testStatuses *intgteststat.SnapshotIntegrationTestStatuses,
+) []v1beta2.IntegrationTestScenario {
+	if integrationTestScenarios == nil {
+		return nil
+	}
+	var ready []v1beta2.IntegrationTestScenario
+	for _, scenario := range *integrationTestScenarios {
+		if a.isScenarioPendingWithoutPLR(scenario.Name, testStatuses) &&
+			a.areRunAfterRequirementsSatisfiedForScenario(scenario.Name, testStatuses) {
+			ready = append(ready, scenario)
+		}
+	}
+	return ready
+}
+
+// cascadeFailFastFromFailedScenarios goes through the scenarios which have runAfter and checks if their parent scenarios
+// have failed testing and marks them as also failed if the failFast option in their testGraph is set to `true`.
+// It will then cascade that failure to their dependents to make sure that the
+// failure is propagated through all levels of the test graph.
+func (a *Adapter) cascadeFailFastFromFailedScenarios(
+	testStatuses *intgteststat.SnapshotIntegrationTestStatuses,
+) {
+	if a.componentGroup == nil || a.componentGroup.Spec.TestGraph == nil {
+		return
+	}
+	for _, detail := range testStatuses.GetStatuses() {
+		if detail.Status.IsFinal() && !detail.Status.IsPassed() {
+			dag.CascadeFailFastDependents(
+				a.componentGroup.Spec.TestGraph, testStatuses, detail.ScenarioName,
+			)
+		}
+	}
+}
+
+// initializeOrLoadTestStatuses checks if the test statuses have been set and initializes them in case they are missing
+// for the given list of integrationTestScenarios
+func (a *Adapter) initializeOrLoadTestStatuses(
+	integrationTestScenarios *[]v1beta2.IntegrationTestScenario,
+) (*intgteststat.SnapshotIntegrationTestStatuses, func(), error) {
+	testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(a.snapshot)
+	if err != nil {
+		return nil, nil, err
+	}
+	runAfterMap := map[string][]string{}
+	if a.componentGroup != nil && a.componentGroup.Spec.TestGraph != nil {
+		runAfterMap = dag.GetRunAfterMapForTestGraphNodes(
+			a.componentGroup.Spec.TestGraph, integrationTestScenarios,
+		)
+	}
+	testStatuses.InitStatuses(integrationTestScenarios, runAfterMap)
+	deferFunc := func() {
+		if err := gitops.WriteIntegrationTestStatusesIntoSnapshot(
+			a.context, a.snapshot, testStatuses, a.client,
+		); err != nil {
+			a.logger.Error(err, "Defer: Updating statuses of tests in snapshot failed")
+		}
+	}
+	return testStatuses, deferFunc, nil
+}
+
+// createEligibleIntegrationPipelineRuns creates PipelineRuns for every scenario that is
+// eligible to run now but has not yet been started. Handles both roots and dependents.
+func (a *Adapter) createEligibleIntegrationPipelineRuns(
+	integrationTestScenarios *[]v1beta2.IntegrationTestScenario,
+) error {
+	if integrationTestScenarios == nil {
+		return nil
+	}
+	testStatuses, deferFunc, err := a.initializeOrLoadTestStatuses(integrationTestScenarios)
+	if err != nil {
+		return err
+	}
+	defer deferFunc()
+	a.cascadeFailFastFromFailedScenarios(testStatuses)
+
+	superseded, err := a.isSnapshotSupersededInPRGroup()
+	if err != nil {
+		return err
+	}
+
+	var errsForPLRCreation error
+
+	if !superseded {
+		readyScenarios := a.findScenariosReadyToRunWithoutPLR(integrationTestScenarios, testStatuses)
+		if len(readyScenarios) > 0 {
+			errsForPLRCreation = a.processAllScenarios(&readyScenarios, testStatuses)
+		}
+	}
+
+	a.cancelOldPipelinesIfNeeded()
+
+	if testStatuses.IsDirty() {
+		if err := gitops.WriteIntegrationTestStatusesIntoSnapshot(
+			a.context, a.snapshot, testStatuses, a.client,
+		); err != nil {
+			errsForPLRCreation = errors.Join(errsForPLRCreation, err)
+		}
+	}
+	return errsForPLRCreation
+}
+
 func (a *Adapter) EnsureIntegrationPipelineRunsExist() (controller.OperationResult, error) {
 	if gitops.HaveAppStudioTestsFinished(a.snapshot) {
 		a.logger.Info("The Snapshot has finished testing.")
 		return controller.ContinueProcessing()
 	}
-
-	if metadata.HasAnnotation(a.snapshot, gitops.SnapshotTestsStatusAnnotation) {
-		a.logger.Info("The Snapshot has its test.appstudio.openshift.io/status annotation already defined and has already started testing.")
-		return controller.ContinueProcessing()
-	}
-
 	integrationTestScenarios := a.loadAndFilterIntegrationTestScenarios()
-
 	var errsForPLRCreation error
-
-	// Process scenarios if they exist
 	if integrationTestScenarios != nil {
-		testStatuses, deferFunc, err := a.initializeTestStatusesWithDefer(integrationTestScenarios)
-		if err != nil {
-			return controller.RequeueWithError(err)
-		}
-		defer deferFunc()
-
-		if a.componentGroup != nil && a.componentGroup.Spec.TestGraph != nil {
-			integrationTestScenarios = dag.FilterRootIntegrationTestScenarios(a.componentGroup.Spec.TestGraph, integrationTestScenarios)
-		}
-
-		// Process all scenarios
-		errsForPLRCreation = a.processAllScenarios(integrationTestScenarios, testStatuses)
-
-		// Cancel old pipelines if needed
-		a.cancelOldPipelinesIfNeeded()
-
-		// Persist final status
-		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
-		if err != nil {
-			a.logger.Error(err, "Failed to update test status in snapshot annotation")
-			errsForPLRCreation = errors.Join(errsForPLRCreation, err)
-		}
+		errsForPLRCreation = a.createEligibleIntegrationPipelineRuns(integrationTestScenarios)
 	}
-
-	// Always validate required scenarios, even if scenario loading failed
 	result, err := a.markSnapshotPassedIfNoRequiredScenarios()
 	if err != nil || result.CancelRequest {
 		return result, err
 	}
-
 	// Return any pipeline creation errors after required scenario validation
 	if errsForPLRCreation != nil {
 		return controller.RequeueWithError(errsForPLRCreation)
 	}
-
 	return controller.ContinueProcessing()
 }
 
@@ -960,85 +1043,6 @@ func (a *Adapter) EnsureGroupSnapshotExist() (controller.OperationResult, error)
 		return controller.RequeueWithError(err)
 	}
 	return controller.ContinueProcessing()
-}
-
-// EnsureDependentPipelineRunsExist ensures any dependent integration tests that are supposed to run after other test pipelines
-// and have their requirements satisfied are started.
-func (a *Adapter) EnsureDependentPipelineRunsExist() (controller.OperationResult, error) {
-	if gitops.HaveAppStudioTestsFinished(a.snapshot) {
-		a.logger.Info("The Snapshot has finished testing.")
-		return controller.ContinueProcessing()
-	}
-
-	// This logic only applies to Snapshots associated with componentGroups which have spec.testGraph defined
-	if a.componentGroup == nil || a.componentGroup.Spec.TestGraph == nil {
-		return controller.ContinueProcessing()
-	}
-
-	var err error
-	var errsForPLRCreation error
-
-	allIntegrationScenariosForComponentGroup, err := a.loader.GetAllIntegrationTestScenariosForComponentGroup(a.context, a.client, a.componentGroup)
-	if err != nil {
-		return controller.RequeueWithError(err)
-	}
-	testStatuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(a.snapshot)
-	if err != nil {
-		return controller.RequeueWithError(err)
-	}
-
-	// Find and process dependent scenarios which have runAfter requirements satisfied
-	dependentIntegrationScenariosToRun := a.findPendingScenariosWithSatisfiedRunAfter(allIntegrationScenariosForComponentGroup, testStatuses)
-	if dependentIntegrationScenariosToRun != nil {
-		// Process all scenarios
-		errsForPLRCreation = a.processAllScenarios(dependentIntegrationScenariosToRun, testStatuses)
-
-		// Persist final status
-		err = gitops.WriteIntegrationTestStatusesIntoSnapshot(a.context, a.snapshot, testStatuses, a.client)
-		if err != nil {
-			a.logger.Error(err, "Failed to update test status in snapshot annotation")
-			errsForPLRCreation = errors.Join(errsForPLRCreation, err)
-		}
-	}
-
-	// Return any pipeline creation errors
-	if errsForPLRCreation != nil {
-		return controller.RequeueWithError(errsForPLRCreation)
-	}
-
-	return controller.ContinueProcessing()
-}
-
-// findPendingScenariosWithSatisfiedRunAfter finds all pending IntegrationTestScenarios which have all of the scenarios
-// listed in their runAfter map finished and satisfied the requirements to run the scenario.
-func (a *Adapter) findPendingScenariosWithSatisfiedRunAfter(allIntegrationTestScenarios *[]v1beta2.IntegrationTestScenario, testStatuses *intgteststat.SnapshotIntegrationTestStatuses) *[]v1beta2.IntegrationTestScenario {
-	var dependentIntegrationScenariosToRun []v1beta2.IntegrationTestScenario
-	for _, scenario := range *allIntegrationTestScenarios {
-		scenarioDetail, found := testStatuses.GetScenarioStatus(scenario.Name)
-		// Check if pending test scenarios have runAfter requirements
-		if found && scenarioDetail.Status == intgteststat.IntegrationTestStatusPending && scenarioDetail.RunAfter != nil && len(scenarioDetail.RunAfter) > 0 {
-			numRunAfter := 0
-			// Check if all runAfter scenarios have finished
-			for _, runAfterScenario := range scenarioDetail.RunAfter {
-				testDetails, ok := testStatuses.GetScenarioStatus(runAfterScenario)
-				if ok && testDetails.Status.IsFinal() {
-					if testDetails.Status == intgteststat.IntegrationTestStatusTestPassed {
-						numRunAfter++
-					} else {
-						// Consider the runAfter scenario as finished if failFast option isn't set to true
-						if !dag.ShouldFailFastForScenariosParent(a.componentGroup.Spec.TestGraph, scenario.Name, runAfterScenario) {
-							numRunAfter++
-						}
-					}
-				}
-			}
-			// Iff all runAfter scenarios have finished in the required manner, add it to the list
-			if numRunAfter >= len(scenarioDetail.RunAfter) {
-				dependentIntegrationScenariosToRun = append(dependentIntegrationScenariosToRun, scenario)
-			}
-		}
-	}
-	return &dependentIntegrationScenariosToRun
 }
 
 // createMissingReleasesForReleasePlans checks if there's existing Releases for a given list of ReleasePlans and creates
@@ -1497,9 +1501,13 @@ func (a *Adapter) filterPipelineRunsForComponentGroup(allPipelineRuns *[]tektonv
 	return &filteredPipelineRuns
 }
 
-// checkAndCancelOldSnapshotsPipelineRun sorts all snapshots for component group and cancels all running integrationTest pipelineruns within component group
-// removes finalizer before the pipelinerun is set as CancelledRunFinally to be gracefully cancelled
-func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun() error {
+// getSortedPRSnapshotsForSupersession returns PR component or group snapshots for the
+// current adapter snapshot, sorted newest-first. Returns nil when not applicable
+// (push event, non-PR snapshot, etc.).
+func (a *Adapter) getSortedPRSnapshotsForSupersession() ([]applicationapiv1alpha1.Snapshot, error) {
+	if gitops.IsSnapshotCreatedByPACPushEvent(a.snapshot) {
+		return nil, nil
+	}
 	var err error
 	snapshots := &[]applicationapiv1alpha1.Snapshot{}
 	if gitops.IsComponentSnapshot(a.snapshot) {
@@ -1508,23 +1516,22 @@ func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun() error {
 			if err != nil {
 				a.logger.Error(err, "Failed to fetch Snapshots for the application",
 					"application.Name:", a.application.Name)
-				return err
+				return nil, err
 			}
 		} else {
 			snapshots, err = a.loader.GetAllSnapshotsForPR(a.context, a.client, a.componentGroup.ObjectMeta, a.snapshot.GetLabels()[gitops.SnapshotComponentLabel], a.snapshot.GetLabels()[gitops.PipelineAsCodePullRequestAnnotation])
 			if err != nil {
 				a.logger.Error(err, "Failed to fetch Snapshots for the componentGroup",
 					"componentGroup.Name:", a.componentGroup.Name)
-				return err
+				return nil, err
 			}
 		}
 	}
-
 	if gitops.IsGroupSnapshot(a.snapshot) {
 		prGroupHash, prGroup := gitops.GetPRGroup(a.snapshot)
 		if prGroupHash == "" || prGroup == "" {
 			a.logger.Error(fmt.Errorf("pr group info can't be found in group snapshot"), "snapshot.Namespace", a.snapshot.Namespace, "snapshot.Name", a.snapshot.Name)
-			return fmt.Errorf("pr group info can't be found in group snapshot %s/%s", a.snapshot.Namespace, a.snapshot.Name)
+			return nil, fmt.Errorf("pr group info can't be found in group snapshot %s/%s", a.snapshot.Namespace, a.snapshot.Name)
 		}
 		// TODO: remove if statement when we deprecated old application model
 		if a.application != nil {
@@ -1534,12 +1541,21 @@ func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun() error {
 		}
 		if err != nil {
 			a.logger.Error(fmt.Errorf("failed to get group snapshot for pr group from group snapshot"), "snapshot.Namespace", a.snapshot.Namespace, "snapshot.Name", a.snapshot.Name)
-			return err
+			return nil, err
 		}
 
 	}
+	return gitops.SortSnapshots(*snapshots), nil
+}
 
-	sortedSnapshots := gitops.SortSnapshots(*snapshots)
+// checkAndCancelOldSnapshotsPipelineRun sorts all snapshots for component group and cancels all running integrationTest pipelineruns within component group
+// removes finalizer before the pipelinerun is set as CancelledRunFinally to be gracefully cancelled
+func (a *Adapter) checkAndCancelOldSnapshotsPipelineRun() error {
+	var err error
+	sortedSnapshots, err := a.getSortedPRSnapshotsForSupersession()
+	if err != nil {
+		return err
+	}
 	// no snapshots found that fulfill the condition
 	if len(sortedSnapshots) < 2 {
 		return nil
@@ -1578,6 +1594,17 @@ func (a *Adapter) cancelAllPipelineRunsForSnapshot(snapshot *applicationapiv1alp
 		return nil
 	}
 	return gitops.CancelPipelineRuns(a.client, a.context, a.logger, integrationTestPipelineRuns)
+}
+
+// isSnapshotSupersededInPRGroup reports whether a.snapshot is not the newest
+// snapshot in its PR component/group set.
+func (a *Adapter) isSnapshotSupersededInPRGroup() (bool, error) {
+	sortedSnapshots, err := a.getSortedPRSnapshotsForSupersession()
+	if err != nil || len(sortedSnapshots) == 0 {
+		return false, err
+	}
+	newest := &sortedSnapshots[0]
+	return newest.Name != a.snapshot.Name || newest.Namespace != a.snapshot.Namespace, nil
 }
 
 // isSnapshotOlderThanLastBuild queries sibling push snapshots instead of comparing against

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/konflux-ci/integration-service/pkg/dag"
 	"github.com/tonglil/buflogr"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/propagation"
@@ -54,6 +55,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 	v1 "knative.dev/pkg/apis/duck/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/konflux-ci/integration-service/gitops"
 	"github.com/konflux-ci/integration-service/helpers"
@@ -140,20 +142,21 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 		integrationPipelineRunOld                 *tektonv1.PipelineRun
 	)
 	const (
-		SampleRepoLink            = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
-		sample_image              = "quay.io/redhat-appstudio/sample-image"
-		sample_revision           = "random-value"
-		sample_commit             = "a2ba645d50e471d5f084b"
-		sampleDigest              = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-		customLabel               = "custom.appstudio.openshift.io/custom-label"
-		sourceRepoRef             = "db2c043b72b3f8d292ee0e38768d0a94859a308b"
-		hasComSnapshot1Name       = "hascomsnapshot1-sample"
-		hasComSnapshot2Name       = "hascomsnapshot2-sample"
-		hasComSnapshot3Name       = "hascomsnapshot3-sample"
-		cgSnapshotName            = "componentgroup-snapshot-sample"
-		prGroup                   = "feature1"
-		prGroupSha                = "feature1hash"
-		plrstarttime        int64 = 1775992257000 // milliseconds (was 1775992257 seconds)
+		SampleRepoLink               = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		sample_image                 = "quay.io/redhat-appstudio/sample-image"
+		sample_revision              = "random-value"
+		sample_commit                = "a2ba645d50e471d5f084b"
+		sampleDigest                 = "sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
+		customLabel                  = "custom.appstudio.openshift.io/custom-label"
+		sourceRepoRef                = "db2c043b72b3f8d292ee0e38768d0a94859a308b"
+		hasComSnapshot1Name          = "hascomsnapshot1-sample"
+		hasComSnapshot2Name          = "hascomsnapshot2-sample"
+		hasComSnapshot3Name          = "hascomsnapshot3-sample"
+		cgSnapshotName               = "componentgroup-snapshot-sample"
+		prGroup                      = "feature1"
+		prGroupSha                   = "feature1hash"
+		plrstarttime           int64 = 1775992257000 // milliseconds (was 1775992257 seconds)
+		ensurePLRSourceRepoRef       = "a2ba645d50e471d5f084b"
 	)
 
 	BeforeAll(func() {
@@ -1119,11 +1122,21 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 
 			// It will not re-trigger integration pipelineRuns
 			result, err = adapter.EnsureIntegrationPipelineRunsExist()
-			expectedLogEntry = "Found existing integrationPipelineRun"
-			Expect(buf.String()).Should(ContainSubstring(expectedLogEntry))
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(result.RequeueRequest).To(BeFalse())
 			Expect(err).ToNot(HaveOccurred())
+
+			Eventually(func() error {
+				integrationPipelineRuns, err = adapter.loader.GetAllIntegrationPipelineRunsForSnapshot(adapter.context, k8sClient, hasCGSnapshot)
+				if err != nil {
+					return err
+				}
+
+				if expected, got := 1, len(integrationPipelineRuns); expected != got {
+					return fmt.Errorf("found %d PipelineRuns, expected: %d", got, expected)
+				}
+				return nil
+			}, time.Second*10).Should(Succeed())
 		})
 
 		It("ensures global Component Image will not be updated in the PR context", func() {
@@ -4991,5 +5004,530 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(result.CancelRequest).To(BeFalse())
 		})
 	})
+})
 
+var _ = Describe("Dependent scenarios snapshot adapter scheduling", Ordered, func() {
+	const (
+		sampleRepoLink                     = "https://github.com/devfile-samples/devfile-sample-java-springboot-basic"
+		sampleImage                        = "quay.io/redhat-appstudio/sample-image"
+		samplePRGroup                      = "feature1"
+		samplePLRStartTime           int64 = 1775992257000
+		sampleEnsurePLRSourceRepoRef       = "a2ba645d50e471d5f084b"
+	)
+	var (
+		sampleLogger         helpers.IntegrationLogger
+		sampleAdapter        *Adapter
+		sampleComponent      *applicationapiv1alpha1.Component
+		sampleComponentGroup *v1beta2.ComponentGroup
+		sampleSnapshot       *applicationapiv1alpha1.Snapshot
+		scenarioRoot         *v1beta2.IntegrationTestScenario
+		scenarioDependent    *v1beta2.IntegrationTestScenario
+	)
+
+	createSampleScenario := func(name string) *v1beta2.IntegrationTestScenario {
+		scenario := &v1beta2.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      name,
+				Namespace: "default",
+				Labels: map[string]string{
+					"test.appstudio.openshift.io/optional": "false",
+				},
+			},
+			Spec: v1beta2.IntegrationTestScenarioSpec{
+				ComponentGroup: sampleComponentGroup.Name,
+				ResolverRef: v1beta2.ResolverRef{
+					Resolver: "git",
+					Params: []v1beta2.ResolverParameter{
+						{Name: "url", Value: "https://github.com/redhat-appstudio/integration-examples.git"},
+						{Name: "revision", Value: sampleEnsurePLRSourceRepoRef},
+						{Name: "pathInRepo", Value: "pipelineruns/integration_pipelinerun_pass.yaml"},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, scenario)).To(Succeed())
+		helpers.SetScenarioIntegrationStatusAsValid(scenario, "valid")
+		return scenario
+	}
+
+	newSampleAdapter := func(snapshot *applicationapiv1alpha1.Snapshot, buf *bytes.Buffer) *Adapter {
+		log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(buf)}
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      sampleComponentGroup.Name,
+			Namespace: sampleComponentGroup.Namespace,
+		}, sampleComponentGroup)).To(Succeed())
+		sampleAdapter = NewAdapter(ctx, snapshot, sampleComponentGroup, log, loader.NewMockLoader(), k8sClient)
+		sampleAdapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+			{
+				ContextKey: loader.ComponentGroupContextKey,
+				Resource:   sampleComponentGroup,
+			},
+			{
+				ContextKey: loader.ComponentContextKey,
+				Resource:   sampleComponent,
+			},
+			{
+				ContextKey: loader.SnapshotContextKey,
+				Resource:   snapshot,
+			},
+			{
+				ContextKey: loader.SnapshotComponentsContextKey,
+				Resource:   []applicationapiv1alpha1.Component{*sampleComponent},
+			},
+		})
+		return sampleAdapter
+	}
+
+	refreshSampleSnapshot := func() {
+		Expect(k8sClient.Get(ctx, types.NamespacedName{
+			Name:      sampleSnapshot.Name,
+			Namespace: sampleSnapshot.Namespace,
+		}, sampleSnapshot)).To(Succeed())
+	}
+
+	countSampleIntegrationPLRs := func(snapshot *applicationapiv1alpha1.Snapshot) int {
+		plrLoader := loader.NewLoader()
+		pipelineRuns, err := plrLoader.GetAllIntegrationPipelineRunsForSnapshot(ctx, k8sClient, snapshot)
+		Expect(err).NotTo(HaveOccurred())
+		return len(pipelineRuns)
+	}
+
+	initTestStatuses := func(
+		scenarios []v1beta2.IntegrationTestScenario,
+		testGraph map[string][]v1beta2.TestGraphNode,
+	) *intgteststat.SnapshotIntegrationTestStatuses {
+		statuses, err := intgteststat.NewSnapshotIntegrationTestStatuses("")
+		Expect(err).NotTo(HaveOccurred())
+		runAfterMap := map[string][]string{}
+		if testGraph != nil {
+			scenarioPtrs := make([]v1beta2.IntegrationTestScenario, len(scenarios))
+			copy(scenarioPtrs, scenarios)
+			runAfterMap = dag.GetRunAfterMapForTestGraphNodes(testGraph, &scenarioPtrs)
+		}
+		scenarioPtrs := make([]v1beta2.IntegrationTestScenario, len(scenarios))
+		copy(scenarioPtrs, scenarios)
+		statuses.InitStatuses(&scenarioPtrs, runAfterMap)
+		return statuses
+	}
+
+	BeforeAll(func() {
+		sampleLogger = helpers.IntegrationLogger{Logger: buflogr.New()}
+
+		sampleComponent = &applicationapiv1alpha1.Component{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample-component",
+				Namespace: "default",
+			},
+			Spec: applicationapiv1alpha1.ComponentSpec{
+				ComponentName: "sample-component",
+				Application:   "application-sample",
+				Source: applicationapiv1alpha1.ComponentSource{
+					ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+						GitSource: &applicationapiv1alpha1.GitSource{
+							URL:      sampleRepoLink,
+							Revision: "revision",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sampleComponent)).To(Succeed())
+
+		sampleComponentGroup = &v1beta2.ComponentGroup{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample-component-group",
+				Namespace: "default",
+			},
+			Spec: v1beta2.ComponentGroupSpec{
+				Components: []v1beta2.ComponentReference{
+					{
+						Name: "sample-component",
+						ComponentVersion: v1beta2.ComponentVersionReference{
+							Name:     "v1",
+							Revision: "main",
+						},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sampleComponentGroup)).To(Succeed())
+
+		sampleSnapshot = &applicationapiv1alpha1.Snapshot{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "sample-snapshot",
+				Namespace: "default",
+				Labels: map[string]string{
+					gitops.SnapshotTypeLabel:            gitops.SnapshotComponentType,
+					gitops.SnapshotComponentLabel:       "sample-component",
+					gitops.PipelineAsCodeEventTypeLabel: "push",
+				},
+			},
+			Spec: applicationapiv1alpha1.SnapshotSpec{
+				ComponentGroup: sampleComponentGroup.Name,
+				Components: []applicationapiv1alpha1.SnapshotComponent{
+					{
+						Name:           "sample-component",
+						ContainerImage: sampleImage,
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, sampleSnapshot)).To(Succeed())
+
+		scenarioRoot = createSampleScenario("sample-scenario-root")
+		scenarioDependent = createSampleScenario("sample-scenario-dependent")
+	})
+
+	AfterAll(func() {
+		for _, obj := range []client.Object{
+			sampleSnapshot, scenarioRoot, scenarioDependent, sampleComponentGroup, sampleComponent,
+		} {
+			_ = k8sClient.Delete(ctx, obj)
+		}
+		plrLoader := loader.NewLoader()
+		pipelineRuns, err := plrLoader.GetAllIntegrationPipelineRunsForSnapshot(ctx, k8sClient, sampleSnapshot)
+		if err == nil {
+			for _, pipelineRun := range pipelineRuns {
+				_ = k8sClient.Delete(ctx, &pipelineRun)
+			}
+		}
+	})
+
+	BeforeEach(func() {
+		refreshSampleSnapshot()
+		plrLoader := loader.NewLoader()
+		pipelineRuns, err := plrLoader.GetAllIntegrationPipelineRunsForSnapshot(ctx, k8sClient, sampleSnapshot)
+		Expect(err).NotTo(HaveOccurred())
+		for i := range pipelineRuns {
+			Expect(k8sClient.Delete(ctx, &pipelineRuns[i])).To(Succeed())
+		}
+		if sampleSnapshot.GetAnnotations() != nil {
+			patch := client.MergeFrom(sampleSnapshot.DeepCopy())
+			delete(sampleSnapshot.Annotations, gitops.SnapshotTestsStatusAnnotation)
+			Expect(k8sClient.Patch(ctx, sampleSnapshot, patch)).To(Succeed())
+			refreshSampleSnapshot()
+		}
+	})
+
+	Describe("scheduling helper methods", func() {
+		var (
+			helperAdapter *Adapter
+			testGraph     map[string][]v1beta2.TestGraphNode
+		)
+
+		BeforeEach(func() {
+			testGraph = map[string][]v1beta2.TestGraphNode{
+				"scenario-b": {
+					{Name: "scenario-a", FailFast: false},
+				},
+				"scenario-c": {
+					{Name: "scenario-a", FailFast: true},
+				},
+			}
+			helperAdapter = NewAdapter(ctx, sampleSnapshot, &v1beta2.ComponentGroup{
+				ObjectMeta: metav1.ObjectMeta{Name: "helpers-cg", Namespace: "default"},
+				Spec: v1beta2.ComponentGroupSpec{
+					TestGraph: testGraph,
+				},
+			}, sampleLogger, loader.NewMockLoader(), k8sClient)
+		})
+
+		Describe("isScenarioPendingWithoutPLR", func() {
+			It("returns true when the scenario is unknown", func() {
+				statuses, _ := intgteststat.NewSnapshotIntegrationTestStatuses("")
+				Expect(helperAdapter.isScenarioPendingWithoutPLR("missing", statuses)).To(BeTrue())
+			})
+
+			It("returns true for pending scenarios without a pipelineRun name", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{{ObjectMeta: metav1.ObjectMeta{Name: "scenario-a"}}},
+					nil,
+				)
+				Expect(helperAdapter.isScenarioPendingWithoutPLR("scenario-a", statuses)).To(BeTrue())
+			})
+
+			It("returns false when a pipelineRun name is already registered", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{{ObjectMeta: metav1.ObjectMeta{Name: "scenario-a"}}},
+					nil,
+				)
+				Expect(statuses.UpdateTestPipelineRunName("scenario-a", "existing-plr")).To(Succeed())
+				Expect(helperAdapter.isScenarioPendingWithoutPLR("scenario-a", statuses)).To(BeFalse())
+			})
+		})
+
+		Describe("areRunAfterRequirementsSatisfiedForScenario", func() {
+			It("treats empty runAfter as satisfied for known scenarios", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{{ObjectMeta: metav1.ObjectMeta{Name: "scenario-a"}}},
+					nil,
+				)
+				Expect(helperAdapter.areRunAfterRequirementsSatisfiedForScenario("scenario-a", statuses)).To(BeTrue())
+			})
+
+			It("returns false when a parent is still running", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{
+						{ObjectMeta: metav1.ObjectMeta{Name: "scenario-a"}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "scenario-b"}},
+					},
+					testGraph,
+				)
+				Expect(helperAdapter.areRunAfterRequirementsSatisfiedForScenario("scenario-b", statuses)).To(BeFalse())
+			})
+
+			It("returns true when a non-fail-fast parent has failed", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{
+						{ObjectMeta: metav1.ObjectMeta{Name: "scenario-a"}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "scenario-b"}},
+					},
+					testGraph,
+				)
+				statuses.UpdateTestStatusIfChanged("scenario-a", intgteststat.IntegrationTestStatusTestFail, "failed")
+				Expect(helperAdapter.areRunAfterRequirementsSatisfiedForScenario("scenario-b", statuses)).To(BeTrue())
+			})
+
+			It("returns false when a fail-fast parent has failed", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{
+						{ObjectMeta: metav1.ObjectMeta{Name: "scenario-a"}},
+						{ObjectMeta: metav1.ObjectMeta{Name: "scenario-c"}},
+					},
+					testGraph,
+				)
+				statuses.UpdateTestStatusIfChanged("scenario-a", intgteststat.IntegrationTestStatusTestFail, "failed")
+				Expect(helperAdapter.areRunAfterRequirementsSatisfiedForScenario("scenario-c", statuses)).To(BeFalse())
+			})
+		})
+
+		Describe("findScenariosReadyToRunWithoutPLR", func() {
+			It("returns only root scenarios while parents are still pending", func() {
+				scenarios := []v1beta2.IntegrationTestScenario{
+					{ObjectMeta: metav1.ObjectMeta{Name: scenarioRoot.Name}},
+					{ObjectMeta: metav1.ObjectMeta{Name: scenarioDependent.Name}},
+				}
+				statuses := initTestStatuses(scenarios, map[string][]v1beta2.TestGraphNode{
+					scenarioDependent.Name: {{Name: scenarioRoot.Name, FailFast: false}},
+				})
+				adapterWithGraph := NewAdapter(ctx, sampleSnapshot, &v1beta2.ComponentGroup{
+					Spec: v1beta2.ComponentGroupSpec{TestGraph: map[string][]v1beta2.TestGraphNode{
+						scenarioDependent.Name: {{Name: scenarioRoot.Name, FailFast: false}},
+					}},
+				}, sampleLogger, loader.NewMockLoader(), k8sClient)
+
+				ready := adapterWithGraph.findScenariosReadyToRunWithoutPLR(&scenarios, statuses)
+				Expect(ready).To(HaveLen(1))
+				Expect(ready[0].Name).To(Equal(scenarioRoot.Name))
+			})
+
+			It("returns dependents once every parent has passed", func() {
+				scenarios := []v1beta2.IntegrationTestScenario{
+					{ObjectMeta: metav1.ObjectMeta{Name: scenarioRoot.Name}},
+					{ObjectMeta: metav1.ObjectMeta{Name: scenarioDependent.Name}},
+				}
+				statuses := initTestStatuses(scenarios, map[string][]v1beta2.TestGraphNode{
+					scenarioDependent.Name: {{Name: scenarioRoot.Name, FailFast: false}},
+				})
+				statuses.UpdateTestStatusIfChanged(
+					scenarioRoot.Name, intgteststat.IntegrationTestStatusTestPassed, "passed",
+				)
+				Expect(statuses.UpdateTestPipelineRunName(scenarioRoot.Name, "sample-root-plr")).To(Succeed())
+
+				adapterWithGraph := NewAdapter(ctx, sampleSnapshot, &v1beta2.ComponentGroup{
+					Spec: v1beta2.ComponentGroupSpec{TestGraph: map[string][]v1beta2.TestGraphNode{
+						scenarioDependent.Name: {{Name: scenarioRoot.Name, FailFast: false}},
+					}},
+				}, sampleLogger, loader.NewMockLoader(), k8sClient)
+
+				ready := adapterWithGraph.findScenariosReadyToRunWithoutPLR(&scenarios, statuses)
+				Expect(ready).To(HaveLen(1))
+				Expect(ready[0].Name).To(Equal(scenarioDependent.Name))
+			})
+		})
+
+		Describe("cascadeFailFastFromFailedScenarios", func() {
+			It("marks fail-fast dependents as failed without starting them", func() {
+				statuses := initTestStatuses(
+					[]v1beta2.IntegrationTestScenario{
+						{ObjectMeta: metav1.ObjectMeta{Name: scenarioRoot.Name}},
+						{ObjectMeta: metav1.ObjectMeta{Name: scenarioDependent.Name}},
+					},
+					map[string][]v1beta2.TestGraphNode{
+						scenarioDependent.Name: {{Name: scenarioRoot.Name, FailFast: true}},
+					},
+				)
+				statuses.UpdateTestStatusIfChanged(
+					scenarioRoot.Name, intgteststat.IntegrationTestStatusTestFail, "failed",
+				)
+				adapterWithGraph := NewAdapter(ctx, sampleSnapshot, &v1beta2.ComponentGroup{
+					Spec: v1beta2.ComponentGroupSpec{TestGraph: map[string][]v1beta2.TestGraphNode{
+						scenarioDependent.Name: {{Name: scenarioRoot.Name, FailFast: true}},
+					}},
+				}, sampleLogger, loader.NewMockLoader(), k8sClient)
+
+				adapterWithGraph.cascadeFailFastFromFailedScenarios(statuses)
+
+				dependentDetail, ok := statuses.GetScenarioStatus(scenarioDependent.Name)
+				Expect(ok).To(BeTrue())
+				Expect(dependentDetail.Status).To(Equal(intgteststat.IntegrationTestStatusTestFail))
+				Expect(dependentDetail.Details).To(Equal(
+					fmt.Sprintf("Cancelled on account of required %s failing", scenarioRoot.Name),
+				))
+			})
+		})
+	})
+
+	Describe("isSnapshotSupersededInPRGroup", func() {
+		It("returns false for push snapshots", func() {
+			adapter := newSampleAdapter(sampleSnapshot, &bytes.Buffer{})
+			superseded, err := adapter.isSnapshotSupersededInPRGroup()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(superseded).To(BeFalse())
+		})
+
+		It("returns true when the adapter snapshot is not the newest in the PR group", func() {
+			oldPRSnapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample-old-pr-snapshot",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:              "sample-component",
+						gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+						gitops.PipelineAsCodePullRequestAnnotation: "99",
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime: strconv.FormatInt(samplePLRStartTime, 10),
+					},
+				},
+			}
+			newPRSnapshot := applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample-new-pr-snapshot",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:              "sample-component",
+						gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+						gitops.PipelineAsCodePullRequestAnnotation: "99",
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime: strconv.FormatInt(samplePLRStartTime+100000, 10),
+					},
+				},
+			}
+
+			adapter := NewAdapter(ctx, oldPRSnapshot, sampleComponentGroup, sampleLogger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{{
+				ContextKey: loader.AllSnapshotsForGivenPRContextKey,
+				Resource:   []applicationapiv1alpha1.Snapshot{newPRSnapshot, *oldPRSnapshot},
+			}})
+
+			superseded, err := adapter.isSnapshotSupersededInPRGroup()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(superseded).To(BeTrue())
+		})
+	})
+
+	Describe("ensureMissingIntegrationPipelineRunsExist", func() {
+		It("returns no error when integration test scenarios is nil", func() {
+			adapter := newSampleAdapter(sampleSnapshot, &bytes.Buffer{})
+			Expect(adapter.createEligibleIntegrationPipelineRuns(nil)).NotTo(HaveOccurred())
+		})
+
+		When("no testGraph is defined", func() {
+			It("creates a pipelineRun for a pending scenario", func() {
+				var buf bytes.Buffer
+				adapter := newSampleAdapter(sampleSnapshot, &buf)
+				scenarios := []v1beta2.IntegrationTestScenario{*scenarioRoot}
+
+				Expect(adapter.createEligibleIntegrationPipelineRuns(&scenarios)).NotTo(HaveOccurred())
+				Expect(buf.String()).To(ContainSubstring("Creating new pipelinerun for integrationTestscenario"))
+
+				Eventually(func(g Gomega) {
+					refreshSampleSnapshot()
+					statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(sampleSnapshot)
+					g.Expect(err).NotTo(HaveOccurred())
+					detail, ok := statuses.GetScenarioStatus(scenarioRoot.Name)
+					g.Expect(ok).To(BeTrue())
+					g.Expect(detail.Status).To(Equal(intgteststat.IntegrationTestStatusInProgress))
+					g.Expect(detail.TestPipelineRunName).NotTo(BeEmpty())
+				}).Should(Succeed())
+			})
+		})
+
+		It("skips pipelineRun creation for superseded PR snapshots", func() {
+			oldPRSnapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample-superseded-pr-snapshot",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:              "sample-component",
+						gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+						gitops.PipelineAsCodePullRequestAnnotation: "100",
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime:     strconv.FormatInt(samplePLRStartTime, 10),
+						gitops.PRGroupAnnotation:             samplePRGroup,
+						gitops.IntegrationWorkflowAnnotation: gitops.IntegrationWorkflowPullRequestValue,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					ComponentGroup: sampleComponentGroup.Name,
+					Components: []applicationapiv1alpha1.SnapshotComponent{
+						{Name: "sample-component", ContainerImage: sampleImage},
+					},
+				},
+			}
+			newPRSnapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "sample-newer-pr-snapshot",
+					Namespace: "default",
+					Labels: map[string]string{
+						gitops.SnapshotTypeLabel:                   gitops.SnapshotComponentType,
+						gitops.SnapshotComponentLabel:              "sample-component",
+						gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+						gitops.PipelineAsCodePullRequestAnnotation: "100",
+					},
+					Annotations: map[string]string{
+						gitops.BuildPipelineRunStartTime:     strconv.FormatInt(samplePLRStartTime+100000, 10),
+						gitops.PRGroupAnnotation:             samplePRGroup,
+						gitops.IntegrationWorkflowAnnotation: gitops.IntegrationWorkflowPullRequestValue,
+					},
+				},
+				Spec: applicationapiv1alpha1.SnapshotSpec{
+					ComponentGroup: sampleComponentGroup.Name,
+					Components: []applicationapiv1alpha1.SnapshotComponent{
+						{Name: "sample-component", ContainerImage: sampleImage},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, oldPRSnapshot)).To(Succeed())
+			Expect(k8sClient.Create(ctx, newPRSnapshot)).To(Succeed())
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, oldPRSnapshot)
+				_ = k8sClient.Delete(ctx, newPRSnapshot)
+			})
+
+			var buf bytes.Buffer
+			adapter := NewAdapter(ctx, oldPRSnapshot, sampleComponentGroup, helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{{
+				ContextKey: loader.AllSnapshotsForGivenPRContextKey,
+				Resource:   []applicationapiv1alpha1.Snapshot{*newPRSnapshot, *oldPRSnapshot},
+			}})
+			scenarios := []v1beta2.IntegrationTestScenario{*scenarioRoot}
+
+			Expect(adapter.createEligibleIntegrationPipelineRuns(&scenarios)).NotTo(HaveOccurred())
+			Expect(buf.String()).NotTo(ContainSubstring("Creating new pipelinerun for integrationTestscenario"))
+			Expect(countSampleIntegrationPLRs(oldPRSnapshot)).To(Equal(0))
+
+			statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(oldPRSnapshot)
+			Expect(err).NotTo(HaveOccurred())
+			detail, ok := statuses.GetScenarioStatus(scenarioRoot.Name)
+			Expect(ok).To(BeTrue())
+			Expect(detail.Status).To(Equal(intgteststat.IntegrationTestStatusPending))
+		})
+	})
 })

--- a/internal/controller/snapshot/snapshot_controller.go
+++ b/internal/controller/snapshot/snapshot_controller.go
@@ -233,6 +233,7 @@ func setupControllerWithManager(manager ctrl.Manager, controller *Reconciler) er
 				predicate.Or(
 					gitops.IntegrationSnapshotChangePredicate(),
 					gitops.SnapshotIntegrationTestRerunTriggerPredicate(),
+					gitops.SnapshotTestAnnotationChangePredicate(),
 				),
 			),
 		).

--- a/pkg/dag/utils.go
+++ b/pkg/dag/utils.go
@@ -17,71 +17,93 @@
 package dag
 
 import (
-	"maps"
+	"fmt"
 
 	"github.com/konflux-ci/integration-service/api/v1beta2"
+	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
 )
 
-// FilterRootIntegrationTestScenarios uses Kahn's algorithm on the reversed dependency graph to
-// get root IntegrationTestScenarios.
-func FilterRootIntegrationTestScenarios(testGraph map[string][]v1beta2.TestGraphNode, scenarios *[]v1beta2.IntegrationTestScenario) *[]v1beta2.IntegrationTestScenario {
-	// indegrees[x] = number of nodes that list x as a parent (i.e. x's child count).
-	var filteredScenarios []v1beta2.IntegrationTestScenario
-	graphCopy := maps.Clone(testGraph)
-
-	for _, scenario := range *scenarios {
-		// Ensure every scenario appears in testGraph even if it has no declared
-		// parents.
-		if _, ok := graphCopy[scenario.Name]; !ok {
-			graphCopy[scenario.Name] = []v1beta2.TestGraphNode{}
-		}
-	}
-
-	// Find root nodes (ones which don't depend on any other nodes) and match them with a scenario.
-	for node := range graphCopy {
-		if len(graphCopy[node]) == 0 {
-			for _, scenario := range *scenarios {
-				if scenario.Name == node {
-					filteredScenarios = append(filteredScenarios, scenario)
-					break
-				}
-			}
-		}
-	}
-	return &filteredScenarios
-}
-
 // GetRunAfterMapForTestGraphNodes generates a RunAfter map which contains the list of scenarios that a given scenario node
-// should run after. It checks if a parentNode is in the list of provided scenarios before appending to the runAfter map
+// should run after. It checks if a child is in the list of provided scenarios before appending to the runAfter map
 func GetRunAfterMapForTestGraphNodes(testGraph map[string][]v1beta2.TestGraphNode, integrationTestScenarios *[]v1beta2.IntegrationTestScenario) map[string][]string {
 	runAfterMap := make(map[string][]string)
+	if integrationTestScenarios == nil {
+		return runAfterMap
+	}
 
-	for node := range testGraph {
+	scenarioSet := make(map[string]struct{}, len(*integrationTestScenarios))
+	for _, scenario := range *integrationTestScenarios {
+		scenarioSet[scenario.Name] = struct{}{}
+	}
+
+	for node, parents := range testGraph {
 		runAfterMap[node] = make([]string, 0)
-		for _, parentNode := range testGraph[node] {
-			for _, integrationTestScenario := range *integrationTestScenarios {
-				if integrationTestScenario.Name == node {
-					runAfterMap[node] = append(runAfterMap[node], parentNode.Name)
-					break
-				}
+		if _, exists := scenarioSet[node]; !exists {
+			continue
+		}
+		for _, parentNode := range parents {
+			if _, exists := scenarioSet[parentNode.Name]; exists {
+				runAfterMap[node] = append(runAfterMap[node], parentNode.Name)
 			}
 		}
 	}
 	return runAfterMap
 }
 
-// ShouldFailFastForScenariosParent find the requested parent's failFast option for a given scenario
-func ShouldFailFastForScenariosParent(testGraph map[string][]v1beta2.TestGraphNode, scenarioName, parentScenarioName string) bool {
-	failFast := false
+// hasParent reports whether parentName appears in the child's declared parent list.
+func hasParent(parents []v1beta2.TestGraphNode, parentName string) bool {
+	for _, parent := range parents {
+		if parent.Name == parentName {
+			return true
+		}
+	}
+	return false
+}
 
-	for node := range testGraph {
-		if node == scenarioName {
-			for _, parentNode := range testGraph[node] {
-				if parentNode.Name == parentScenarioName {
-					failFast = parentNode.FailFast
-				}
+// ShouldFailFastForScenariosParent finds the requested parent's failFast option for a given scenario
+func ShouldFailFastForScenariosParent(testGraph map[string][]v1beta2.TestGraphNode, scenarioName, parentScenarioName string) bool {
+	if parents, ok := testGraph[scenarioName]; ok {
+		for _, parentNode := range parents {
+			if parentNode.Name == parentScenarioName {
+				return parentNode.FailFast
 			}
 		}
 	}
-	return failFast
+	return false
+}
+
+// CascadeFailFastDependents walks the testGraph from failedScenario and marks
+// all transitively blocked dependents as TestFail when each edge has failFast: true.
+func CascadeFailFastDependents(
+	testGraph map[string][]v1beta2.TestGraphNode,
+	statuses *intgteststat.SnapshotIntegrationTestStatuses,
+	failedScenario string,
+) {
+	queue := []string{failedScenario}
+	seen := map[string]struct{}{failedScenario: {}}
+	for len(queue) > 0 {
+		parent := queue[0]
+		queue = queue[1:]
+		for child, parents := range testGraph {
+			if !hasParent(parents, parent) {
+				continue
+			}
+			if !ShouldFailFastForScenariosParent(testGraph, child, parent) {
+				continue
+			}
+			detail, ok := statuses.GetScenarioStatus(child)
+			if !ok || detail.Status.IsFinal() {
+				continue
+			}
+			statuses.UpdateTestStatusIfChanged(
+				child,
+				intgteststat.IntegrationTestStatusTestFail,
+				fmt.Sprintf("Cancelled on account of required %s failing", parent),
+			)
+			if _, already := seen[child]; !already {
+				seen[child] = struct{}{}
+				queue = append(queue, child) // cascade B → C, C → D, ...
+			}
+		}
+	}
 }

--- a/pkg/dag/utils.go
+++ b/pkg/dag/utils.go
@@ -1,0 +1,87 @@
+/*
+   Copyright 2025 Red Hat Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package dag
+
+import (
+	"maps"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+)
+
+// FilterRootIntegrationTestScenarios uses Kahn's algorithm on the reversed dependency graph to
+// get root IntegrationTestScenarios.
+func FilterRootIntegrationTestScenarios(testGraph map[string][]v1beta2.TestGraphNode, scenarios *[]v1beta2.IntegrationTestScenario) *[]v1beta2.IntegrationTestScenario {
+	// indegrees[x] = number of nodes that list x as a parent (i.e. x's child count).
+	var filteredScenarios []v1beta2.IntegrationTestScenario
+	graphCopy := maps.Clone(testGraph)
+
+	for _, scenario := range *scenarios {
+		// Ensure every scenario appears in testGraph even if it has no declared
+		// parents.
+		if _, ok := graphCopy[scenario.Name]; !ok {
+			graphCopy[scenario.Name] = []v1beta2.TestGraphNode{}
+		}
+	}
+
+	// Find root nodes (ones which don't depend on any other nodes) and match them with a scenario.
+	for node := range graphCopy {
+		if len(graphCopy[node]) == 0 {
+			for _, scenario := range *scenarios {
+				if scenario.Name == node {
+					filteredScenarios = append(filteredScenarios, scenario)
+					break
+				}
+			}
+		}
+	}
+	return &filteredScenarios
+}
+
+// GetRunAfterMapForTestGraphNodes generates a RunAfter map which contains the list of scenarios that a given scenario node
+// should run after. It checks if a parentNode is in the list of provided scenarios before appending to the runAfter map
+func GetRunAfterMapForTestGraphNodes(testGraph map[string][]v1beta2.TestGraphNode, integrationTestScenarios *[]v1beta2.IntegrationTestScenario) map[string][]string {
+	runAfterMap := make(map[string][]string)
+
+	for node := range testGraph {
+		runAfterMap[node] = make([]string, 0)
+		for _, parentNode := range testGraph[node] {
+			for _, integrationTestScenario := range *integrationTestScenarios {
+				if integrationTestScenario.Name == node {
+					runAfterMap[node] = append(runAfterMap[node], parentNode.Name)
+					break
+				}
+			}
+		}
+	}
+	return runAfterMap
+}
+
+// ShouldFailFastForScenariosParent find the requested parent's failFast option for a given scenario
+func ShouldFailFastForScenariosParent(testGraph map[string][]v1beta2.TestGraphNode, scenarioName, parentScenarioName string) bool {
+	failFast := false
+
+	for node := range testGraph {
+		if node == scenarioName {
+			for _, parentNode := range testGraph[node] {
+				if parentNode.Name == parentScenarioName {
+					failFast = parentNode.FailFast
+				}
+			}
+		}
+	}
+	return failFast
+}

--- a/pkg/dag/utils_test.go
+++ b/pkg/dag/utils_test.go
@@ -1,0 +1,230 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dag
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
+)
+
+var _ = Describe("DAG utils unittests", Ordered, func() {
+	Context("GetRunAfterMapForTestGraphNodes", func() {
+		var (
+			testGraph   map[string][]v1beta2.TestGraphNode
+			scenarios   *[]v1beta2.IntegrationTestScenario
+			runAfterMap map[string][]string
+		)
+
+		BeforeAll(func() {
+			testGraph = map[string][]v1beta2.TestGraphNode{
+				"scenarioB": createTestGraphNodesForScenarios([]string{"scenarioA"}),
+				"scenarioC": createTestGraphNodesForScenarios([]string{"scenarioA", "scenarioB"}),
+				"scenarioD": createTestGraphNodesForScenarios([]string{"missing-parent"}),
+				"scenarioE": createTestGraphNodesForScenarios([]string{"missing-parent"}),
+			}
+			scenarios = createIntegrationTestScenarios("scenarioA", "scenarioB", "scenarioC", "scenarioD")
+		})
+
+		When("the child scenario is in the integration test scenario list", func() {
+			It("returns the parent scenario names in the runAfter map", func() {
+				runAfterMap = GetRunAfterMapForTestGraphNodes(testGraph, scenarios)
+				Expect(runAfterMap).To(HaveKey("scenarioB"))
+				Expect(runAfterMap["scenarioB"]).To(Equal([]string{"scenarioA"}))
+				Expect(runAfterMap["scenarioC"]).To(Equal([]string{"scenarioA", "scenarioB"}))
+			})
+		})
+
+		When("the parent scenario is not in the integration test scenario list", func() {
+			It("returns an empty runAfter list for that node", func() {
+				runAfterMap = GetRunAfterMapForTestGraphNodes(testGraph, scenarios)
+				Expect(runAfterMap).To(HaveKey("scenarioD"))
+				Expect(runAfterMap["scenarioD"]).To(BeEmpty())
+			})
+		})
+
+		When("the child scenario is not in the integration test scenario list", func() {
+			It("returns an empty runAfter list for that node", func() {
+				runAfterMap = GetRunAfterMapForTestGraphNodes(testGraph, scenarios)
+				Expect(runAfterMap).To(HaveKey("scenarioE"))
+				Expect(runAfterMap["scenarioD"]).To(BeEmpty())
+			})
+		})
+	})
+
+	Context("hasParent", func() {
+		var parents []v1beta2.TestGraphNode
+
+		BeforeAll(func() {
+			parents = []v1beta2.TestGraphNode{
+				{Name: "scenarioA", FailFast: true},
+				{Name: "scenarioB", FailFast: false},
+			}
+		})
+
+		It("returns true when the parent name is in the list", func() {
+			Expect(hasParent(parents, "scenarioA")).To(BeTrue())
+			Expect(hasParent(parents, "scenarioB")).To(BeTrue())
+		})
+
+		It("returns false when the parent name is not in the list", func() {
+			Expect(hasParent(parents, "scenarioC")).To(BeFalse())
+		})
+
+		It("returns false for an empty parent list", func() {
+			Expect(hasParent(nil, "scenarioA")).To(BeFalse())
+			Expect(hasParent([]v1beta2.TestGraphNode{}, "scenarioA")).To(BeFalse())
+		})
+	})
+
+	Context("ShouldFailFastForScenariosParent", func() {
+		var testGraph map[string][]v1beta2.TestGraphNode
+
+		BeforeAll(func() {
+			testGraph = map[string][]v1beta2.TestGraphNode{
+				"scenarioB": {
+					{Name: "scenarioA", FailFast: true},
+				},
+				"scenarioC": {
+					{Name: "scenarioB", FailFast: false},
+				},
+			}
+		})
+
+		It("returns the failFast value for a matching parent edge", func() {
+			Expect(ShouldFailFastForScenariosParent(testGraph, "scenarioB", "scenarioA")).To(BeTrue())
+			Expect(ShouldFailFastForScenariosParent(testGraph, "scenarioC", "scenarioB")).To(BeFalse())
+		})
+
+		It("returns false when the parent edge is not found", func() {
+			Expect(ShouldFailFastForScenariosParent(testGraph, "scenarioB", "scenarioC")).To(BeFalse())
+			Expect(ShouldFailFastForScenariosParent(testGraph, "scenarioD", "scenarioA")).To(BeFalse())
+		})
+	})
+
+	Context("CascadeFailFastDependents", func() {
+		var (
+			testGraph map[string][]v1beta2.TestGraphNode
+			statuses  *intgteststat.SnapshotIntegrationTestStatuses
+		)
+
+		initPendingStatuses := func(scenarioNames ...string) {
+			var err error
+			statuses, err = intgteststat.NewSnapshotIntegrationTestStatuses("")
+			Expect(err).NotTo(HaveOccurred())
+			for _, name := range scenarioNames {
+				statuses.UpdateTestStatusIfChanged(name, intgteststat.IntegrationTestStatusPending, "Pending")
+			}
+		}
+
+		getScenarioStatus := func(name string) intgteststat.IntegrationTestStatus {
+			detail, ok := statuses.GetScenarioStatus(name)
+			Expect(ok).To(BeTrue())
+			return detail.Status
+		}
+
+		BeforeAll(func() {
+			testGraph = map[string][]v1beta2.TestGraphNode{
+				"scenarioB": {{Name: "scenarioA", FailFast: true}},
+				"scenarioC": {{Name: "scenarioB", FailFast: true}},
+				"scenarioD": {{Name: "scenarioB", FailFast: false}},
+			}
+		})
+
+		When("a direct dependent has failFast set to true", func() {
+			BeforeEach(func() {
+				initPendingStatuses("scenarioB")
+			})
+
+			It("marks the dependent as TestFail", func() {
+				CascadeFailFastDependents(testGraph, statuses, "scenarioA")
+				Expect(getScenarioStatus("scenarioB")).To(Equal(intgteststat.IntegrationTestStatusTestFail))
+				detail, ok := statuses.GetScenarioStatus("scenarioB")
+				Expect(ok).To(BeTrue())
+				Expect(detail.Details).To(Equal("Cancelled on account of required scenarioA failing"))
+			})
+		})
+
+		When("a transitive chain has failFast set to true on each edge", func() {
+			BeforeEach(func() {
+				initPendingStatuses("scenarioB", "scenarioC")
+			})
+
+			It("marks all blocked dependents as TestFail", func() {
+				CascadeFailFastDependents(testGraph, statuses, "scenarioA")
+				Expect(getScenarioStatus("scenarioB")).To(Equal(intgteststat.IntegrationTestStatusTestFail))
+				Expect(getScenarioStatus("scenarioC")).To(Equal(intgteststat.IntegrationTestStatusTestFail))
+			})
+		})
+
+		When("failFast is false on the edge to a dependent", func() {
+			BeforeEach(func() {
+				initPendingStatuses("scenarioB", "scenarioD")
+			})
+
+			It("does not cancel the dependent", func() {
+				CascadeFailFastDependents(testGraph, statuses, "scenarioB")
+				Expect(getScenarioStatus("scenarioD")).To(Equal(intgteststat.IntegrationTestStatusPending))
+			})
+		})
+
+		When("the dependent already has a final status", func() {
+			BeforeEach(func() {
+				initPendingStatuses("scenarioB")
+				statuses.UpdateTestStatusIfChanged(
+					"scenarioB", intgteststat.IntegrationTestStatusTestPassed, "passed",
+				)
+			})
+
+			It("does not change the dependent status", func() {
+				CascadeFailFastDependents(testGraph, statuses, "scenarioA")
+				Expect(getScenarioStatus("scenarioB")).To(Equal(intgteststat.IntegrationTestStatusTestPassed))
+			})
+		})
+
+		When("cascade is invoked more than once", func() {
+			BeforeEach(func() {
+				initPendingStatuses("scenarioB")
+			})
+
+			It("is idempotent", func() {
+				CascadeFailFastDependents(testGraph, statuses, "scenarioA")
+				detailAfterFirst, ok := statuses.GetScenarioStatus("scenarioB")
+				Expect(ok).To(BeTrue())
+				CascadeFailFastDependents(testGraph, statuses, "scenarioA")
+				detailAfterSecond, ok := statuses.GetScenarioStatus("scenarioB")
+				Expect(ok).To(BeTrue())
+				Expect(detailAfterSecond.Status).To(Equal(detailAfterFirst.Status))
+				Expect(detailAfterSecond.Details).To(Equal(detailAfterFirst.Details))
+				Expect(detailAfterSecond.LastUpdateTime).To(Equal(detailAfterFirst.LastUpdateTime))
+			})
+		})
+	})
+})
+
+func createIntegrationTestScenarios(names ...string) *[]v1beta2.IntegrationTestScenario {
+	scenarios := make([]v1beta2.IntegrationTestScenario, len(names))
+	for i, name := range names {
+		scenarios[i] = v1beta2.IntegrationTestScenario{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+		}
+	}
+	return &scenarios
+}

--- a/pkg/integrationteststatus/integration_test_status.go
+++ b/pkg/integrationteststatus/integration_test_status.go
@@ -86,6 +86,12 @@ const integrationTestStatusesSchema = `{
         },
         "testPipelineRunName": {
           "type": "string"
+        },
+        "runAfter": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
 	  "required": ["scenario", "status", "lastUpdateTime"]
@@ -110,6 +116,8 @@ type IntegrationTestStatusDetail struct {
 	TestPipelineRunName string `json:"testPipelineRunName,omitempty"`
 	// IsOptionalScenario defines if the scenario is optional, which means that test failure should not block promotion of snapshot
 	IsOptionalScenario bool `json:"isOptionalScenario,omitempty"`
+	// RunAfter defines the list of scenarios this scenario is supposed to run after
+	RunAfter []string `json:"runAfter,omitempty"`
 }
 
 // SnapshotIntegrationTestStatuses type handles details about snapshot tests
@@ -221,6 +229,15 @@ func (sits *SnapshotIntegrationTestStatuses) SetTestDetailOptional(name string, 
 	}
 }
 
+// SetTestDetailRunAfterList sets test details runAfter list according to the provided list of scenarios
+func (sits *SnapshotIntegrationTestStatuses) SetTestDetailRunAfterList(name string, runAfter []string) {
+	var detail *IntegrationTestStatusDetail
+	detail, ok := sits.statuses[name]
+	if ok {
+		detail.RunAfter = runAfter
+	}
+}
+
 // UpdateTestPipelineRunName updates TestPipelineRunName if changed
 // scenario must already exist in statuses
 func (sits *SnapshotIntegrationTestStatuses) UpdateTestPipelineRunName(scenarioName string, pipelineRunName string) error {
@@ -239,7 +256,7 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestPipelineRunName(scenarioN
 
 // InitStatuses creates initial representation all scenarios
 // This function also removes scenarios which are not defined in scenarios param
-func (sits *SnapshotIntegrationTestStatuses) InitStatuses(integrationTestScenarios *[]v1beta2.IntegrationTestScenario) {
+func (sits *SnapshotIntegrationTestStatuses) InitStatuses(integrationTestScenarios *[]v1beta2.IntegrationTestScenario, runAfterMap map[string][]string) {
 	var expectedScenarios = make(map[string]struct{}) // map as a set
 
 	// if given scenario doesn't exist, create it in pending state
@@ -249,9 +266,12 @@ func (sits *SnapshotIntegrationTestStatuses) InitStatuses(integrationTestScenari
 		expectedScenarios[name] = struct{}{}
 		_, ok := sits.statuses[name]
 		if !ok {
-			// init test statuses and optional value only if they doesn't exist
+			// init test statuses and optional value only if they don't exist
 			sits.UpdateTestStatusIfChanged(name, IntegrationTestStatusPending, "Pending")
 			sits.SetTestDetailOptional(name, helpers.IsIntegrationTestScenarioOptional(&scenario))
+			if _, found := runAfterMap[name]; found {
+				sits.SetTestDetailRunAfterList(name, runAfterMap[name])
+			}
 		}
 	}
 

--- a/pkg/integrationteststatus/integration_test_status.go
+++ b/pkg/integrationteststatus/integration_test_status.go
@@ -19,6 +19,7 @@ package integrationteststatus
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/konflux-ci/integration-service/api/v1beta2"
@@ -144,6 +145,15 @@ func (sits *IntegrationTestStatus) IsFinal() bool {
 	return false
 }
 
+func (sits *IntegrationTestStatus) IsPassed() bool {
+	switch *sits {
+	case IntegrationTestStatusTestPassed,
+		IntegrationTestStatusTestWarning:
+		return true
+	}
+	return false
+}
+
 // IsDirty returns boolean if there are any changes
 func (sits *SnapshotIntegrationTestStatuses) IsDirty() bool {
 	return sits.dirty
@@ -220,22 +230,36 @@ func (sits *SnapshotIntegrationTestStatuses) UpdateTestStatusIfChanged(scenarioN
 
 }
 
-// SetTestDetailOptional set test details optional according to the given value of name and isOptionalScenario
 func (sits *SnapshotIntegrationTestStatuses) SetTestDetailOptional(name string, isOptionalScenario bool) {
-	var detail *IntegrationTestStatusDetail
 	detail, ok := sits.statuses[name]
-	if ok {
-		detail.IsOptionalScenario = isOptionalScenario
+	if !ok {
+		return
 	}
+	if detail.IsOptionalScenario == isOptionalScenario {
+		return
+	}
+	detail.IsOptionalScenario = isOptionalScenario
+	sits.dirty = true
 }
 
-// SetTestDetailRunAfterList sets test details runAfter list according to the provided list of scenarios
-func (sits *SnapshotIntegrationTestStatuses) SetTestDetailRunAfterList(name string, runAfter []string) {
-	var detail *IntegrationTestStatusDetail
-	detail, ok := sits.statuses[name]
-	if ok {
-		detail.RunAfter = runAfter
+func runAfterEqual(existing, updated []string) bool {
+	// Treat nil and empty slice as equivalent (JSON / map init inconsistency).
+	if len(existing) == 0 && len(updated) == 0 {
+		return true
 	}
+	return slices.Equal(existing, updated)
+}
+
+func (sits *SnapshotIntegrationTestStatuses) SetTestDetailRunAfterList(name string, runAfter []string) {
+	detail, ok := sits.statuses[name]
+	if !ok {
+		return
+	}
+	if runAfterEqual(detail.RunAfter, runAfter) {
+		return
+	}
+	detail.RunAfter = runAfter
+	sits.dirty = true
 }
 
 // UpdateTestPipelineRunName updates TestPipelineRunName if changed
@@ -268,10 +292,10 @@ func (sits *SnapshotIntegrationTestStatuses) InitStatuses(integrationTestScenari
 		if !ok {
 			// init test statuses and optional value only if they don't exist
 			sits.UpdateTestStatusIfChanged(name, IntegrationTestStatusPending, "Pending")
-			sits.SetTestDetailOptional(name, helpers.IsIntegrationTestScenarioOptional(&scenario))
-			if _, found := runAfterMap[name]; found {
-				sits.SetTestDetailRunAfterList(name, runAfterMap[name])
-			}
+		}
+		sits.SetTestDetailOptional(name, helpers.IsIntegrationTestScenarioOptional(&scenario))
+		if _, found := runAfterMap[name]; found {
+			sits.SetTestDetailRunAfterList(name, runAfterMap[name])
 		}
 	}
 

--- a/pkg/integrationteststatus/integration_test_status_test.go
+++ b/pkg/integrationteststatus/integration_test_status_test.go
@@ -560,6 +560,29 @@ var _ = Describe("integrationteststatus library unittests", func() {
 			})
 		})
 
+		When("SetTestDetailRunAfterList is called", func() {
+			BeforeEach(func() {
+				sits.InitStatuses(&[]v1beta2.IntegrationTestScenario{*integrationTestScenario},
+					map[string][]string{integrationTestScenario.Name: {"parent-a"}})
+				sits.ResetDirty()
+			})
+			It("marks dirty when runAfter changes", func() {
+				sits.SetTestDetailRunAfterList(integrationTestScenario.Name, []string{"parent-b"})
+				Expect(sits.IsDirty()).To(BeTrue())
+			})
+			It("does not mark dirty when runAfter is unchanged", func() {
+				sits.SetTestDetailRunAfterList(integrationTestScenario.Name, []string{"parent-a"})
+				Expect(sits.IsDirty()).To(BeFalse())
+			})
+			It("does not mark dirty for nil vs empty slice", func() {
+				sits.SetTestDetailRunAfterList(integrationTestScenario.Name, []string{})
+				detail, _ := sits.GetScenarioStatus(integrationTestScenario.Name)
+				detail.RunAfter = nil
+				sits.ResetDirty()
+				sits.SetTestDetailRunAfterList(integrationTestScenario.Name, []string{})
+				Expect(sits.IsDirty()).To(BeFalse())
+			})
+		})
 	})
 
 })

--- a/pkg/integrationteststatus/integration_test_status_test.go
+++ b/pkg/integrationteststatus/integration_test_status_test.go
@@ -492,7 +492,7 @@ var _ = Describe("integrationteststatus library unittests", func() {
 
 			It("Initialization with empty scenario list will remove data", func() {
 				sits.ResetDirty()
-				sits.InitStatuses(&[]v1beta2.IntegrationTestScenario{})
+				sits.InitStatuses(&[]v1beta2.IntegrationTestScenario{}, map[string][]string{})
 				Expect(sits.GetStatuses()).To(BeEmpty())
 				Expect(sits.IsDirty()).To(BeTrue())
 			})
@@ -501,7 +501,7 @@ var _ = Describe("integrationteststatus library unittests", func() {
 
 		It("Initialization with new test scenario creates pending status", func() {
 			sits.ResetDirty()
-			sits.InitStatuses(&[]v1beta2.IntegrationTestScenario{*integrationTestScenario})
+			sits.InitStatuses(&[]v1beta2.IntegrationTestScenario{*integrationTestScenario}, map[string][]string{})
 
 			Expect(sits.IsDirty()).To(BeTrue())
 			Expect(sits.GetStatuses()).To(HaveLen(1))


### PR DESCRIPTION
Now that we have the ability to set the testing Directed Acyclic Graph (DAG) by way of `testGraph` array in the new componentGroup CRD, we want the integration-service to execute scenarios in the provided order.

- If the testGraph is not specified or the ITS is a root scenario (has no parents in the graph), run the ITS immediately
- Once the ITS pipelineRun finishes, update the snapshot status annotation and run another ITS in the list provided by the DAG
- If any of listed scenarios failed, it should be reflected in the snapshot status annotation (it should inform about this fact by message: “Cancelled on account of required $failedITS failing.”)

To this end, this PR introduces the following changes:
* The updated EnsureIntegrationPipelineRunsExist is now meant to run the initial (root) scenarios as well as dependent scenarios after the initial scenarios finish
* Scenarios with runAfter in their status annotation will wait for the ones in the runAfter list before executing
* isScenarioReadyToRunWithoutPLR — eligibility rules
* findScenariosReadyToRunWithoutPLR — which scenarios should start
* createEligibleIntegrationPipelineRuns — cascade, create PLRs, persist status

Assisted-By: Cursor

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
