### PR TITLE
feat(STONEINTG-1671): implement immediate-mode nudging orchestration

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
   - secrets
   verbs:
   - create
@@ -82,6 +83,7 @@ rules:
   - appstudio.redhat.com
   resources:
   - environments
+  - nudgeconfigs
   - releaseplans
   verbs:
   - get

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math/big"
 	"strconv"
+	"strings"
 	"time"
 
 	"k8s.io/client-go/util/retry"
@@ -39,6 +40,7 @@ import (
 	"github.com/konflux-ci/integration-service/status"
 	"github.com/konflux-ci/integration-service/tekton"
 	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
+	"github.com/konflux-ci/integration-service/tekton/nudging"
 	"github.com/konflux-ci/operator-toolkit/controller"
 	"github.com/konflux-ci/operator-toolkit/metadata"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
@@ -143,6 +145,120 @@ func (a *Adapter) EnsureGlobalCandidateImageUpdated() (controller.OperationResul
 		a.logger.Error(err, "Failed to update the build pipelinerun's annotation to AddedToGlobalCandidateList")
 		return controller.RequeueWithError(err)
 	}
+
+	return controller.ContinueProcessing()
+}
+
+// EnsureNudgePipelineRunsExist creates Renovate nudge PipelineRuns for downstream
+// components defined in NudgeConfig when a push build succeeds.
+func (a *Adapter) EnsureNudgePipelineRunsExist() (controller.OperationResult, error) {
+	if !tekton.IsPLRCreatedByPACPushEvent(a.pipelineRun) {
+		return controller.ContinueProcessing()
+	}
+
+	if !h.HasPipelineRunSucceeded(a.pipelineRun) {
+		return controller.ContinueProcessing()
+	}
+
+	if metadata.HasAnnotation(a.pipelineRun, tektonconsts.NudgeProcessedAnnotation) {
+		return controller.ContinueProcessing()
+	}
+
+	nudgeConfig, err := a.loader.GetNudgeConfigForNamespace(a.context, a.client, a.pipelineRun.Namespace)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			return controller.ContinueProcessing()
+		}
+		a.logger.Error(err, "Failed to get NudgeConfig")
+		return controller.RequeueWithError(err)
+	}
+
+	componentName := a.component.Name
+	var targetNames []string
+	for _, nudge := range nudgeConfig.Spec.Nudges {
+		if nudge.From == componentName && (nudge.Mode == "" || nudge.Mode == v1beta2.NudgeModeImmediate) {
+			targetNames = append(targetNames, nudge.To)
+		}
+	}
+
+	if len(targetNames) == 0 {
+		_ = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, "no-matching-edges", a.client)
+		return controller.ContinueProcessing()
+	}
+
+	var targetComponents []applicationapiv1alpha1.Component
+	for _, name := range targetNames {
+		comp, err := a.loader.GetComponent(a.context, a.client, name, a.pipelineRun.Namespace)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				a.logger.Info("Nudge target component not found, skipping", "component.Name", name)
+				continue
+			}
+			a.logger.Error(err, "Failed to load nudge target component", "component.Name", name)
+			return controller.RequeueWithError(err)
+		}
+		targetComponents = append(targetComponents, *comp)
+	}
+
+	if len(targetComponents) == 0 {
+		a.logger.Info("No valid nudge target components found")
+		_ = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, "no-valid-targets", a.client)
+		return controller.ContinueProcessing()
+	}
+
+	buildResult, err := nudging.ExtractBuildResultForNudging(a.pipelineRun, a.component)
+	if err != nil {
+		a.logger.Error(err, "Failed to extract build result for nudging, skipping")
+		_ = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, "build-result-error", a.client)
+		return controller.ContinueProcessing()
+	}
+
+	simpleBranchName := a.component.Annotations != nil && a.component.Annotations[tektonconsts.NudgeSimpleBranchAnnotation] == "true"
+
+	saName := a.pipelineRun.Spec.TaskRunTemplate.ServiceAccountName
+	if saName == "" {
+		saName = tektonconsts.DefaultPipelineServiceAccount
+	}
+	imageRepoHost, imageRepoUser, imageRepoPwd, err := nudging.GetImageRegistryCredentials(a.context, a.client, a.component, saName)
+	if err != nil {
+		a.logger.Error(err, "Failed to get image registry credentials for nudging, skipping")
+		_ = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, "credentials-error", a.client)
+		return controller.ContinueProcessing()
+	}
+
+	var targets []nudging.NudgeTarget
+
+	githubTargets := nudging.GetNudgeTargetsGithubApp(a.context, a.client, targetComponents, imageRepoHost, imageRepoUser, imageRepoPwd)
+	targets = append(targets, githubTargets...)
+
+	basicAuthTargets := nudging.GetNudgeTargetsBasicAuth(a.context, a.client, targetComponents, imageRepoHost, imageRepoUser, imageRepoPwd)
+	targets = append(targets, basicAuthTargets...)
+
+	if len(targets) == 0 {
+		a.logger.Info("No nudge targets with resolved credentials found")
+		_ = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, "no-credentials", a.client)
+		return controller.ContinueProcessing()
+	}
+
+	err = nudging.CreateNudgePipelineRun(a.context, a.client, a.pipelineRun, targets, buildResult, simpleBranchName)
+	if err != nil {
+		a.logger.Error(err, "Failed to create nudge PipelineRun")
+		return controller.RequeueWithError(err)
+	}
+
+	names := make([]string, len(targets))
+	for i, t := range targets {
+		names[i] = t.ComponentName
+	}
+	processedValue := strings.Join(names, ",")
+	err = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, processedValue, a.client)
+	if err != nil {
+		a.logger.Error(err, "Failed to annotate build PLR as nudge-processed")
+		return controller.RequeueWithError(err)
+	}
+
+	a.logger.LogAuditEvent("Created nudge PipelineRun for downstream components", a.pipelineRun, h.LogActionAdd,
+		"targets", processedValue)
 
 	return controller.ContinueProcessing()
 }

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -3965,6 +3965,264 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		})
 	})
 
+	When("EnsureNudgePipelineRunsExist is called", func() {
+		makePushPLR := func() *tektonv1.PipelineRun {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Labels["pipelinesascode.tekton.dev/event-type"] = "push"
+			delete(plr.Labels, "pipelinesascode.tekton.dev/pull-request")
+			delete(plr.Annotations, tektonconsts.NudgeProcessedAnnotation)
+			return plr
+		}
+
+		It("skips when PipelineRun is not a push event", func() {
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+		})
+
+		It("skips when build PipelineRun has not succeeded", func() {
+			pushPLR := makePushPLR()
+			pushPLR.Status.SetCondition(&apis.Condition{
+				Type:   apis.ConditionSucceeded,
+				Status: "False",
+			})
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+		})
+
+		It("skips when build PipelineRun is already nudge-processed", func() {
+			pushPLR := makePushPLR()
+			pushPLR.Annotations[tektonconsts.NudgeProcessedAnnotation] = "component-b"
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+		})
+
+		It("skips when NudgeConfig is not found", func() {
+			pushPLR := makePushPLR()
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Err:        k8serrors.NewNotFound(v1beta2.GroupVersion.WithResource("nudgeconfigs").GroupResource(), "nudge-config"),
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+		})
+
+		It("requeues when NudgeConfig load fails with transient error", func() {
+			pushPLR := makePushPLR()
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Err:        fmt.Errorf("transient API error"),
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueRequest).To(BeTrue())
+		})
+
+		It("annotates no-matching-edges when NudgeConfig has no edges for the built component", func() {
+			pushPLR := makePushPLR()
+			nudgeConfig := &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: "other-component", To: "another-component-sample", Mode: v1beta2.NudgeModeImmediate},
+					},
+				},
+			}
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Resource:   nudgeConfig,
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				updatedPLR := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+				g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("no-matching-edges"))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("annotates no-valid-targets when all target components are not found", func() {
+			pushPLR := makePushPLR()
+			nudgeConfig := &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: hasComp.Name, To: "nonexistent-component", Mode: v1beta2.NudgeModeImmediate},
+					},
+				},
+			}
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Resource:   nudgeConfig,
+				},
+				{
+					ContextKey: loader.GetComponentContextKey,
+					Err:        k8serrors.NewNotFound(applicationapiv1alpha1.GroupVersion.WithResource("components").GroupResource(), "nonexistent-component"),
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				updatedPLR := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+				g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("no-valid-targets"))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("requeues when target component load returns transient error", func() {
+			pushPLR := makePushPLR()
+			nudgeConfig := &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: hasComp.Name, To: "another-component-sample", Mode: v1beta2.NudgeModeImmediate},
+					},
+				},
+			}
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Resource:   nudgeConfig,
+				},
+				{
+					ContextKey: loader.GetComponentContextKey,
+					Err:        fmt.Errorf("transient API error"),
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).To(HaveOccurred())
+			Expect(result.RequeueRequest).To(BeTrue())
+		})
+
+		It("annotates build-result-error and stops when build result extraction fails", func() {
+			pushPLR := makePushPLR()
+			pushPLR.Status.Results = nil
+			nudgeConfig := &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: hasComp.Name, To: "another-component-sample", Mode: v1beta2.NudgeModeImmediate},
+					},
+				},
+			}
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Resource:   nudgeConfig,
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				updatedPLR := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+				g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("build-result-error"))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("annotates credentials-error and stops when image registry credentials cannot be resolved", func() {
+			pushPLR := makePushPLR()
+			nudgeConfig := &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: hasComp.Name, To: "another-component-sample", Mode: v1beta2.NudgeModeImmediate},
+					},
+				},
+			}
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Resource:   nudgeConfig,
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				updatedPLR := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+				g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("credentials-error"))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("skips validated-mode edges and only processes immediate-mode edges", func() {
+			pushPLR := makePushPLR()
+			nudgeConfig := &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: hasComp.Name, To: "another-component-sample", Mode: v1beta2.NudgeModeValidated},
+					},
+				},
+			}
+			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NudgeConfigContextKey,
+					Resource:   nudgeConfig,
+				},
+			})
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+
+			Eventually(func(g Gomega) {
+				updatedPLR := &tektonv1.PipelineRun{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+				g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("no-matching-edges"))
+			}, time.Second*5).Should(Succeed())
+		})
+	})
+
 	createAdapter = func() *Adapter {
 		adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
 		return adapter

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -64,6 +64,9 @@ func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme 
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/status,verbs=get
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=nudgeconfigs,verbs=get;list;watch
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -164,6 +167,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		adapter.EnsureGlobalCandidateImageUpdated,
 		adapter.EnsureSnapshotExists,
 		adapter.EnsureSnapshotExistsApplication,
+		adapter.EnsureNudgePipelineRunsExist,
 		adapter.EnsureSupercededSnapshotsCanceled,
 	})
 }
@@ -175,6 +179,7 @@ type AdapterInterface interface {
 	EnsurePRGroupAnnotated() (controller.OperationResult, error)
 	EnsureIntegrationTestReportedToGitProvider() (controller.OperationResult, error)
 	EnsureGlobalCandidateImageUpdated() (controller.OperationResult, error)
+	EnsureNudgePipelineRunsExist() (controller.OperationResult, error)
 	EnsureSnapshotExists() (controller.OperationResult, error)
 	EnsureSnapshotExistsApplication() (controller.OperationResult, error)
 	EnsureSupercededSnapshotsCanceled() (controller.OperationResult, error)

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -2041,8 +2041,17 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
 
 			// update snapshot type label to override type
-			hasOldSnapshot.Labels[gitops.SnapshotTypeLabel] = gitops.SnapshotOverrideType
-			Expect(k8sClient.Update(ctx, hasOldSnapshot)).Should(Succeed())
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return err
+				}
+				hasOldSnapshot.Labels[gitops.SnapshotTypeLabel] = gitops.SnapshotOverrideType
+				return k8sClient.Update(ctx, hasOldSnapshot)
+			}, time.Second*10).Should(Succeed())
 
 			// WAIT for snapshot status to be properly updated, eventually helps stop test flakiness
 			Eventually(func() bool {
@@ -2409,9 +2418,18 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 					gitops.HaveAppStudioTestsSucceeded(hasOldSnapshot)
 			}, time.Second*10).Should(BeTrue())
 
-			metav1.SetMetaDataAnnotation(&hasOldSnapshot.ObjectMeta, tracing.SpanContextAnnotation,
-				`{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`)
-			Expect(k8sClient.Update(ctx, hasOldSnapshot)).Should(Succeed())
+			Eventually(func() error {
+				err := k8sClient.Get(ctx, types.NamespacedName{
+					Name:      hasOldSnapshot.Name,
+					Namespace: hasOldSnapshot.Namespace,
+				}, hasOldSnapshot)
+				if err != nil {
+					return err
+				}
+				metav1.SetMetaDataAnnotation(&hasOldSnapshot.ObjectMeta, tracing.SpanContextAnnotation,
+					`{"traceparent":"00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"}`)
+				return k8sClient.Update(ctx, hasOldSnapshot)
+			}, time.Second*10).Should(Succeed())
 
 			newerSibling := applicationapiv1alpha1.Snapshot{
 				ObjectMeta: metav1.ObjectMeta{

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -87,6 +87,7 @@ type ObjectLoader interface {
 	GetComponentGroupsContainingComponentGroup(ctx context.Context, c client.Client, childComponentGroup *v1beta2.ComponentGroup) ([]v1beta2.ComponentGroup, error)
 	GetAllComponentGroupsInNamespace(ctx context.Context, c client.Client, namespace string) ([]v1beta2.ComponentGroup, error)
 	GetNestedComponentGroupsForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) ([]v1beta2.ComponentGroup, error)
+	GetNudgeConfigForNamespace(ctx context.Context, c client.Client, namespace string) (*v1beta2.NudgeConfig, error)
 }
 
 type loader struct{}
@@ -1103,6 +1104,19 @@ func (l *loader) GetAllComponentGroupsInNamespace(ctx context.Context, c client.
 
 	err := c.List(ctx, componentGroupList, options)
 	return componentGroupList.Items, err
+}
+
+// GetNudgeConfigForNamespace returns the NudgeConfig singleton from the given namespace.
+func (l *loader) GetNudgeConfigForNamespace(ctx context.Context, c client.Client, namespace string) (*v1beta2.NudgeConfig, error) {
+	nudgeConfig := &v1beta2.NudgeConfig{}
+	err := c.Get(ctx, types.NamespacedName{
+		Namespace: namespace,
+		Name:      v1beta2.NudgeConfigSingletonName,
+	}, nudgeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return nudgeConfig, nil
 }
 
 func (l *loader) GetNestedComponentGroupsForComponentGroup(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) ([]v1beta2.ComponentGroup, error) {

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -76,6 +76,7 @@ const (
 	RequiredIntegrationTestScenariosForSnapshotContextKey
 	GetPushComponentSnapshotsForComponentContextKey
 	ComponentGroupComponentsContextKey
+	NudgeConfigContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -463,4 +464,12 @@ func (l *mockLoader) GetNestedComponentGroupsForComponentGroup(ctx context.Conte
 	}
 	componentGroups, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, NestedComponentGroupsContextKey, []v1beta2.ComponentGroup{})
 	return componentGroups, err
+}
+
+// GetNudgeConfigForNamespace returns the resource and error passed as values of the context.
+func (l *mockLoader) GetNudgeConfigForNamespace(ctx context.Context, c client.Client, namespace string) (*v1beta2.NudgeConfig, error) {
+	if ctx.Value(NudgeConfigContextKey) == nil {
+		return l.loader.GetNudgeConfigForNamespace(ctx, c, namespace)
+	}
+	return toolkit.GetMockedResourceAndErrorFromContext(ctx, NudgeConfigContextKey, &v1beta2.NudgeConfig{})
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1558,7 +1558,9 @@ var _ = Describe("Loader", Ordered, func() {
 	It("can get all componentGroups in the namespace", func() {
 		componentGroups, err := loader.GetAllComponentGroupsInNamespace(ctx, k8sClient, "default")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(componentGroups).To(HaveLen(6))
+		Expect(componentGroups).To(ContainElement(HaveField("Name", "componentgroup-1")))
+		Expect(componentGroups).To(ContainElement(HaveField("Name", "componentgroup-2")))
+		Expect(componentGroups).To(ContainElement(HaveField("Name", hasContainerCompGroup.Name)))
 	})
 
 	It("can get componentGroups that contain another componentGroup", func() {

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -143,6 +143,105 @@ const (
 
 	// PipelineRunShouldReleaseResultName is the name of the SHOULD_RELEASE result in build PipelineRuns
 	PipelineRunShouldReleaseResultName = "SHOULD_RELEASE"
+
+	/*
+	 * Nudge PipelineRun constants — build-service compatible annotation/label names
+	 */
+
+	// NudgeProcessedAnnotation marks a build PLR as having already been processed for nudging
+	NudgeProcessedAnnotation = "build.appstudio.openshift.io/component-nudge-processed"
+
+	// NudgeSimpleBranchAnnotation on a Component controls simplified branch naming for nudge PRs
+	NudgeSimpleBranchAnnotation = "build.appstudio.openshift.io/build-nudge-simple-branch"
+
+	// NudgeFilesAnnotation on a build PLR restricts which files Renovate updates
+	NudgeFilesAnnotation = "build.appstudio.openshift.io/build-nudge-files"
+
+	// NudgeTypeLabel labels a PipelineRun as a nudge pipeline
+	NudgeTypeLabel = "build.appstudio.redhat.com/type"
+
+	// NudgePipelineRunTypeValue is the value for the nudge type label
+	NudgePipelineRunTypeValue = "nudge"
+
+	// NudgedComponentsAnnotation lists target components being nudged
+	NudgedComponentsAnnotation = "build.appstudio.redhat.com/nudged-components"
+
+	// NudgingCommitAnnotation records the source commit hash
+	NudgingCommitAnnotation = "build.appstudio.redhat.com/nudging-commit"
+
+	// NudgingComponentAnnotation records the source component name
+	NudgingComponentAnnotation = "build.appstudio.redhat.com/nudging-component"
+
+	// NudgingImageAnnotation records the built image reference
+	NudgingImageAnnotation = "build.appstudio.redhat.com/nudging-image"
+
+	// NudgingPipelineAnnotation records the source build PLR name
+	NudgingPipelineAnnotation = "build.appstudio.redhat.com/nudging-pipeline"
+
+	// GitRepoAtShaAnnotation on a build PLR links to the source repo at the built commit
+	GitRepoAtShaAnnotation = "build.appstudio.openshift.io/repo-url-at-sha"
+
+	/*
+	 * Renovate defaults
+	 */
+
+	// RenovateImageEnvName is the env var to override the Renovate image
+	RenovateImageEnvName = "RENOVATE_IMAGE"
+
+	// DefaultRenovateImageUrl is the default Renovate container image
+	DefaultRenovateImageUrl = "quay.io/konflux-ci/mintmaker-renovate-image:29a2f31"
+
+	// DefaultRenovateUser is the default git username for Renovate
+	DefaultRenovateUser = "red-hat-konflux"
+
+	// DefaultRenovateLabel is the label applied to Renovate PRs
+	DefaultRenovateLabel = "konflux-nudge"
+
+	// BranchPrefix is the branch prefix for nudge PRs
+	BranchPrefix = "konflux/component-updates/"
+
+	// DefaultNudgeFiles is the default file match pattern for Renovate
+	DefaultNudgeFiles = ".*Dockerfile.*, .*.yaml, .*Containerfile.*"
+
+	// NamespaceWideRenovateConfigMapName is the name of the namespace-wide custom Renovate config
+	NamespaceWideRenovateConfigMapName = "namespace-wide-nudging-renovate-config"
+
+	// CustomRenovateConfigMapAnnotation on a Component points to a per-component custom Renovate ConfigMap
+	CustomRenovateConfigMapAnnotation = "build.appstudio.openshift.io/nudge_renovate_config_map"
+
+	// CaConfigMapLabel identifies ConfigMaps containing trusted CA bundles
+	CaConfigMapLabel = "config.openshift.io/inject-trusted-cabundle"
+
+	// CaConfigMapKey is the key in CA ConfigMaps
+	CaConfigMapKey = "ca-bundle.crt"
+
+	// CaFilePath is the filename for the CA bundle mount
+	CaFilePath = "tls-ca-bundle.pem"
+
+	// CaMountPath is where the CA bundle is mounted in the Renovate container
+	CaMountPath = "/etc/pki/ca-trust/extracted/pem"
+
+	// CaVolumeMountName is the volume name for the CA bundle
+	CaVolumeMountName = "trusted-ca"
+
+	/*
+	 * Build-service namespace and PaC secret constants (for GitHub App auth)
+	 */
+
+	// BuildServiceNamespaceName is the namespace where build-service is deployed
+	BuildServiceNamespaceName = "build-service"
+
+	// PipelinesAsCodeGitHubAppSecretName is the global PaC secret for GitHub App auth
+	PipelinesAsCodeGitHubAppSecretName = "pipelines-as-code-secret"
+
+	// PipelinesAsCodeGithubAppIdKey is the key for the GitHub App ID in the PaC secret
+	PipelinesAsCodeGithubAppIdKey = "github-application-id"
+
+	// PipelinesAsCodeGithubPrivateKey is the key for the GitHub App private key in the PaC secret
+	PipelinesAsCodeGithubPrivateKey = "github-private-key"
+
+	// DefaultPipelineServiceAccount is the default ServiceAccount used by build PipelineRuns
+	DefaultPipelineServiceAccount = "appstudio-pipeline"
 )
 
 var (

--- a/tekton/nudging/nudge_credentials.go
+++ b/tekton/nudging/nudge_credentials.go
@@ -1,0 +1,627 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nudging
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const (
+	// scmCredentialsSecretLabel is the label that marks a Secret as containing SCM credentials.
+	// Matches build-service's appstudio.redhat.com/credentials label.
+	scmCredentialsSecretLabel = "appstudio.redhat.com/credentials"
+
+	// scmSecretHostnameLabel is the label whose value is the SCM hostname this secret applies to.
+	scmSecretHostnameLabel = "appstudio.redhat.com/scm.host"
+
+	// scmSecretRepositoryAnnotation is the annotation whose value is a comma-separated list of
+	// repository paths (org/repo or org/*) this secret applies to.
+	scmSecretRepositoryAnnotation = "appstudio.redhat.com/scm.repository"
+
+	// gitProviderAnnotationName is the annotation on a Component that overrides git provider detection.
+	gitProviderAnnotationName = "git-provider"
+)
+
+// repositoryCredentials holds parsed docker config auth data for a single registry entry.
+type repositoryCredentials struct {
+	secretName string
+	repoName   string
+	username   string
+	password   string
+}
+
+// repositoryConfigAuth mirrors the docker config auth JSON structure.
+type repositoryConfigAuth struct {
+	Username string `json:"username,omitempty"`
+	Password string `json:"password,omitempty"`
+	Auth     string `json:"auth,omitempty"`
+}
+
+// dockerConfigJSON mirrors the top-level .dockerconfigjson structure.
+type dockerConfigJSON struct {
+	Auths map[string]repositoryConfigAuth `json:"auths"`
+}
+
+// GetNudgeTargetsGithubApp returns NudgeTargets for components that use GitHub App authentication.
+//
+// It reads the global PaC secret from the integration-service namespace (INTEGRATION_NS env var),
+// verifies that GitHub App credentials are configured, and for each GitHub-hosted component it
+// obtains an installation token via the GitHub App API.
+//
+// TODO(STONEINTG-1671): Implement GitHub App JWT + installation token flow.
+// This requires creating a JWT from the App ID + private key, calling
+// GET /app/installations to find the installation for each repo, then
+// POST /app/installations/{id}/access_tokens to get scoped tokens.
+// For now this returns nil and logs a message. Basic auth covers the majority of use cases.
+func GetNudgeTargetsGithubApp(ctx context.Context, c client.Client, targetComponents []applicationapiv1alpha1.Component, imageRepoHost, imageRepoUser, imageRepoPwd string) []NudgeTarget {
+	log := ctrllog.FromContext(ctx)
+
+	integrationNS := os.Getenv("INTEGRATION_NS")
+	if integrationNS == "" {
+		integrationNS = "integration-service"
+	}
+
+	pacSecret := corev1.Secret{}
+	globalPaCSecretKey := types.NamespacedName{
+		Namespace: integrationNS,
+		Name:      tektonconsts.PipelinesAsCodeGitHubAppSecretName,
+	}
+	if err := c.Get(ctx, globalPaCSecretKey, &pacSecret); err != nil {
+		log.Info("GitHub App PaC secret not found, skipping GitHub App auth path",
+			"namespace", globalPaCSecretKey.Namespace,
+			"secret", globalPaCSecretKey.Name,
+			"error", err.Error())
+		return nil
+	}
+
+	// Check if GitHub App is actually configured
+	if !isPaCGitHubAppConfigured(pacSecret.Data) {
+		log.Info("GitHub App is not configured in PaC secret, skipping GitHub App auth path")
+		return nil
+	}
+
+	// TODO(STONEINTG-1671): Implement GitHub App installation token flow.
+	// The full implementation needs to:
+	// 1. Parse github-application-id and github-private-key from the PaC secret
+	// 2. Create a JWT signed with the private key
+	// 3. For each github-hosted component, call the GitHub API to get an installation token
+	// 4. Build NudgeTargets with those tokens
+	//
+	// For now, return nil. The basic auth path in GetNudgeTargetsBasicAuth handles
+	// most real-world cases since PaC provisions per-repo secrets in the user namespace.
+	log.Info("GitHub App auth path not yet implemented for nudge credential resolution, falling back to basic auth")
+	return nil
+}
+
+// GetNudgeTargetsBasicAuth returns NudgeTargets for components using basic auth (token-based) credentials.
+//
+// For each target component it:
+// 1. Detects the git provider from the component's source URL
+// 2. Looks up SCM credentials from namespace Secrets matching the repo host
+// 3. Reads optional custom Renovate configuration
+// 4. Builds a NudgeTarget with the gathered information
+func GetNudgeTargetsBasicAuth(ctx context.Context, c client.Client, targetComponents []applicationapiv1alpha1.Component, imageRepoHost, imageRepoUser, imageRepoPwd string) []NudgeTarget {
+	log := ctrllog.FromContext(ctx)
+	targets := []NudgeTarget{}
+
+	for i := range targetComponents {
+		component := &targetComponents[i]
+
+		gitProvider, err := getGitProvider(*component)
+		if err != nil {
+			log.Error(err, "error detecting git provider",
+				"ComponentName", component.Name,
+				"ComponentNamespace", component.Namespace)
+			continue
+		}
+
+		repoURL := getGitRepoURL(component)
+		if repoURL == "" {
+			log.Info("component has no git source URL, skipping",
+				"ComponentName", component.Name)
+			continue
+		}
+
+		repoHost := getGitRepoHost(repoURL)
+		if repoHost == "" {
+			log.Error(fmt.Errorf("cannot parse host from URL %q", repoURL),
+				"error parsing git repo host",
+				"ComponentName", component.Name)
+			continue
+		}
+
+		repoPath := parseGitRepoPath(repoURL)
+
+		// Look up SCM credentials
+		username, token, err := lookupSCMCredentials(ctx, c, component.Namespace, repoHost, repoPath)
+		if err != nil {
+			log.Error(err, "error getting basic auth credentials for component",
+				"ComponentName", component.Name,
+				"ComponentNamespace", component.Namespace,
+				"RepositoryUrl", repoURL)
+			continue
+		}
+
+		if username == "" {
+			username = tektonconsts.DefaultRenovateUser
+		}
+
+		// Determine branch
+		branch := ""
+		if component.Spec.Source.GitSource != nil && component.Spec.Source.GitSource.Revision != "" {
+			branch = component.Spec.Source.GitSource.Revision
+		}
+
+		repositories := []RenovateRepository{
+			{
+				Repository:   repoPath,
+				BaseBranches: branchSlice(branch),
+			},
+		}
+
+		// Read custom Renovate config
+		customOpts, err := ReadCustomRenovateConfigMap(ctx, c, component)
+		if err != nil {
+			log.Error(err, "failed to read custom renovate config map, will still continue with nudging",
+				"ComponentName", component.Name,
+				"ComponentNamespace", component.Namespace)
+		}
+
+		endpoint := buildAPIEndpoint(gitProvider, repoHost)
+
+		targets = append(targets, NudgeTarget{
+			ComponentName:                  component.Name,
+			ComponentCustomRenovateOptions: customOpts,
+			GitProvider:                    gitProvider,
+			Username:                       username,
+			GitAuthor:                      fmt.Sprintf("%s <%s@users.noreply.%s>", username, username, repoHost),
+			Token:                          token,
+			Endpoint:                       endpoint,
+			Repositories:                   repositories,
+			ImageRepositoryHost:            imageRepoHost,
+			ImageRepositoryUsername:        imageRepoUser,
+			ImageRepositoryPassword:        imageRepoPwd,
+		})
+		log.Info("component to update for basic auth",
+			"component", component.Name,
+			"repositories", repositories)
+	}
+
+	return targets
+}
+
+// GetImageRegistryCredentials resolves image registry credentials for a component by examining
+// docker config secrets linked to the specified ServiceAccount.
+//
+// It parses the component's ContainerImage to determine the registry host, reads the
+// ServiceAccount's linked secrets, and returns matching credentials.
+func GetImageRegistryCredentials(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component, saName string) (host, username, password string, err error) {
+	log := ctrllog.FromContext(ctx)
+
+	if component.Spec.ContainerImage == "" {
+		return "", "", "", fmt.Errorf("component %s/%s has no container image set", component.Namespace, component.Name)
+	}
+
+	// Parse registry host from container image
+	host = parseImageHost(component.Spec.ContainerImage)
+	if host == "" {
+		return "", "", "", fmt.Errorf("cannot parse registry host from container image %q", component.Spec.ContainerImage)
+	}
+
+	namespace := component.Namespace
+
+	// Read the ServiceAccount
+	sa := &corev1.ServiceAccount{}
+	if err := c.Get(ctx, types.NamespacedName{Name: saName, Namespace: namespace}, sa); err != nil {
+		return "", "", "", fmt.Errorf("failed to read service account %s in namespace %s: %w", saName, namespace, err)
+	}
+
+	// Gather all linked secret names from both .secrets and .imagePullSecrets
+	linkedSecretNames := map[string]bool{}
+	for _, ref := range sa.Secrets {
+		linkedSecretNames[ref.Name] = true
+	}
+	for _, ref := range sa.ImagePullSecrets {
+		linkedSecretNames[ref.Name] = true
+	}
+
+	if len(linkedSecretNames) == 0 {
+		return "", "", "", fmt.Errorf("no secrets linked to service account %s in namespace %s", saName, namespace)
+	}
+
+	// List all secrets in the namespace and filter to dockerconfigjson type
+	allSecrets := &corev1.SecretList{}
+	if err := c.List(ctx, allSecrets, client.InNamespace(namespace)); err != nil {
+		return "", "", "", fmt.Errorf("failed to list secrets in %s namespace: %w", namespace, err)
+	}
+
+	// Parse credentials from linked docker config secrets
+	var allCreds []repositoryCredentials
+	for _, secret := range allSecrets.Items {
+		if secret.Type != corev1.SecretTypeDockerConfigJson {
+			continue
+		}
+		if !linkedSecretNames[secret.Name] {
+			continue
+		}
+
+		dockerConfig := &dockerConfigJSON{}
+		configData, ok := secret.Data[corev1.DockerConfigJsonKey]
+		if !ok {
+			continue
+		}
+		if err := json.Unmarshal(configData, dockerConfig); err != nil {
+			log.Error(err, "unable to parse docker json config",
+				"secretName", secret.Name)
+			continue
+		}
+
+		for repoName, repoAuth := range dockerConfig.Auths {
+			if repoAuth.Username != "" && repoAuth.Password != "" {
+				allCreds = append(allCreds, repositoryCredentials{
+					secretName: secret.Name,
+					repoName:   repoName,
+					username:   repoAuth.Username,
+					password:   repoAuth.Password,
+				})
+			} else if repoAuth.Auth != "" {
+				decoded, err := base64.StdEncoding.DecodeString(repoAuth.Auth)
+				if err != nil {
+					log.Error(err, "unable to decode docker config json auth",
+						"repository", repoName,
+						"secretName", secret.Name)
+					continue
+				}
+				parts := strings.SplitN(string(decoded), ":", 2)
+				if len(parts) == 2 {
+					allCreds = append(allCreds, repositoryCredentials{
+						secretName: secret.Name,
+						repoName:   repoName,
+						username:   parts[0],
+						password:   parts[1],
+					})
+				}
+			}
+		}
+	}
+
+	// Find the best matching credential for the image
+	username, password, err = matchCredentialForImage(ctx, component.Spec.ContainerImage, allCreds)
+	if err != nil {
+		return host, "", "", fmt.Errorf("no credentials found for image %q in service account %s: %w",
+			component.Spec.ContainerImage, saName, err)
+	}
+
+	return host, username, password, nil
+}
+
+// ---------- Helper functions ----------
+
+// getGitProvider returns the git provider name (github, gitlab, bitbucket) based on
+// the component's git-provider annotation or by inspecting the repository URL hostname.
+func getGitProvider(component applicationapiv1alpha1.Component) (string, error) {
+	allowedProviders := []string{"github", "gitlab", "bitbucket"}
+
+	if component.Spec.Source.GitSource == nil {
+		return "", fmt.Errorf("git source is not set for component %s/%s",
+			component.Namespace, component.Name)
+	}
+
+	// Check annotation override first
+	if component.Annotations != nil {
+		if ann, ok := component.Annotations[gitProviderAnnotationName]; ok && ann != "" {
+			for _, p := range allowedProviders {
+				if ann == p {
+					return p, nil
+				}
+			}
+			return "", fmt.Errorf("unsupported git-provider annotation value %q on component %s/%s",
+				ann, component.Namespace, component.Name)
+		}
+	}
+
+	// Detect from URL hostname
+	sourceURL := component.Spec.Source.GitSource.URL
+	u, err := url.Parse(sourceURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot parse git source URL %q: %w", sourceURL, err)
+	}
+	host := u.Hostname()
+
+	for _, provider := range allowedProviders {
+		if strings.Contains(host, provider) {
+			return provider, nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot determine git provider from URL %q for component %s/%s, "+
+		"set the %q annotation on the component",
+		sourceURL, component.Namespace, component.Name, gitProviderAnnotationName)
+}
+
+// getGitRepoURL returns the normalized git repository URL from a component, stripping
+// trailing slashes and .git suffix.
+func getGitRepoURL(component *applicationapiv1alpha1.Component) string {
+	if component.Spec.Source.GitSource == nil {
+		return ""
+	}
+	return strings.TrimSuffix(strings.TrimSuffix(component.Spec.Source.GitSource.URL, "/"), ".git")
+}
+
+// parseGitRepoPath extracts the "org/repo" path from a full git URL.
+// For example, "https://github.com/org/repo.git" returns "org/repo".
+func parseGitRepoPath(gitURL string) string {
+	u, err := url.Parse(strings.TrimSuffix(strings.TrimSuffix(gitURL, "/"), ".git"))
+	if err != nil {
+		return ""
+	}
+	return strings.Trim(u.Path, "/")
+}
+
+// getGitRepoHost extracts the hostname from a git URL.
+// For example, "https://github.com/org/repo" returns "github.com".
+func getGitRepoHost(gitURL string) string {
+	u, err := url.Parse(gitURL)
+	if err != nil {
+		return ""
+	}
+	return u.Hostname()
+}
+
+// buildAPIEndpoint returns the API endpoint URL for the given git provider and host.
+// This replicates the logic from build-service's git.BuildAPIEndpoint.
+func buildAPIEndpoint(provider, host string) string {
+	switch provider {
+	case "github":
+		return fmt.Sprintf("https://api.%s/", host)
+	case "gitlab":
+		return fmt.Sprintf("https://%s/api/v4/", host)
+	case "bitbucket":
+		return fmt.Sprintf("https://api.%s/2.0/", host)
+	default:
+		return ""
+	}
+}
+
+// lookupSCMCredentials searches for basic auth secrets in the component's namespace
+// that match the given repository host and path.
+//
+// It replicates build-service's GitCredentialProvider.LookupSecret logic:
+//   - Lists secrets with label appstudio.redhat.com/credentials=scm and
+//     appstudio.redhat.com/scm.host=<host>
+//   - Filters for BasicAuth type secrets
+//   - Selects the best match based on the scm.repository annotation
+func lookupSCMCredentials(ctx context.Context, c client.Client, namespace, repoHost, repoPath string) (username, password string, err error) {
+	log := ctrllog.FromContext(ctx)
+
+	secretList := &corev1.SecretList{}
+	if err := c.List(ctx, secretList,
+		client.InNamespace(namespace),
+		client.MatchingLabels{
+			scmCredentialsSecretLabel: "scm",
+			scmSecretHostnameLabel:    repoHost,
+		},
+	); err != nil {
+		return "", "", fmt.Errorf("failed to list SCM secrets in %s namespace: %w", namespace, err)
+	}
+
+	log.Info("found SCM secrets matching host",
+		"count", len(secretList.Items),
+		"host", repoHost)
+
+	// Filter to BasicAuth secrets with data
+	var candidates []corev1.Secret
+	for _, s := range secretList.Items {
+		if s.Type == corev1.SecretTypeBasicAuth && len(s.Data) > 0 {
+			candidates = append(candidates, s)
+		}
+	}
+
+	if len(candidates) == 0 {
+		return "", "", fmt.Errorf("no SCM basic auth secrets found for host %q in namespace %s", repoHost, namespace)
+	}
+
+	best := bestMatchingSCMSecret(ctx, repoPath, candidates)
+	if best == nil {
+		return "", "", fmt.Errorf("no matching SCM secret found for repo %q in namespace %s", repoPath, namespace)
+	}
+
+	return string(best.Data[corev1.BasicAuthUsernameKey]),
+		string(best.Data[corev1.BasicAuthPasswordKey]),
+		nil
+}
+
+// bestMatchingSCMSecret finds the best matching secret for a given repository path.
+// Priority:
+// 1. Direct match of scm.repository annotation to the component repository path
+// 2. Wildcard match (org/*) with the longest intersection
+// 3. Host-only match (no repository annotation)
+func bestMatchingSCMSecret(ctx context.Context, componentRepo string, secrets []corev1.Secret) *corev1.Secret {
+	log := ctrllog.FromContext(ctx)
+
+	var hostOnlySecrets []corev1.Secret
+	// Map from secret index to its best path intersection count
+	potentialMatches := make(map[int]int, len(secrets))
+
+	for idx, secret := range secrets {
+		repoAnnotation, exists := secret.Annotations[scmSecretRepositoryAnnotation]
+		if !exists || repoAnnotation == "" {
+			hostOnlySecrets = append(hostOnlySecrets, secret)
+			continue
+		}
+
+		secretRepos := strings.Split(repoAnnotation, ",")
+		for i := range secretRepos {
+			secretRepos[i] = strings.TrimPrefix(strings.TrimSpace(secretRepos[i]), "/")
+		}
+
+		// Check for direct match
+		for _, r := range secretRepos {
+			if r == componentRepo {
+				log.Info("found direct SCM secret match",
+					"secret", secret.Name,
+					"repository", componentRepo)
+				return &secrets[idx]
+			}
+		}
+
+		// Check wildcard matches (e.g., "org/*")
+		componentParts := strings.Split(componentRepo, "/")
+		for _, r := range secretRepos {
+			if !strings.HasSuffix(r, "*") {
+				continue
+			}
+			wildcardParts := strings.Split(strings.TrimSuffix(r, "*"), "/")
+			// Count matching path segments
+			matched := 0
+			for i, part := range wildcardParts {
+				if i < len(componentParts) && part == componentParts[i] {
+					matched++
+				}
+			}
+			if matched > 0 && potentialMatches[idx] < matched {
+				potentialMatches[idx] = matched
+			}
+		}
+	}
+
+	if len(potentialMatches) == 0 {
+		if len(hostOnlySecrets) == 0 {
+			return nil
+		}
+		log.Info("using host-only SCM secret",
+			"secret", hostOnlySecrets[0].Name)
+		return &hostOnlySecrets[0]
+	}
+
+	// Find the best wildcard match
+	var bestIdx, bestCount int
+	for idx, count := range potentialMatches {
+		if count > bestCount {
+			bestCount = count
+			bestIdx = idx
+		}
+	}
+
+	log.Info("using best wildcard-matched SCM secret",
+		"secret", secrets[bestIdx].Name)
+	return &secrets[bestIdx]
+}
+
+// parseImageHost extracts the registry host from a container image reference.
+// For "quay.io/org/repo:tag" it returns "quay.io".
+// For "quay.io/org/repo@sha256:abc" it returns "quay.io".
+func parseImageHost(image string) string {
+	// Strip tag or digest
+	ref := image
+	if idx := strings.Index(ref, "@"); idx >= 0 {
+		ref = ref[:idx]
+	}
+	if idx := strings.Index(ref, ":"); idx >= 0 {
+		// Only strip if it looks like a tag (no slashes after the colon position)
+		afterColon := ref[idx+1:]
+		if !strings.Contains(afterColon, "/") {
+			ref = ref[:idx]
+		}
+	}
+
+	parts := strings.Split(ref, "/")
+	if len(parts) >= 2 {
+		// First part is the host if it contains a dot or colon (port)
+		if strings.Contains(parts[0], ".") || strings.Contains(parts[0], ":") {
+			return parts[0]
+		}
+	}
+	// Docker Hub shorthand (e.g., "library/nginx")
+	return "docker.io"
+}
+
+// matchCredentialForImage finds the best matching credential for an image reference.
+// It first tries an exact repo path match, then progressively shorter partial matches.
+func matchCredentialForImage(ctx context.Context, outputImage string, creds []repositoryCredentials) (string, string, error) {
+	log := ctrllog.FromContext(ctx)
+
+	// Normalize image to just host/path (no tag or digest)
+	repoPath := outputImage
+	if idx := strings.Index(repoPath, "@"); idx >= 0 {
+		repoPath = repoPath[:idx]
+	} else if idx := strings.LastIndex(repoPath, ":"); idx >= 0 {
+		// Only strip if this looks like a tag, not a port
+		afterColon := repoPath[idx+1:]
+		if !strings.Contains(afterColon, "/") {
+			repoPath = repoPath[:idx]
+		}
+	}
+	repoPath = strings.TrimSuffix(repoPath, "/")
+
+	// Try exact match first
+	for _, cred := range creds {
+		credRepo := strings.TrimSuffix(cred.repoName, "/")
+		if repoPath == credRepo {
+			log.Info("found full match of repository in auth",
+				"repo", repoPath,
+				"secretName", cred.secretName)
+			return cred.username, cred.password, nil
+		}
+	}
+
+	// Try progressively shorter partial matches
+	repoParts := strings.Split(repoPath, "/")
+	for len(repoParts) > 1 {
+		repoParts = repoParts[:len(repoParts)-1]
+		partialRepo := strings.Join(repoParts, "/")
+
+		for _, cred := range creds {
+			credRepo := strings.TrimSuffix(cred.repoName, "/")
+			if partialRepo == credRepo && cred.username != "" && cred.password != "" {
+				log.Info("partial match found of repository in auth",
+					"repo", partialRepo,
+					"secretName", cred.secretName)
+				return cred.username, cred.password, nil
+			}
+		}
+	}
+
+	return "", "", fmt.Errorf("no credentials found for repository %s", repoPath)
+}
+
+// isPaCGitHubAppConfigured checks if the PaC secret has GitHub App credentials configured.
+func isPaCGitHubAppConfigured(secretData map[string][]byte) bool {
+	return len(secretData[tektonconsts.PipelinesAsCodeGithubAppIdKey]) > 0 &&
+		len(secretData[tektonconsts.PipelinesAsCodeGithubPrivateKey]) > 0
+}
+
+// branchSlice returns a single-element slice with the branch if non-empty, or nil.
+func branchSlice(branch string) []string {
+	if branch == "" {
+		return nil
+	}
+	return []string{branch}
+}

--- a/tekton/nudging/nudge_credentials_test.go
+++ b/tekton/nudging/nudge_credentials_test.go
@@ -1,0 +1,1109 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nudging
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Nudge credentials", func() {
+
+	const (
+		testNamespace = "test-ns"
+	)
+
+	newCredentialScheme := func() *runtime.Scheme {
+		scheme := runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		Expect(applicationapiv1alpha1.AddToScheme(scheme)).To(Succeed())
+		return scheme
+	}
+
+	// ---------- getGitProvider ----------
+
+	Describe("getGitProvider", func() {
+
+		DescribeTable("detects provider from URL hostname",
+			func(sourceURL, expectedProvider string) {
+				comp := applicationapiv1alpha1.Component{
+					ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: sourceURL},
+							},
+						},
+					},
+				}
+				provider, err := getGitProvider(comp)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(provider).To(Equal(expectedProvider))
+			},
+			Entry("github.com URL", "https://github.com/org/repo", "github"),
+			Entry("gitlab.com URL", "https://gitlab.com/org/repo", "gitlab"),
+			Entry("bitbucket.org URL", "https://bitbucket.org/org/repo", "bitbucket"),
+			Entry("self-hosted GitHub", "https://github.example.com/org/repo", "github"),
+			Entry("self-hosted GitLab", "https://gitlab.internal.company.com/org/repo", "gitlab"),
+		)
+
+		DescribeTable("uses annotation override",
+			func(annotation, expectedProvider string) {
+				comp := applicationapiv1alpha1.Component{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "c",
+						Namespace:   testNamespace,
+						Annotations: map[string]string{gitProviderAnnotationName: annotation},
+					},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://custom-git.example.com/org/repo"},
+							},
+						},
+					},
+				}
+				provider, err := getGitProvider(comp)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(provider).To(Equal(expectedProvider))
+			},
+			Entry("github annotation", "github", "github"),
+			Entry("gitlab annotation", "gitlab", "gitlab"),
+			Entry("bitbucket annotation", "bitbucket", "bitbucket"),
+		)
+
+		It("returns error for unsupported annotation value", func() {
+			comp := applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "c",
+					Namespace:   testNamespace,
+					Annotations: map[string]string{gitProviderAnnotationName: "svn"},
+				},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					Source: applicationapiv1alpha1.ComponentSource{
+						ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+							GitSource: &applicationapiv1alpha1.GitSource{URL: "https://svn.example.com/org/repo"},
+						},
+					},
+				},
+			}
+			_, err := getGitProvider(comp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unsupported git-provider annotation"))
+		})
+
+		It("returns error when git source is nil", func() {
+			comp := applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: testNamespace},
+				Spec:       applicationapiv1alpha1.ComponentSpec{},
+			}
+			_, err := getGitProvider(comp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("git source is not set"))
+		})
+
+		It("returns error for unrecognized hostname without annotation", func() {
+			comp := applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "c", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					Source: applicationapiv1alpha1.ComponentSource{
+						ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+							GitSource: &applicationapiv1alpha1.GitSource{URL: "https://custom-scm.example.com/org/repo"},
+						},
+					},
+				},
+			}
+			_, err := getGitProvider(comp)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("cannot determine git provider"))
+		})
+	})
+
+	// ---------- parseGitRepoPath ----------
+
+	Describe("parseGitRepoPath", func() {
+		DescribeTable("extracts org/repo from URL",
+			func(gitURL, expectedPath string) {
+				Expect(parseGitRepoPath(gitURL)).To(Equal(expectedPath))
+			},
+			Entry("HTTPS URL", "https://github.com/org/repo", "org/repo"),
+			Entry("HTTPS URL with .git", "https://github.com/org/repo.git", "org/repo"),
+			Entry("HTTPS URL with trailing slash", "https://github.com/org/repo/", "org/repo"),
+			Entry("HTTPS URL with .git and trailing slash", "https://github.com/org/repo.git/", "org/repo"),
+			Entry("GitLab nested group", "https://gitlab.com/group/subgroup/repo", "group/subgroup/repo"),
+			Entry("empty URL returns empty", "", ""),
+		)
+	})
+
+	// ---------- getGitRepoHost ----------
+
+	Describe("getGitRepoHost", func() {
+		DescribeTable("extracts hostname",
+			func(gitURL, expectedHost string) {
+				Expect(getGitRepoHost(gitURL)).To(Equal(expectedHost))
+			},
+			Entry("github.com", "https://github.com/org/repo", "github.com"),
+			Entry("gitlab.com", "https://gitlab.com/org/repo", "gitlab.com"),
+			Entry("bitbucket.org", "https://bitbucket.org/org/repo", "bitbucket.org"),
+			Entry("custom host", "https://git.internal.example.com/org/repo", "git.internal.example.com"),
+			Entry("malformed URL returns empty", "://bad-url", ""),
+		)
+	})
+
+	// ---------- buildAPIEndpoint ----------
+
+	Describe("buildAPIEndpoint", func() {
+		DescribeTable("returns correct API URL",
+			func(provider, host, expected string) {
+				Expect(buildAPIEndpoint(provider, host)).To(Equal(expected))
+			},
+			Entry("github", "github", "github.com", "https://api.github.com/"),
+			Entry("gitlab", "gitlab", "gitlab.com", "https://gitlab.com/api/v4/"),
+			Entry("bitbucket", "bitbucket", "bitbucket.org", "https://api.bitbucket.org/2.0/"),
+			Entry("self-hosted github", "github", "github.example.com", "https://api.github.example.com/"),
+			Entry("self-hosted gitlab", "gitlab", "gitlab.internal.co", "https://gitlab.internal.co/api/v4/"),
+			Entry("unknown provider", "unknown", "example.com", ""),
+		)
+	})
+
+	// ---------- parseImageHost ----------
+
+	Describe("parseImageHost", func() {
+		DescribeTable("extracts registry host from image reference",
+			func(image, expectedHost string) {
+				Expect(parseImageHost(image)).To(Equal(expectedHost))
+			},
+			Entry("quay.io with tag", "quay.io/org/repo:latest", "quay.io"),
+			Entry("quay.io with digest", "quay.io/org/repo@sha256:abc123", "quay.io"),
+			Entry("quay.io no tag", "quay.io/org/repo", "quay.io"),
+			Entry("registry with port", "registry.example.com:5000/org/repo:v1", "registry.example.com:5000"),
+			Entry("Docker Hub shorthand", "library/nginx", "docker.io"),
+			Entry("gcr.io", "gcr.io/project/image:v1", "gcr.io"),
+		)
+	})
+
+	// ---------- branchSlice ----------
+
+	Describe("branchSlice", func() {
+		It("returns nil for empty branch", func() {
+			Expect(branchSlice("")).To(BeNil())
+		})
+
+		It("returns single-element slice for non-empty branch", func() {
+			Expect(branchSlice("main")).To(Equal([]string{"main"}))
+		})
+	})
+
+	// ---------- isPaCGitHubAppConfigured ----------
+
+	Describe("isPaCGitHubAppConfigured", func() {
+		It("returns true when both keys are present and non-empty", func() {
+			data := map[string][]byte{
+				tektonconsts.PipelinesAsCodeGithubAppIdKey:   []byte("12345"),
+				tektonconsts.PipelinesAsCodeGithubPrivateKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"),
+			}
+			Expect(isPaCGitHubAppConfigured(data)).To(BeTrue())
+		})
+
+		It("returns false when app ID is missing", func() {
+			data := map[string][]byte{
+				tektonconsts.PipelinesAsCodeGithubPrivateKey: []byte("key-data"),
+			}
+			Expect(isPaCGitHubAppConfigured(data)).To(BeFalse())
+		})
+
+		It("returns false when private key is missing", func() {
+			data := map[string][]byte{
+				tektonconsts.PipelinesAsCodeGithubAppIdKey: []byte("12345"),
+			}
+			Expect(isPaCGitHubAppConfigured(data)).To(BeFalse())
+		})
+
+		It("returns false when both keys are empty", func() {
+			data := map[string][]byte{
+				tektonconsts.PipelinesAsCodeGithubAppIdKey:   {},
+				tektonconsts.PipelinesAsCodeGithubPrivateKey: {},
+			}
+			Expect(isPaCGitHubAppConfigured(data)).To(BeFalse())
+		})
+
+		It("returns false for nil map", func() {
+			Expect(isPaCGitHubAppConfigured(nil)).To(BeFalse())
+		})
+	})
+
+	// ---------- matchCredentialForImage ----------
+
+	Describe("matchCredentialForImage", func() {
+		ctx := context.Background()
+
+		It("returns exact match", func() {
+			creds := []repositoryCredentials{
+				{secretName: "sec1", repoName: "quay.io/org/repo", username: "u1", password: "p1"},
+				{secretName: "sec2", repoName: "quay.io/other/repo", username: "u2", password: "p2"},
+			}
+			u, p, err := matchCredentialForImage(ctx, "quay.io/org/repo:latest", creds)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(u).To(Equal("u1"))
+			Expect(p).To(Equal("p1"))
+		})
+
+		It("returns partial match when no exact match", func() {
+			creds := []repositoryCredentials{
+				{secretName: "sec1", repoName: "quay.io/org", username: "u1", password: "p1"},
+			}
+			u, p, err := matchCredentialForImage(ctx, "quay.io/org/repo:v1", creds)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(u).To(Equal("u1"))
+			Expect(p).To(Equal("p1"))
+		})
+
+		It("returns host-level partial match", func() {
+			creds := []repositoryCredentials{
+				{secretName: "sec1", repoName: "quay.io", username: "u1", password: "p1"},
+			}
+			u, p, err := matchCredentialForImage(ctx, "quay.io/org/repo:v1", creds)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(u).To(Equal("u1"))
+			Expect(p).To(Equal("p1"))
+		})
+
+		It("returns error when no matching credential", func() {
+			creds := []repositoryCredentials{
+				{secretName: "sec1", repoName: "gcr.io/project", username: "u1", password: "p1"},
+			}
+			_, _, err := matchCredentialForImage(ctx, "quay.io/org/repo:v1", creds)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no credentials found"))
+		})
+
+		It("strips digest from image reference", func() {
+			creds := []repositoryCredentials{
+				{secretName: "sec1", repoName: "quay.io/org/repo", username: "u1", password: "p1"},
+			}
+			u, p, err := matchCredentialForImage(ctx, "quay.io/org/repo@sha256:abc123def456", creds)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(u).To(Equal("u1"))
+			Expect(p).To(Equal("p1"))
+		})
+	})
+
+	// ---------- bestMatchingSCMSecret ----------
+
+	Describe("bestMatchingSCMSecret", func() {
+		ctx := context.Background()
+
+		It("returns direct match from scm.repository annotation", func() {
+			secrets := []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "wildcard-secret",
+						Annotations: map[string]string{
+							scmSecretRepositoryAnnotation: "org/*",
+						},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user"),
+						corev1.BasicAuthPasswordKey: []byte("pass"),
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "exact-secret",
+						Annotations: map[string]string{
+							scmSecretRepositoryAnnotation: "org/repo",
+						},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user-exact"),
+						corev1.BasicAuthPasswordKey: []byte("pass-exact"),
+					},
+				},
+			}
+			result := bestMatchingSCMSecret(ctx, "org/repo", secrets)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal("exact-secret"))
+		})
+
+		It("returns wildcard match when no direct match", func() {
+			secrets := []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "wildcard-secret",
+						Annotations: map[string]string{
+							scmSecretRepositoryAnnotation: "org/*",
+						},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user"),
+						corev1.BasicAuthPasswordKey: []byte("pass"),
+					},
+				},
+			}
+			result := bestMatchingSCMSecret(ctx, "org/other-repo", secrets)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal("wildcard-secret"))
+		})
+
+		It("returns host-only secret as fallback", func() {
+			secrets := []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:        "host-only-secret",
+						Annotations: map[string]string{},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user"),
+						corev1.BasicAuthPasswordKey: []byte("pass"),
+					},
+				},
+			}
+			result := bestMatchingSCMSecret(ctx, "org/repo", secrets)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal("host-only-secret"))
+		})
+
+		It("returns nil when no secrets match", func() {
+			secrets := []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "wrong-repo-secret",
+						Annotations: map[string]string{
+							scmSecretRepositoryAnnotation: "other-org/other-repo",
+						},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user"),
+						corev1.BasicAuthPasswordKey: []byte("pass"),
+					},
+				},
+			}
+			result := bestMatchingSCMSecret(ctx, "org/repo", secrets)
+			Expect(result).To(BeNil())
+		})
+
+		It("handles leading slashes in repository annotation", func() {
+			secrets := []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "prefixed-secret",
+						Annotations: map[string]string{
+							scmSecretRepositoryAnnotation: "/org/repo",
+						},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user"),
+						corev1.BasicAuthPasswordKey: []byte("pass"),
+					},
+				},
+			}
+			result := bestMatchingSCMSecret(ctx, "org/repo", secrets)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal("prefixed-secret"))
+		})
+
+		It("handles comma-separated repositories in annotation", func() {
+			secrets := []corev1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "multi-repo-secret",
+						Annotations: map[string]string{
+							scmSecretRepositoryAnnotation: "org/repo-a, org/repo-b, org/repo-c",
+						},
+					},
+					Data: map[string][]byte{
+						corev1.BasicAuthUsernameKey: []byte("user"),
+						corev1.BasicAuthPasswordKey: []byte("pass"),
+					},
+				},
+			}
+			result := bestMatchingSCMSecret(ctx, "org/repo-b", secrets)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Name).To(Equal("multi-repo-secret"))
+		})
+	})
+
+	// ---------- GetNudgeTargetsGithubApp ----------
+
+	Describe("GetNudgeTargetsGithubApp", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = newCredentialScheme()
+		})
+
+		It("returns nil when PaC secret does not exist", func() {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo"},
+							},
+						},
+					},
+				},
+			}
+			targets := GetNudgeTargetsGithubApp(ctx, c, components, "quay.io", "user", "pass")
+			Expect(targets).To(BeNil())
+		})
+
+		It("returns nil when PaC secret exists but GitHub App is not configured", func() {
+			pacSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tektonconsts.PipelinesAsCodeGitHubAppSecretName,
+					Namespace: "integration-service",
+				},
+				Data: map[string][]byte{
+					"some-other-key": []byte("some-value"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pacSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo"},
+							},
+						},
+					},
+				},
+			}
+			targets := GetNudgeTargetsGithubApp(ctx, c, components, "quay.io", "user", "pass")
+			Expect(targets).To(BeNil())
+		})
+
+		It("returns nil when PaC secret has GitHub App configured (not yet implemented)", func() {
+			pacSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      tektonconsts.PipelinesAsCodeGitHubAppSecretName,
+					Namespace: "integration-service",
+				},
+				Data: map[string][]byte{
+					tektonconsts.PipelinesAsCodeGithubAppIdKey:   []byte("12345"),
+					tektonconsts.PipelinesAsCodeGithubPrivateKey: []byte("-----BEGIN RSA PRIVATE KEY-----\nfake\n-----END RSA PRIVATE KEY-----"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(pacSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo"},
+							},
+						},
+					},
+				},
+			}
+			// Currently returns nil because the implementation is a TODO stub
+			targets := GetNudgeTargetsGithubApp(ctx, c, components, "quay.io", "user", "pass")
+			Expect(targets).To(BeNil())
+		})
+	})
+
+	// ---------- GetNudgeTargetsBasicAuth ----------
+
+	Describe("GetNudgeTargetsBasicAuth", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = newCredentialScheme()
+		})
+
+		It("creates a target for a component with matching SCM secret", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-github-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+					Annotations: map[string]string{
+						scmSecretRepositoryAnnotation: "org/repo",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("bot-user"),
+					corev1.BasicAuthPasswordKey: []byte("ghp_secret-token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									URL:      "https://github.com/org/repo",
+									Revision: "main",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "img-user", "img-pass")
+			Expect(targets).To(HaveLen(1))
+			Expect(targets[0].ComponentName).To(Equal("comp"))
+			Expect(targets[0].GitProvider).To(Equal("github"))
+			Expect(targets[0].Username).To(Equal("bot-user"))
+			Expect(targets[0].Token).To(Equal("ghp_secret-token"))
+			Expect(targets[0].Endpoint).To(Equal("https://api.github.com/"))
+			Expect(targets[0].ImageRepositoryHost).To(Equal("quay.io"))
+			Expect(targets[0].ImageRepositoryUsername).To(Equal("img-user"))
+			Expect(targets[0].ImageRepositoryPassword).To(Equal("img-pass"))
+			Expect(targets[0].Repositories).To(HaveLen(1))
+			Expect(targets[0].Repositories[0].Repository).To(Equal("org/repo"))
+			Expect(targets[0].Repositories[0].BaseBranches).To(Equal([]string{"main"}))
+		})
+
+		It("uses default username when SCM secret has empty username", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: {},
+					corev1.BasicAuthPasswordKey: []byte("token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo"},
+							},
+						},
+					},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "u", "p")
+			Expect(targets).To(HaveLen(1))
+			Expect(targets[0].Username).To(Equal(tektonconsts.DefaultRenovateUser))
+		})
+
+		It("skips components without matching SCM secret", func() {
+			// No secrets created in the namespace
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo"},
+							},
+						},
+					},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "u", "p")
+			Expect(targets).To(BeEmpty())
+		})
+
+		It("handles multiple components where only some have credentials", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+					Annotations: map[string]string{
+						scmSecretRepositoryAnnotation: "org/repo-a",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("user"),
+					corev1.BasicAuthPasswordKey: []byte("token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp-a", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo-a"},
+							},
+						},
+					},
+				},
+				{
+					// This component is on gitlab, no secret matches
+					ObjectMeta: metav1.ObjectMeta{Name: "comp-b", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://gitlab.com/org/repo-b"},
+							},
+						},
+					},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "u", "p")
+			Expect(targets).To(HaveLen(1))
+			Expect(targets[0].ComponentName).To(Equal("comp-a"))
+		})
+
+		It("skips component with no git source", func() {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec:       applicationapiv1alpha1.ComponentSpec{},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "u", "p")
+			Expect(targets).To(BeEmpty())
+		})
+
+		It("sets nil BaseBranches when revision is empty", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("user"),
+					corev1.BasicAuthPasswordKey: []byte("token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{
+									URL:      "https://github.com/org/repo",
+									Revision: "",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "u", "p")
+			Expect(targets).To(HaveLen(1))
+			Expect(targets[0].Repositories[0].BaseBranches).To(BeNil())
+		})
+
+		It("creates target with correct GitAuthor format", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("my-bot"),
+					corev1.BasicAuthPasswordKey: []byte("token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+			components := []applicationapiv1alpha1.Component{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+					Spec: applicationapiv1alpha1.ComponentSpec{
+						Source: applicationapiv1alpha1.ComponentSource{
+							ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+								GitSource: &applicationapiv1alpha1.GitSource{URL: "https://github.com/org/repo"},
+							},
+						},
+					},
+				},
+			}
+
+			targets := GetNudgeTargetsBasicAuth(ctx, c, components, "quay.io", "u", "p")
+			Expect(targets).To(HaveLen(1))
+			expectedAuthor := "my-bot <my-bot@users.noreply.github.com>"
+			Expect(targets[0].GitAuthor).To(Equal(expectedAuthor))
+		})
+	})
+
+	// ---------- GetImageRegistryCredentials ----------
+
+	Describe("GetImageRegistryCredentials", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = newCredentialScheme()
+		})
+
+		It("returns credentials from SA-linked dockerconfigjson secret", func() {
+			dockerConfig := dockerConfigJSON{
+				Auths: map[string]repositoryConfigAuth{
+					"quay.io/org/repo": {Username: "quay-user", Password: "quay-pass"},
+				},
+			}
+			dockerConfigBytes, err := json.Marshal(dockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			dockerSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret", Namespace: testNamespace},
+				Type:       corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: dockerConfigBytes,
+				},
+			}
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipeline-sa", Namespace: testNamespace},
+				Secrets:    []corev1.ObjectReference{{Name: "docker-secret"}},
+			}
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo:latest",
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dockerSecret, sa).Build()
+			host, username, password, err := GetImageRegistryCredentials(ctx, c, comp, "pipeline-sa")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).To(Equal("quay.io"))
+			Expect(username).To(Equal("quay-user"))
+			Expect(password).To(Equal("quay-pass"))
+		})
+
+		It("decodes base64 auth field when username/password not explicit", func() {
+			encodedAuth := base64.StdEncoding.EncodeToString([]byte("b64-user:b64-pass"))
+			dockerConfig := dockerConfigJSON{
+				Auths: map[string]repositoryConfigAuth{
+					"quay.io/org/repo": {Auth: encodedAuth},
+				},
+			}
+			dockerConfigBytes, err := json.Marshal(dockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			dockerSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret", Namespace: testNamespace},
+				Type:       corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: dockerConfigBytes,
+				},
+			}
+			sa := &corev1.ServiceAccount{
+				ObjectMeta:       metav1.ObjectMeta{Name: "pipeline-sa", Namespace: testNamespace},
+				ImagePullSecrets: []corev1.LocalObjectReference{{Name: "docker-secret"}},
+			}
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo:latest",
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dockerSecret, sa).Build()
+			host, username, password, err := GetImageRegistryCredentials(ctx, c, comp, "pipeline-sa")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).To(Equal("quay.io"))
+			Expect(username).To(Equal("b64-user"))
+			Expect(password).To(Equal("b64-pass"))
+		})
+
+		It("returns error when ServiceAccount not found", func() {
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo:latest",
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			_, _, _, err := GetImageRegistryCredentials(ctx, c, comp, "nonexistent-sa")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to read service account"))
+		})
+
+		It("returns error when component has no container image", func() {
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec:       applicationapiv1alpha1.ComponentSpec{},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			_, _, _, err := GetImageRegistryCredentials(ctx, c, comp, "sa")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("has no container image set"))
+		})
+
+		It("returns error when no matching registry in docker config", func() {
+			dockerConfig := dockerConfigJSON{
+				Auths: map[string]repositoryConfigAuth{
+					"gcr.io/other-project": {Username: "gcr-user", Password: "gcr-pass"},
+				},
+			}
+			dockerConfigBytes, err := json.Marshal(dockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			dockerSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret", Namespace: testNamespace},
+				Type:       corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: dockerConfigBytes,
+				},
+			}
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipeline-sa", Namespace: testNamespace},
+				Secrets:    []corev1.ObjectReference{{Name: "docker-secret"}},
+			}
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo:latest",
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dockerSecret, sa).Build()
+			host, _, _, err := GetImageRegistryCredentials(ctx, c, comp, "pipeline-sa")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no credentials found for image"))
+			// Host is still returned even when credentials fail
+			Expect(host).To(Equal("quay.io"))
+		})
+
+		It("returns error when SA has no linked secrets", func() {
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "empty-sa", Namespace: testNamespace},
+			}
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo:latest",
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa).Build()
+			_, _, _, err := GetImageRegistryCredentials(ctx, c, comp, "empty-sa")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no secrets linked to service account"))
+		})
+
+		It("skips non-dockerconfigjson secrets", func() {
+			opaqueSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "opaque-secret", Namespace: testNamespace},
+				Type:       corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"key": []byte("value"),
+				},
+			}
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipeline-sa", Namespace: testNamespace},
+				Secrets:    []corev1.ObjectReference{{Name: "opaque-secret"}},
+			}
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo:latest",
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(opaqueSecret, sa).Build()
+			_, _, _, err := GetImageRegistryCredentials(ctx, c, comp, "pipeline-sa")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no credentials found for image"))
+		})
+
+		It("handles image with digest instead of tag", func() {
+			dockerConfig := dockerConfigJSON{
+				Auths: map[string]repositoryConfigAuth{
+					"quay.io/org/repo": {Username: "user", Password: "pass"},
+				},
+			}
+			dockerConfigBytes, err := json.Marshal(dockerConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			dockerSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{Name: "docker-secret", Namespace: testNamespace},
+				Type:       corev1.SecretTypeDockerConfigJson,
+				Data: map[string][]byte{
+					corev1.DockerConfigJsonKey: dockerConfigBytes,
+				},
+			}
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "pipeline-sa", Namespace: testNamespace},
+				Secrets:    []corev1.ObjectReference{{Name: "docker-secret"}},
+			}
+			comp := &applicationapiv1alpha1.Component{
+				ObjectMeta: metav1.ObjectMeta{Name: "comp", Namespace: testNamespace},
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					ContainerImage: "quay.io/org/repo@sha256:abc123def456",
+				},
+			}
+
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(dockerSecret, sa).Build()
+			host, username, password, err := GetImageRegistryCredentials(ctx, c, comp, "pipeline-sa")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(host).To(Equal("quay.io"))
+			Expect(username).To(Equal("user"))
+			Expect(password).To(Equal("pass"))
+		})
+	})
+
+	// ---------- lookupSCMCredentials ----------
+
+	Describe("lookupSCMCredentials", func() {
+		var (
+			ctx    context.Context
+			scheme *runtime.Scheme
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			scheme = newCredentialScheme()
+		})
+
+		It("returns credentials from matching BasicAuth secret", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+					Annotations: map[string]string{
+						scmSecretRepositoryAnnotation: "org/repo",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("user"),
+					corev1.BasicAuthPasswordKey: []byte("token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+
+			username, password, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(username).To(Equal("user"))
+			Expect(password).To(Equal("token"))
+		})
+
+		It("returns error when no secrets match the host", func() {
+			c := fake.NewClientBuilder().WithScheme(scheme).Build()
+			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no SCM basic auth secrets found"))
+		})
+
+		It("skips non-BasicAuth secrets", func() {
+			opaqueSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "opaque-scm",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+				},
+				Type: corev1.SecretTypeOpaque,
+				Data: map[string][]byte{
+					"token": []byte("some-token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(opaqueSecret).Build()
+			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no SCM basic auth secrets found"))
+		})
+	})
+
+	// ---------- getGitRepoURL ----------
+
+	Describe("getGitRepoURL", func() {
+		It("returns normalized URL stripping .git and trailing slash", func() {
+			comp := &applicationapiv1alpha1.Component{
+				Spec: applicationapiv1alpha1.ComponentSpec{
+					Source: applicationapiv1alpha1.ComponentSource{
+						ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+							GitSource: &applicationapiv1alpha1.GitSource{
+								URL: "https://github.com/org/repo.git/",
+							},
+						},
+					},
+				},
+			}
+			Expect(getGitRepoURL(comp)).To(Equal("https://github.com/org/repo"))
+		})
+
+		It("returns empty string when git source is nil", func() {
+			comp := &applicationapiv1alpha1.Component{
+				Spec: applicationapiv1alpha1.ComponentSpec{},
+			}
+			Expect(getGitRepoURL(comp)).To(Equal(""))
+		})
+	})
+})

--- a/tekton/nudging/nudge_pipeline.go
+++ b/tekton/nudging/nudge_pipeline.go
@@ -1,0 +1,662 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nudging
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	tektonhelpers "github.com/konflux-ci/integration-service/tekton"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logger "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// ConfigMap data keys for custom Renovate options, matching build-service constants.
+const (
+	renovateConfigMapAutomergeKey             = "automerge"
+	renovateConfigMapCommitMessagePrefixKey   = "commitMessagePrefix"
+	renovateConfigMapCommitMessageSuffixKey   = "commitMessageSuffix"
+	renovateConfigMapFileMatchKey             = "fileMatch"
+	renovateConfigMapAutomergeTypeKey         = "automergeType"
+	renovateConfigMapPlatformAutomergeKey     = "platformAutomerge"
+	renovateConfigMapIgnoreTestsKey           = "ignoreTests"
+	renovateConfigMapGitLabIgnoreApprovalsKey = "gitLabIgnoreApprovals"
+	renovateConfigMapAutomergeScheduleKey     = "automergeSchedule"
+	renovateConfigMapLabelsKey                = "labels"
+)
+
+// RenovateRepository represents a single git repository for Renovate to process.
+type RenovateRepository struct {
+	Repository   string   `json:"repository"`
+	BaseBranches []string `json:"baseBranches,omitempty"`
+}
+
+// CustomRenovateOptions holds per-component Renovate configuration read from a ConfigMap.
+type CustomRenovateOptions struct {
+	Automerge             bool     `json:"automerge,omitempty"`
+	AutomergeType         string   `json:"automergeType,omitempty"`
+	PlatformAutomerge     bool     `json:"platformAutomerge,omitempty"`
+	IgnoreTests           bool     `json:"ignoreTests,omitempty"`
+	CommitMessagePrefix   string   `json:"commitMessagePrefix,omitempty"`
+	CommitMessageSuffix   string   `json:"commitMessageSuffix,omitempty"`
+	FileMatch             []string `json:"fileMatch,omitempty"`
+	GitLabIgnoreApprovals bool     `json:"gitLabIgnoreApprovals,omitempty"`
+	AutomergeSchedule     []string `json:"automergeSchedule,omitempty"`
+	Labels                []string `json:"labels,omitempty"`
+}
+
+// NudgeTarget represents a target source code repository to be updated by
+// Renovate with the necessary credentials and repository information.
+type NudgeTarget struct {
+	ComponentName                  string
+	ComponentCustomRenovateOptions *CustomRenovateOptions
+	GitProvider                    string
+	Username                       string
+	GitAuthor                      string
+	Token                          string
+	Endpoint                       string
+	Repositories                   []RenovateRepository
+	ImageRepositoryHost            string
+	ImageRepositoryUsername        string
+	ImageRepositoryPassword        string
+}
+
+// NudgeBuildResult holds the data extracted from a build PipelineRun that is
+// needed to generate Renovate nudge configurations.
+type NudgeBuildResult struct {
+	BuiltImageRepository     string
+	BuiltImageTag            string
+	Digest                   string
+	FileMatches              string
+	SourceComponentName      string
+	GitRepoAtShaLink         string
+	DistributionRepositories []string
+}
+
+// CustomManager configures a Renovate custom regex manager for matching image
+// digest references in downstream repository files.
+type CustomManager struct {
+	FileMatch            []string `json:"fileMatch,omitempty"`
+	CustomType           string   `json:"customType"`
+	DatasourceTemplate   string   `json:"datasourceTemplate"`
+	MatchStrings         []string `json:"matchStrings"`
+	CurrentValueTemplate string   `json:"currentValueTemplate"`
+	DepNameTemplate      string   `json:"depNameTemplate"`
+}
+
+// PackageRule configures Renovate's per-package behavior: branch naming,
+// commit messages, PR content, and merge strategy.
+type PackageRule struct {
+	MatchPackagePatterns   []string `json:"matchPackagePatterns,omitempty"`
+	MatchPackageNames      []string `json:"matchPackageNames,omitempty"`
+	GroupName              string   `json:"groupName,omitempty"`
+	BranchPrefix           string   `json:"branchPrefix,omitempty"`
+	BranchTopic            string   `json:"branchTopic,omitempty"`
+	AdditionalBranchPrefix string   `json:"additionalBranchPrefix,omitempty"`
+	CommitMessageTopic     string   `json:"commitMessageTopic,omitempty"`
+	CommitMessagePrefix    string   `json:"commitMessagePrefix,omitempty"`
+	CommitMessageSuffix    string   `json:"commitMessageSuffix,omitempty"`
+	CommitBody             string   `json:"commitBody,omitempty"`
+	PRFooter               string   `json:"prFooter,omitempty"`
+	PRHeader               string   `json:"prHeader,omitempty"`
+	RecreateWhen           string   `json:"recreateWhen,omitempty"`
+	RebaseWhen             string   `json:"rebaseWhen,omitempty"`
+	Enabled                bool     `json:"enabled"`
+}
+
+// RenovateConfig is the top-level Renovate JSON configuration written to the
+// ConfigMap that drives a nudge PipelineRun.
+type RenovateConfig struct {
+	GitProvider           string               `json:"platform"`
+	Username              string               `json:"username"`
+	GitAuthor             string               `json:"gitAuthor"`
+	Onboarding            bool                 `json:"onboarding"`
+	RequireConfig         string               `json:"requireConfig"`
+	Repositories          []RenovateRepository `json:"repositories"`
+	EnabledManagers       []string             `json:"enabledManagers"`
+	Endpoint              string               `json:"endpoint"`
+	CustomManagers        []CustomManager      `json:"customManagers,omitempty"`
+	RegistryAliases       map[string]string    `json:"registryAliases,omitempty"`
+	PackageRules          []PackageRule        `json:"packageRules,omitempty"`
+	ForkProcessing        string               `json:"forkProcessing"`
+	Extends               []string             `json:"extends"`
+	DependencyDashboard   bool                 `json:"dependencyDashboard"`
+	Labels                []string             `json:"labels"`
+	Automerge             bool                 `json:"automerge"`
+	AutomergeType         string               `json:"automergeType,omitempty"`
+	PlatformAutomerge     bool                 `json:"platformAutomerge"`
+	IgnoreTests           bool                 `json:"ignoreTests"`
+	GitLabIgnoreApprovals bool                 `json:"gitLabIgnoreApprovals"`
+	AutomergeSchedule     []string             `json:"automergeSchedule,omitempty"`
+}
+
+// DisableAllPackageRules is the catch-all rule that disables all packages; the
+// subsequent enable rule overrides it for the specific built image only.
+var DisableAllPackageRules = PackageRule{MatchPackagePatterns: []string{"*"}, Enabled: false}
+
+// ExtractBuildResultForNudging reads the build pipeline results and annotations to
+// produce the data needed for nudge Renovate config generation.
+func ExtractBuildResultForNudging(plr *tektonv1.PipelineRun, component *applicationapiv1alpha1.Component) (*NudgeBuildResult, error) {
+	outputImage, err := tektonhelpers.GetOutputImage(plr)
+	if err != nil {
+		return nil, fmt.Errorf("extracting IMAGE_URL from build PLR %s: %w", plr.Name, err)
+	}
+
+	digest, err := tektonhelpers.GetOutputImageDigest(plr)
+	if err != nil {
+		return nil, fmt.Errorf("extracting IMAGE_DIGEST from build PLR %s: %w", plr.Name, err)
+	}
+
+	repo := outputImage
+	tag := ""
+	if index := strings.LastIndex(outputImage, ":"); index != -1 {
+		repo = outputImage[:index]
+		tag = outputImage[index+1:]
+	}
+
+	nudgeFiles := ""
+	if plr.Annotations != nil {
+		nudgeFiles = plr.Annotations[tektonconsts.NudgeFilesAnnotation]
+	}
+	if nudgeFiles == "" {
+		nudgeFiles = tektonconsts.DefaultNudgeFiles
+	}
+
+	gitRepoAtShaLink := ""
+	if plr.Annotations != nil {
+		gitRepoAtShaLink = plr.Annotations[tektonconsts.GitRepoAtShaAnnotation]
+	}
+
+	return &NudgeBuildResult{
+		BuiltImageRepository: repo,
+		BuiltImageTag:        tag,
+		Digest:               digest,
+		FileMatches:          nudgeFiles,
+		SourceComponentName:  component.Name,
+		GitRepoAtShaLink:     gitRepoAtShaLink,
+	}, nil
+}
+
+// GenerateRenovateConfig produces the Renovate JSON config for a single nudge
+// target, replicating the build-service generateRenovateConfigForNudge shape.
+func GenerateRenovateConfig(target NudgeTarget, buildResult *NudgeBuildResult, simpleBranchName bool) RenovateConfig {
+	fileMatchParts := strings.Split(buildResult.FileMatches, ",")
+	for i := range fileMatchParts {
+		fileMatchParts[i] = strings.TrimSpace(fileMatchParts[i])
+	}
+
+	var matchStrings []string
+	registryAliases := make(map[string]string)
+	var matchPackageNames []string
+
+	matchStrings = append(matchStrings, regexp.QuoteMeta(buildResult.BuiltImageRepository)+"(:.*)?@(?<currentDigest>sha256:[a-f0-9]+)")
+	matchPackageNames = append(matchPackageNames, buildResult.BuiltImageRepository)
+
+	for _, drepo := range buildResult.DistributionRepositories {
+		matchStrings = append(matchStrings, regexp.QuoteMeta(drepo)+"(:.*)?@(?<currentDigest>sha256:[a-f0-9]+)")
+		matchPackageNames = append(matchPackageNames, drepo)
+		registryAliases[drepo] = buildResult.BuiltImageRepository
+	}
+
+	customOpts := target.ComponentCustomRenovateOptions
+	if customOpts == nil {
+		customOpts = &CustomRenovateOptions{}
+	}
+
+	if customOpts.FileMatch != nil {
+		fileMatchParts = customOpts.FileMatch
+	}
+
+	labels := []string{tektonconsts.DefaultRenovateLabel}
+	if customOpts.Labels != nil {
+		labels = append(labels, customOpts.Labels...)
+	}
+
+	customManagers := []CustomManager{{
+		FileMatch:            fileMatchParts,
+		CustomType:           "regex",
+		DatasourceTemplate:   "docker",
+		MatchStrings:         matchStrings,
+		CurrentValueTemplate: buildResult.BuiltImageTag,
+		DepNameTemplate:      buildResult.BuiltImageRepository,
+	}}
+
+	nudgingBranchName := fmt.Sprintf("%s-", target.ComponentName)
+	if simpleBranchName {
+		nudgingBranchName = ""
+	}
+
+	packageRules := []PackageRule{
+		DisableAllPackageRules,
+		{
+			MatchPackageNames:      matchPackageNames,
+			GroupName:              fmt.Sprintf("Component Update %s", buildResult.SourceComponentName),
+			BranchPrefix:           tektonconsts.BranchPrefix,
+			BranchTopic:            buildResult.SourceComponentName,
+			AdditionalBranchPrefix: nudgingBranchName,
+			CommitMessageTopic:     buildResult.SourceComponentName,
+			PRFooter:               "To execute skipped test pipelines write comment `/ok-to-test`",
+			PRHeader:               fmt.Sprintf("Image created from '%s'", buildResult.GitRepoAtShaLink),
+			RecreateWhen:           "always",
+			RebaseWhen:             "behind-base-branch",
+			Enabled:                true,
+			CommitBody:             fmt.Sprintf("Image created from '%s'\n\nSigned-off-by: %s", buildResult.GitRepoAtShaLink, target.GitAuthor),
+			CommitMessagePrefix:    customOpts.CommitMessagePrefix,
+			CommitMessageSuffix:    customOpts.CommitMessageSuffix,
+		},
+	}
+
+	return RenovateConfig{
+		GitProvider:           target.GitProvider,
+		Username:              target.Username,
+		GitAuthor:             target.GitAuthor,
+		Onboarding:            false,
+		RequireConfig:         "ignored",
+		Repositories:          target.Repositories,
+		EnabledManagers:       []string{"custom.regex"},
+		Endpoint:              target.Endpoint,
+		CustomManagers:        customManagers,
+		RegistryAliases:       registryAliases,
+		PackageRules:          packageRules,
+		ForkProcessing:        "enabled",
+		Extends:               []string{},
+		DependencyDashboard:   false,
+		Labels:                labels,
+		Automerge:             customOpts.Automerge,
+		PlatformAutomerge:     customOpts.PlatformAutomerge,
+		IgnoreTests:           customOpts.IgnoreTests,
+		AutomergeType:         customOpts.AutomergeType,
+		GitLabIgnoreApprovals: customOpts.GitLabIgnoreApprovals,
+		AutomergeSchedule:     customOpts.AutomergeSchedule,
+	}
+}
+
+// CreateNudgePipelineRun creates the Renovate PipelineRun plus its supporting
+// Secret and ConfigMap in the build PLR namespace.  The PipelineRun is created
+// first so owner references can point back to it; Secret and ConfigMap are
+// created afterward (Tekton will wait for them).
+func CreateNudgePipelineRun(ctx context.Context, c client.Client, nudgingPLR *tektonv1.PipelineRun, targets []NudgeTarget, buildResult *NudgeBuildResult, simpleBranchName bool) error {
+	log := logger.FromContext(ctx)
+
+	if len(targets) == 0 {
+		return nil
+	}
+
+	nameSuffix := deterministicSuffix(string(nudgingPLR.UID))
+	name := fmt.Sprintf("renovate-pipeline-%s", nameSuffix)
+	namespace := nudgingPLR.Namespace
+	caConfigMapName := fmt.Sprintf("renovate-ca-%s", nameSuffix)
+
+	secretTokens := map[string]string{}
+	configmaps := map[string]string{}
+	var renovateCmds []string
+
+	for i, target := range targets {
+		configKey := fmt.Sprintf("%s-%d.json", target.ComponentName, i)
+		tokenKey := fmt.Sprintf("token_%d", i)
+		imageKey := fmt.Sprintf("image_%d", i)
+		secretTokens[tokenKey] = target.Token
+		secretTokens[imageKey] = target.ImageRepositoryPassword
+
+		renovateConfig := GenerateRenovateConfig(target, buildResult, simpleBranchName)
+		config, err := json.Marshal(renovateConfig)
+		if err != nil {
+			return fmt.Errorf("marshalling renovate config for component %s: %w", target.ComponentName, err)
+		}
+
+		configmaps[configKey] = string(config)
+		log.Info("created renovate config entry", "component", target.ComponentName, "configLength", len(config))
+
+		hostRules := fmt.Sprintf("\"[{'matchHost':'%s','username':'%s','password':'${TOKEN_%s}'}]\"",
+			target.ImageRepositoryHost, target.ImageRepositoryUsername, imageKey)
+
+		renovateCmds = append(renovateCmds,
+			fmt.Sprintf("RENOVATE_X_GITLAB_MERGE_REQUEST_DELAY=5000 RENOVATE_X_GITLAB_AUTO_MERGEABLE_CHECK_ATTEMPS=11 RENOVATE_PR_HOURLY_LIMIT=0 RENOVATE_PR_CONCURRENT_LIMIT=0 RENOVATE_TOKEN=$TOKEN_%s RENOVATE_CONFIG_FILE=/configs/%s RENOVATE_HOST_RULES=%s renovate",
+				tokenKey, configKey, hostRules),
+		)
+	}
+	if len(renovateCmds) == 0 {
+		return nil
+	}
+
+	// Look for a CA bundle ConfigMap in the build-service namespace.
+	allCaConfigMaps := &corev1.ConfigMapList{}
+	if err := c.List(ctx, allCaConfigMaps,
+		client.InNamespace(tektonconsts.BuildServiceNamespaceName),
+		client.MatchingLabels{tektonconsts.CaConfigMapLabel: "true"},
+	); err != nil {
+		return fmt.Errorf("listing CA config maps in %s namespace: %w", tektonconsts.BuildServiceNamespaceName, err)
+	}
+	caConfigData := ""
+	if len(allCaConfigMaps.Items) > 0 {
+		log.Info("using CA config map", "name", allCaConfigMaps.Items[0].Name)
+		caConfigData = allCaConfigMaps.Items[0].Data[tektonconsts.CaConfigMapKey]
+	}
+
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		StringData: secretTokens,
+	}
+
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Data: configmaps,
+	}
+
+	var caConfigMap *corev1.ConfigMap
+	if caConfigData != "" {
+		caConfigMap = &corev1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      caConfigMapName,
+				Namespace: namespace,
+			},
+			Data: map[string]string{tektonconsts.CaConfigMapKey: caConfigData},
+		}
+	}
+
+	// Determine the service account from the source build PLR.
+	saName := nudgingPLR.Spec.TaskRunTemplate.ServiceAccountName
+	if saName == "" {
+		saName = tektonconsts.DefaultPipelineServiceAccount
+	}
+	if err := c.Get(ctx, types.NamespacedName{Name: saName, Namespace: namespace}, &corev1.ServiceAccount{}); err != nil {
+		return fmt.Errorf("service account %s not found in namespace %s: %w", saName, namespace, err)
+	}
+
+	trueBool := true
+	falseBool := false
+	renovateImageUrl := os.Getenv(tektonconsts.RenovateImageEnvName)
+	if renovateImageUrl == "" {
+		renovateImageUrl = tektonconsts.DefaultRenovateImageUrl
+	}
+
+	pipelineRun := &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Labels: map[string]string{
+				tektonconsts.NudgeTypeLabel: tektonconsts.NudgePipelineRunTypeValue,
+			},
+			Annotations: map[string]string{
+				tektonconsts.NudgedComponentsAnnotation: joinNudgedComponentNames(targets),
+				tektonconsts.NudgingCommitAnnotation:    extractCommitHash(buildResult.GitRepoAtShaLink),
+				tektonconsts.NudgingComponentAnnotation: buildResult.SourceComponentName,
+				tektonconsts.NudgingImageAnnotation:     fmt.Sprintf("%s:%s", buildResult.BuiltImageRepository, buildResult.BuiltImageTag),
+				tektonconsts.NudgingPipelineAnnotation:  nudgingPLR.Name,
+			},
+		},
+		Spec: tektonv1.PipelineRunSpec{
+			PipelineSpec: &tektonv1.PipelineSpec{
+				Tasks: []tektonv1.PipelineTask{{
+					Name: "renovate",
+					TaskSpec: &tektonv1.EmbeddedTask{
+						TaskSpec: tektonv1.TaskSpec{
+							Steps: []tektonv1.Step{{
+								Name:  "renovate",
+								Image: renovateImageUrl,
+								EnvFrom: []corev1.EnvFromSource{
+									{
+										Prefix: "TOKEN_",
+										SecretRef: &corev1.SecretEnvSource{
+											LocalObjectReference: corev1.LocalObjectReference{
+												Name: name,
+											},
+										},
+									},
+								},
+								Command: []string{"bash", "-c", strings.Join(renovateCmds, "; ")},
+								VolumeMounts: []corev1.VolumeMount{
+									{
+										Name:      name,
+										MountPath: "/configs",
+									},
+								},
+								SecurityContext: &corev1.SecurityContext{
+									Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+									RunAsNonRoot:             &trueBool,
+									AllowPrivilegeEscalation: &falseBool,
+									SeccompProfile: &corev1.SeccompProfile{
+										Type: corev1.SeccompProfileTypeRuntimeDefault,
+									},
+								},
+							}},
+							Volumes: []corev1.Volume{
+								{
+									Name: name,
+									VolumeSource: corev1.VolumeSource{
+										ConfigMap: &corev1.ConfigMapVolumeSource{
+											LocalObjectReference: corev1.LocalObjectReference{Name: name},
+										},
+									},
+								},
+							},
+						},
+					},
+				}},
+			},
+			TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
+				ServiceAccountName: saName,
+			},
+		},
+	}
+
+	if caConfigData != "" {
+		caVolume := corev1.Volume{
+			Name: tektonconsts.CaVolumeMountName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: caConfigMapName},
+					Items: []corev1.KeyToPath{
+						{
+							Key:  tektonconsts.CaConfigMapKey,
+							Path: tektonconsts.CaFilePath,
+						},
+					},
+				},
+			},
+		}
+		caVolumeMount := corev1.VolumeMount{
+			Name:      tektonconsts.CaVolumeMountName,
+			MountPath: tektonconsts.CaMountPath,
+			ReadOnly:  true,
+		}
+		pipelineRun.Spec.PipelineSpec.Tasks[0].TaskSpec.Volumes = append(
+			pipelineRun.Spec.PipelineSpec.Tasks[0].TaskSpec.Volumes, caVolume)
+		pipelineRun.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0].VolumeMounts = append(
+			pipelineRun.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0].VolumeMounts, caVolumeMount)
+	}
+
+	// Create supporting resources before the PipelineRun so a partial failure
+	// on retry won't leave a running PLR without its Secret/ConfigMap.
+	if err := createIfNotExists(ctx, c, secret); err != nil {
+		return fmt.Errorf("creating Secret %s: %w", name, err)
+	}
+	if err := createIfNotExists(ctx, c, configMap); err != nil {
+		return fmt.Errorf("creating ConfigMap %s: %w", name, err)
+	}
+	if caConfigData != "" {
+		if err := createIfNotExists(ctx, c, caConfigMap); err != nil {
+			return fmt.Errorf("creating CA ConfigMap %s: %w", caConfigMapName, err)
+		}
+	}
+
+	if err := createIfNotExists(ctx, c, pipelineRun); err != nil {
+		return fmt.Errorf("creating nudge PipelineRun %s: %w", name, err)
+	}
+
+	log.Info("nudge PipelineRun created", "name", pipelineRun.Name, "targets", len(targets))
+	return nil
+}
+
+// createIfNotExists creates the object, silently succeeding if it already exists.
+func createIfNotExists(ctx context.Context, c client.Client, obj client.Object) error {
+	if err := c.Create(ctx, obj); err != nil && !errors.IsAlreadyExists(err) {
+		return err
+	}
+	return nil
+}
+
+// deterministicSuffix returns a short hex string derived from the input,
+// suitable for generating stable resource names from a build PLR UID.
+func deterministicSuffix(input string) string {
+	h := sha256.Sum256([]byte(input))
+	return hex.EncodeToString(h[:])[:12]
+}
+
+// ReadCustomRenovateConfigMap reads custom Renovate options from a ConfigMap
+// referenced by the component annotation, falling back to the namespace-wide
+// ConfigMap.  Returns a zero-value struct (not nil) when no ConfigMap exists.
+func ReadCustomRenovateConfigMap(ctx context.Context, c client.Client, component *applicationapiv1alpha1.Component) (*CustomRenovateOptions, error) {
+	log := logger.FromContext(ctx)
+	opts := &CustomRenovateOptions{}
+
+	cmName := tektonconsts.NamespaceWideRenovateConfigMapName
+	if component.Annotations != nil {
+		if perComponent := component.Annotations[tektonconsts.CustomRenovateConfigMapAnnotation]; perComponent != "" {
+			cmName = perComponent
+		}
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := c.Get(ctx, types.NamespacedName{Name: cmName, Namespace: component.Namespace}, cm); err != nil {
+		if errors.IsNotFound(err) {
+			if cmName != tektonconsts.NamespaceWideRenovateConfigMapName {
+				log.Info("custom renovate config map in component annotation doesn't exist", "configMapName", cmName)
+			}
+			return opts, nil
+		}
+		return opts, err
+	}
+	log.Info("using custom renovate config map", "configMapName", cmName)
+
+	if v, ok := cm.Data[renovateConfigMapAutomergeKey]; ok {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			opts.Automerge = parsed
+		}
+	}
+
+	if v, ok := cm.Data[renovateConfigMapPlatformAutomergeKey]; ok {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			opts.PlatformAutomerge = parsed
+		}
+	} else {
+		// Renovate default is true
+		opts.PlatformAutomerge = true
+	}
+
+	if v, ok := cm.Data[renovateConfigMapIgnoreTestsKey]; ok {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			opts.IgnoreTests = parsed
+		}
+	}
+
+	if v, ok := cm.Data[renovateConfigMapGitLabIgnoreApprovalsKey]; ok {
+		if parsed, err := strconv.ParseBool(v); err == nil {
+			opts.GitLabIgnoreApprovals = parsed
+		}
+	}
+
+	if v, ok := cm.Data[renovateConfigMapAutomergeTypeKey]; ok {
+		opts.AutomergeType = v
+	}
+
+	if v, ok := cm.Data[renovateConfigMapCommitMessagePrefixKey]; ok {
+		opts.CommitMessagePrefix = v
+	}
+
+	if v, ok := cm.Data[renovateConfigMapCommitMessageSuffixKey]; ok {
+		opts.CommitMessageSuffix = v
+	}
+
+	if v, ok := cm.Data[renovateConfigMapFileMatchKey]; ok {
+		parts := strings.Split(v, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		opts.FileMatch = parts
+	}
+
+	if v, ok := cm.Data[renovateConfigMapAutomergeScheduleKey]; ok {
+		parts := strings.Split(v, ";")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		opts.AutomergeSchedule = parts
+	}
+
+	if v, ok := cm.Data[renovateConfigMapLabelsKey]; ok {
+		parts := strings.Split(v, ",")
+		for i := range parts {
+			parts[i] = strings.TrimSpace(parts[i])
+		}
+		opts.Labels = parts
+	}
+
+	return opts, nil
+}
+
+// RandomString returns a cryptographically random hex string of the given length.
+func RandomString(length int) string {
+	bytes := make([]byte, length/2+1)
+	if _, err := rand.Read(bytes); err != nil {
+		panic("failed to read from random generator")
+	}
+	return hex.EncodeToString(bytes)[:length]
+}
+
+func joinNudgedComponentNames(targets []NudgeTarget) string {
+	names := make([]string, 0, len(targets))
+	for _, t := range targets {
+		names = append(names, t.ComponentName)
+	}
+	return strings.Join(names, " ")
+}
+
+var commitHashRegex = regexp.MustCompile(`[a-f0-9]{40}`)
+
+func extractCommitHash(commitUrl string) string {
+	parts := strings.Split(commitUrl, "/")
+	if len(parts) < 2 {
+		return ""
+	}
+	candidate := parts[len(parts)-1]
+	if !commitHashRegex.MatchString(candidate) {
+		return ""
+	}
+	return candidate
+}

--- a/tekton/nudging/nudge_pipeline_test.go
+++ b/tekton/nudging/nudge_pipeline_test.go
@@ -1,0 +1,1041 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nudging_test
+
+import (
+	"context"
+	"encoding/json"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	tektonconsts "github.com/konflux-ci/integration-service/tekton/consts"
+	nudging "github.com/konflux-ci/integration-service/tekton/nudging"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// nudgeTestScheme builds a runtime.Scheme containing the types needed by the
+// nudge pipeline tests (core, Tekton, Application API).
+func nudgeTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	Expect(corev1.AddToScheme(s)).To(Succeed())
+	Expect(tektonv1.AddToScheme(s)).To(Succeed())
+	Expect(applicationapiv1alpha1.AddToScheme(s)).To(Succeed())
+	return s
+}
+
+// nudgeBuildPLR returns a minimal build PipelineRun with the given results and
+// annotations, suitable for passing to ExtractBuildResultForNudging.
+func nudgeBuildPLR(name string, results []tektonv1.PipelineRunResult, annotations map[string]string) *tektonv1.PipelineRun {
+	return &tektonv1.PipelineRun{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   "default",
+			Annotations: annotations,
+		},
+		Status: tektonv1.PipelineRunStatus{
+			PipelineRunStatusFields: tektonv1.PipelineRunStatusFields{
+				Results: results,
+			},
+		},
+	}
+}
+
+// nudgeSampleComponent returns a Component with optional annotations.
+func nudgeSampleComponent(name, namespace string, annotations map[string]string) *applicationapiv1alpha1.Component {
+	return &applicationapiv1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   namespace,
+			Annotations: annotations,
+		},
+		Spec: applicationapiv1alpha1.ComponentSpec{
+			ComponentName: name,
+			Application:   "test-app",
+		},
+	}
+}
+
+var _ = Describe("Nudge Pipeline", func() {
+
+	// ------------------------------------------------------------------
+	// ExtractBuildResultForNudging
+	// ------------------------------------------------------------------
+	Describe("ExtractBuildResultForNudging", func() {
+		var component *applicationapiv1alpha1.Component
+
+		BeforeEach(func() {
+			component = nudgeSampleComponent("my-component", "default", nil)
+		})
+
+		It("extracts IMAGE_URL and IMAGE_DIGEST from PLR results (happy path)", func() {
+			plr := nudgeBuildPLR("build-plr-1", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageUrlParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "quay.io/org/repo:v1.0"}},
+				{Name: tektonconsts.PipelineRunImageDigestParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "sha256:abc123"}},
+			}, nil)
+
+			result, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.BuiltImageRepository).To(Equal("quay.io/org/repo"))
+			Expect(result.BuiltImageTag).To(Equal("v1.0"))
+			Expect(result.Digest).To(Equal("sha256:abc123"))
+			Expect(result.SourceComponentName).To(Equal("my-component"))
+		})
+
+		It("handles IMAGE_URL without a tag", func() {
+			plr := nudgeBuildPLR("build-plr-notag", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageUrlParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "quay.io/org/repo"}},
+				{Name: tektonconsts.PipelineRunImageDigestParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "sha256:def456"}},
+			}, nil)
+
+			result, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.BuiltImageRepository).To(Equal("quay.io/org/repo"))
+			Expect(result.BuiltImageTag).To(BeEmpty())
+		})
+
+		It("returns an error when IMAGE_URL is missing", func() {
+			plr := nudgeBuildPLR("build-plr-nourl", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageDigestParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "sha256:abc123"}},
+			}, nil)
+
+			_, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("IMAGE_URL"))
+		})
+
+		It("returns an error when IMAGE_DIGEST is missing", func() {
+			plr := nudgeBuildPLR("build-plr-nodigest", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageUrlParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "quay.io/org/repo:v1"}},
+			}, nil)
+
+			_, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("IMAGE_DIGEST"))
+		})
+
+		It("uses DefaultNudgeFiles when nudge-files annotation is absent", func() {
+			plr := nudgeBuildPLR("build-plr-defaults", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageUrlParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "quay.io/org/repo:latest"}},
+				{Name: tektonconsts.PipelineRunImageDigestParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "sha256:aaa"}},
+			}, nil)
+
+			result, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.FileMatches).To(Equal(tektonconsts.DefaultNudgeFiles))
+		})
+
+		It("uses the nudge-files annotation when present", func() {
+			plr := nudgeBuildPLR("build-plr-custom-files", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageUrlParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "quay.io/org/repo:latest"}},
+				{Name: tektonconsts.PipelineRunImageDigestParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "sha256:bbb"}},
+			}, map[string]string{
+				tektonconsts.NudgeFilesAnnotation: ".*\\.yaml",
+			})
+
+			result, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.FileMatches).To(Equal(".*\\.yaml"))
+		})
+
+		It("reads the git-repo-at-sha annotation", func() {
+			plr := nudgeBuildPLR("build-plr-sha", []tektonv1.PipelineRunResult{
+				{Name: tektonconsts.PipelineRunImageUrlParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "quay.io/org/repo:tag"}},
+				{Name: tektonconsts.PipelineRunImageDigestParamName, Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "sha256:ccc"}},
+			}, map[string]string{
+				tektonconsts.GitRepoAtShaAnnotation: "https://github.com/org/repo/commit/abc123def456abc123def456abc123def456abcd",
+			})
+
+			result, err := nudging.ExtractBuildResultForNudging(plr, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.GitRepoAtShaLink).To(Equal("https://github.com/org/repo/commit/abc123def456abc123def456abc123def456abcd"))
+		})
+	})
+
+	// ------------------------------------------------------------------
+	// GenerateRenovateConfig
+	// ------------------------------------------------------------------
+	Describe("GenerateRenovateConfig", func() {
+		var (
+			target      nudging.NudgeTarget
+			buildResult *nudging.NudgeBuildResult
+		)
+
+		BeforeEach(func() {
+			target = nudging.NudgeTarget{
+				ComponentName: "target-comp",
+				GitProvider:   "github",
+				Username:      "test-user",
+				GitAuthor:     "Test User <test@example.com>",
+				Token:         "ghp_fake",
+				Endpoint:      "https://api.github.com",
+				Repositories:  []nudging.RenovateRepository{{Repository: "org/downstream"}},
+			}
+			buildResult = &nudging.NudgeBuildResult{
+				BuiltImageRepository: "quay.io/org/image",
+				BuiltImageTag:        "latest",
+				Digest:               "sha256:abcdef",
+				FileMatches:          ".*Dockerfile.*, .*.yaml",
+				SourceComponentName:  "source-comp",
+				GitRepoAtShaLink:     "https://github.com/org/repo/commit/aabbccddaabbccddaabbccddaabbccddaabbccdd",
+			}
+		})
+
+		It("builds custom managers with correct regex match strings", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.CustomManagers).To(HaveLen(1))
+			cm := config.CustomManagers[0]
+			Expect(cm.CustomType).To(Equal("regex"))
+			Expect(cm.DatasourceTemplate).To(Equal("docker"))
+			Expect(cm.CurrentValueTemplate).To(Equal("latest"))
+			Expect(cm.DepNameTemplate).To(Equal("quay.io/org/image"))
+			Expect(cm.MatchStrings).To(HaveLen(1))
+			Expect(cm.MatchStrings[0]).To(ContainSubstring(`quay\.io/org/image`))
+			Expect(cm.MatchStrings[0]).To(ContainSubstring("(?<currentDigest>sha256:[a-f0-9]+)"))
+		})
+
+		It("produces file match parts by splitting on comma", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.CustomManagers[0].FileMatch).To(ConsistOf(".*Dockerfile.*", ".*.yaml"))
+		})
+
+		It("starts packageRules with DisableAll then an enable rule", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.PackageRules).To(HaveLen(2))
+			Expect(config.PackageRules[0]).To(Equal(nudging.DisableAllPackageRules))
+			Expect(config.PackageRules[1].Enabled).To(BeTrue())
+			Expect(config.PackageRules[1].MatchPackageNames).To(ContainElement("quay.io/org/image"))
+		})
+
+		It("sets branch naming with component prefix when simpleBranchName is false", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			enableRule := config.PackageRules[1]
+			Expect(enableRule.BranchPrefix).To(Equal(tektonconsts.BranchPrefix))
+			Expect(enableRule.AdditionalBranchPrefix).To(Equal("target-comp-"))
+			Expect(enableRule.BranchTopic).To(Equal("source-comp"))
+		})
+
+		It("sets empty additional branch prefix when simpleBranchName is true", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, true)
+
+			enableRule := config.PackageRules[1]
+			Expect(enableRule.AdditionalBranchPrefix).To(BeEmpty())
+		})
+
+		It("includes DefaultRenovateLabel in labels", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.Labels).To(ContainElement(tektonconsts.DefaultRenovateLabel))
+		})
+
+		It("appends custom labels from CustomRenovateOptions", func() {
+			target.ComponentCustomRenovateOptions = &nudging.CustomRenovateOptions{
+				Labels: []string{"extra-label-1", "extra-label-2"},
+			}
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.Labels).To(ContainElement(tektonconsts.DefaultRenovateLabel))
+			Expect(config.Labels).To(ContainElement("extra-label-1"))
+			Expect(config.Labels).To(ContainElement("extra-label-2"))
+		})
+
+		It("creates registry aliases for distribution repositories", func() {
+			buildResult.DistributionRepositories = []string{
+				"registry.access.redhat.com/org/image",
+				"registry.redhat.io/org/image",
+			}
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.RegistryAliases).To(HaveLen(2))
+			Expect(config.RegistryAliases["registry.access.redhat.com/org/image"]).To(Equal("quay.io/org/image"))
+			Expect(config.RegistryAliases["registry.redhat.io/org/image"]).To(Equal("quay.io/org/image"))
+
+			// Distribution repos should also appear in matchStrings and matchPackageNames
+			Expect(config.CustomManagers[0].MatchStrings).To(HaveLen(3))
+			Expect(config.PackageRules[1].MatchPackageNames).To(HaveLen(3))
+		})
+
+		It("uses custom fileMatch from CustomRenovateOptions when provided", func() {
+			target.ComponentCustomRenovateOptions = &nudging.CustomRenovateOptions{
+				FileMatch: []string{"custom-dir/.*\\.yaml"},
+			}
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.CustomManagers[0].FileMatch).To(Equal([]string{"custom-dir/.*\\.yaml"}))
+		})
+
+		It("propagates automerge settings from CustomRenovateOptions", func() {
+			target.ComponentCustomRenovateOptions = &nudging.CustomRenovateOptions{
+				Automerge:         true,
+				PlatformAutomerge: true,
+				IgnoreTests:       true,
+				AutomergeType:     "pr",
+			}
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.Automerge).To(BeTrue())
+			Expect(config.PlatformAutomerge).To(BeTrue())
+			Expect(config.IgnoreTests).To(BeTrue())
+			Expect(config.AutomergeType).To(Equal("pr"))
+		})
+
+		It("propagates commit message settings from CustomRenovateOptions", func() {
+			target.ComponentCustomRenovateOptions = &nudging.CustomRenovateOptions{
+				CommitMessagePrefix: "chore(deps):",
+				CommitMessageSuffix: "[skip-ci]",
+			}
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			enableRule := config.PackageRules[1]
+			Expect(enableRule.CommitMessagePrefix).To(Equal("chore(deps):"))
+			Expect(enableRule.CommitMessageSuffix).To(Equal("[skip-ci]"))
+		})
+
+		It("sets static fields correctly", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			Expect(config.GitProvider).To(Equal("github"))
+			Expect(config.Username).To(Equal("test-user"))
+			Expect(config.Onboarding).To(BeFalse())
+			Expect(config.RequireConfig).To(Equal("ignored"))
+			Expect(config.EnabledManagers).To(Equal([]string{"custom.regex"}))
+			Expect(config.ForkProcessing).To(Equal("enabled"))
+			Expect(config.DependencyDashboard).To(BeFalse())
+			Expect(config.Extends).To(BeEmpty())
+		})
+
+		It("includes PRHeader and CommitBody with git-repo-at-sha link", func() {
+			config := nudging.GenerateRenovateConfig(target, buildResult, false)
+
+			enableRule := config.PackageRules[1]
+			Expect(enableRule.PRHeader).To(ContainSubstring(buildResult.GitRepoAtShaLink))
+			Expect(enableRule.CommitBody).To(ContainSubstring(buildResult.GitRepoAtShaLink))
+			Expect(enableRule.CommitBody).To(ContainSubstring("Signed-off-by:"))
+		})
+	})
+
+	// ------------------------------------------------------------------
+	// CreateNudgePipelineRun
+	// ------------------------------------------------------------------
+	Describe("CreateNudgePipelineRun", func() {
+		var (
+			fakeClient  client.Client
+			nudgingPLR  *tektonv1.PipelineRun
+			buildResult *nudging.NudgeBuildResult
+			targets     []nudging.NudgeTarget
+			testCtx     context.Context
+		)
+
+		BeforeEach(func() {
+			testCtx = context.Background()
+
+			scheme := nudgeTestScheme()
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "appstudio-pipeline", Namespace: "test-ns"},
+			}
+
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(sa).
+				Build()
+
+			nudgingPLR = &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "build-plr-source",
+					Namespace: "test-ns",
+				},
+				Spec: tektonv1.PipelineRunSpec{
+					TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{},
+				},
+			}
+
+			buildResult = &nudging.NudgeBuildResult{
+				BuiltImageRepository: "quay.io/org/image",
+				BuiltImageTag:        "v1",
+				Digest:               "sha256:aaa",
+				FileMatches:          ".*.yaml",
+				SourceComponentName:  "source-comp",
+				GitRepoAtShaLink:     "https://github.com/org/repo/commit/aabbccddaabbccddaabbccddaabbccddaabbccdd",
+			}
+
+			targets = []nudging.NudgeTarget{
+				{
+					ComponentName:           "downstream-comp",
+					GitProvider:             "github",
+					Username:                "test-user",
+					GitAuthor:               "Test <test@example.com>",
+					Token:                   "ghp_token",
+					Endpoint:                "https://api.github.com",
+					Repositories:            []nudging.RenovateRepository{{Repository: "org/downstream"}},
+					ImageRepositoryHost:     "quay.io",
+					ImageRepositoryUsername: "robot",
+					ImageRepositoryPassword: "secret",
+				},
+			}
+		})
+
+		It("returns nil when targets is empty", func() {
+			err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, nil, buildResult, false)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("creates a PipelineRun, Secret, and ConfigMap", func() {
+			err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			// List PipelineRuns to find the created one
+			plrList := &tektonv1.PipelineRunList{}
+			Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(plrList.Items).To(HaveLen(1))
+			createdPLR := plrList.Items[0]
+
+			// Verify labels
+			Expect(createdPLR.Labels[tektonconsts.NudgeTypeLabel]).To(Equal(tektonconsts.NudgePipelineRunTypeValue))
+
+			// Verify annotations
+			Expect(createdPLR.Annotations[tektonconsts.NudgingComponentAnnotation]).To(Equal("source-comp"))
+			Expect(createdPLR.Annotations[tektonconsts.NudgingImageAnnotation]).To(Equal("quay.io/org/image:v1"))
+			Expect(createdPLR.Annotations[tektonconsts.NudgingPipelineAnnotation]).To(Equal("build-plr-source"))
+			Expect(createdPLR.Annotations[tektonconsts.NudgedComponentsAnnotation]).To(Equal("downstream-comp"))
+
+			// Verify ServiceAccount falls back to default
+			Expect(createdPLR.Spec.TaskRunTemplate.ServiceAccountName).To(Equal("appstudio-pipeline"))
+
+			// Verify security context
+			step := createdPLR.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0]
+			Expect(step.SecurityContext).NotTo(BeNil())
+			Expect(step.SecurityContext.RunAsNonRoot).NotTo(BeNil())
+			Expect(*step.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(*step.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(step.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+			Expect(step.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+			// Verify Secret was created
+			secretList := &corev1.SecretList{}
+			Expect(fakeClient.List(testCtx, secretList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(secretList.Items).To(HaveLen(1))
+
+			// Verify ConfigMap was created
+			cmList := &corev1.ConfigMapList{}
+			Expect(fakeClient.List(testCtx, cmList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(cmList.Items).To(HaveLen(1))
+		})
+
+		It("uses the ServiceAccount from the source PLR when specified", func() {
+			nudgingPLR.Spec.TaskRunTemplate.ServiceAccountName = "custom-sa"
+
+			customSA := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom-sa", Namespace: "test-ns"},
+			}
+			Expect(fakeClient.Create(testCtx, customSA)).To(Succeed())
+
+			err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			plrList := &tektonv1.PipelineRunList{}
+			Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(plrList.Items).To(HaveLen(1))
+			Expect(plrList.Items[0].Spec.TaskRunTemplate.ServiceAccountName).To(Equal("custom-sa"))
+		})
+
+		It("returns an error when the service account does not exist", func() {
+			nudgingPLR.Spec.TaskRunTemplate.ServiceAccountName = "nonexistent-sa"
+
+			err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("service account nonexistent-sa not found"))
+		})
+
+		It("creates multiple renovate commands for multiple targets", func() {
+			targets = append(targets, nudging.NudgeTarget{
+				ComponentName:           "another-downstream",
+				GitProvider:             "gitlab",
+				Username:                "gl-user",
+				GitAuthor:               "GL <gl@example.com>",
+				Token:                   "glpat_token",
+				Endpoint:                "https://gitlab.com/api/v4",
+				Repositories:            []nudging.RenovateRepository{{Repository: "org/another"}},
+				ImageRepositoryHost:     "quay.io",
+				ImageRepositoryUsername: "robot2",
+				ImageRepositoryPassword: "secret2",
+			})
+
+			err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			plrList := &tektonv1.PipelineRunList{}
+			Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(plrList.Items).To(HaveLen(1))
+
+			// ConfigMap should have two entries (one per target)
+			cmList := &corev1.ConfigMapList{}
+			Expect(fakeClient.List(testCtx, cmList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(cmList.Items).To(HaveLen(1))
+			Expect(cmList.Items[0].Data).To(HaveLen(2))
+
+			// Annotation should list both component names
+			Expect(plrList.Items[0].Annotations[tektonconsts.NudgedComponentsAnnotation]).To(ContainSubstring("downstream-comp"))
+			Expect(plrList.Items[0].Annotations[tektonconsts.NudgedComponentsAnnotation]).To(ContainSubstring("another-downstream"))
+		})
+
+		It("extracts the commit hash from GitRepoAtShaLink into annotation", func() {
+			err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+			Expect(err).NotTo(HaveOccurred())
+
+			plrList := &tektonv1.PipelineRunList{}
+			Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(plrList.Items[0].Annotations[tektonconsts.NudgingCommitAnnotation]).To(Equal("aabbccddaabbccddaabbccddaabbccddaabbccdd"))
+		})
+
+		Context("volume and envFrom setup", func() {
+			It("mounts the config ConfigMap as a volume and the secret as envFrom", func() {
+				err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				plrList := &tektonv1.PipelineRunList{}
+				Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+				createdPLR := plrList.Items[0]
+
+				step := createdPLR.Spec.PipelineSpec.Tasks[0].TaskSpec.Steps[0]
+
+				// Verify envFrom references the secret with TOKEN_ prefix
+				Expect(step.EnvFrom).To(HaveLen(1))
+				Expect(step.EnvFrom[0].Prefix).To(Equal("TOKEN_"))
+				Expect(step.EnvFrom[0].SecretRef).NotTo(BeNil())
+				Expect(step.EnvFrom[0].SecretRef.Name).To(Equal(createdPLR.Name))
+
+				// Verify volume mount for configs
+				var foundConfigMount bool
+				for _, vm := range step.VolumeMounts {
+					if vm.MountPath == "/configs" {
+						foundConfigMount = true
+						Expect(vm.Name).To(Equal(createdPLR.Name))
+					}
+				}
+				Expect(foundConfigMount).To(BeTrue(), "expected /configs volume mount")
+
+				// Verify volume definition
+				volumes := createdPLR.Spec.PipelineSpec.Tasks[0].TaskSpec.Volumes
+				var foundConfigVolume bool
+				for _, v := range volumes {
+					if v.Name == createdPLR.Name {
+						foundConfigVolume = true
+						Expect(v.ConfigMap).NotTo(BeNil())
+						Expect(v.ConfigMap.Name).To(Equal(createdPLR.Name))
+					}
+				}
+				Expect(foundConfigVolume).To(BeTrue(), "expected ConfigMap volume")
+			})
+		})
+
+		Context("naming consistency", func() {
+			It("creates Secret and ConfigMap with the same name as the PipelineRun", func() {
+				err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				plrList := &tektonv1.PipelineRunList{}
+				Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+				plrName := plrList.Items[0].Name
+
+				// Secret should have the same name
+				secret := &corev1.Secret{}
+				Expect(fakeClient.Get(testCtx, types.NamespacedName{Name: plrName, Namespace: "test-ns"}, secret)).To(Succeed())
+
+				// ConfigMap should have the same name
+				cm := &corev1.ConfigMap{}
+				Expect(fakeClient.Get(testCtx, types.NamespacedName{Name: plrName, Namespace: "test-ns"}, cm)).To(Succeed())
+			})
+		})
+
+		Context("ConfigMap data shape", func() {
+			It("contains valid JSON config entries keyed by component name", func() {
+				err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				cmList := &corev1.ConfigMapList{}
+				Expect(fakeClient.List(testCtx, cmList, client.InNamespace("test-ns"))).To(Succeed())
+				Expect(cmList.Items).To(HaveLen(1))
+
+				// Verify the data has exactly one entry keyed like "downstream-comp-<random>.json"
+				Expect(cmList.Items[0].Data).To(HaveLen(1))
+				for key, value := range cmList.Items[0].Data {
+					Expect(key).To(HavePrefix("downstream-comp-"))
+					Expect(key).To(HaveSuffix(".json"))
+
+					// Verify it's valid JSON that can be deserialized into RenovateConfig
+					var config nudging.RenovateConfig
+					Expect(json.Unmarshal([]byte(value), &config)).To(Succeed())
+					Expect(config.GitProvider).To(Equal("github"))
+					Expect(config.Repositories).To(HaveLen(1))
+				}
+			})
+		})
+
+		Context("Secret data shape", func() {
+			It("contains token entries for each target", func() {
+				err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				secretList := &corev1.SecretList{}
+				Expect(fakeClient.List(testCtx, secretList, client.InNamespace("test-ns"))).To(Succeed())
+				Expect(secretList.Items).To(HaveLen(1))
+
+				// The Secret is created with StringData (the fake client does not
+				// auto-convert StringData to Data like a real API server).
+				secret := secretList.Items[0]
+				Expect(secret.StringData).To(HaveLen(2))
+
+				// Verify the actual token values are stored
+				var foundGitToken, foundRegistryPassword bool
+				for _, v := range secret.StringData {
+					if v == "ghp_token" {
+						foundGitToken = true
+					}
+					if v == "secret" {
+						foundRegistryPassword = true
+					}
+				}
+				Expect(foundGitToken).To(BeTrue(), "expected git token to be stored in secret")
+				Expect(foundRegistryPassword).To(BeTrue(), "expected registry password to be stored in secret")
+			})
+		})
+
+		Context("renovate image", func() {
+			It("uses default renovate image when env var is not set", func() {
+				GinkgoT().Setenv(tektonconsts.RenovateImageEnvName, "")
+
+				err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				plrList := &tektonv1.PipelineRunList{}
+				Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+
+				image := plrList.Items[0].Spec.PipelineSpec.Tasks[0].TaskSpec.TaskSpec.Steps[0].Image
+				Expect(image).To(Equal(tektonconsts.DefaultRenovateImageUrl))
+			})
+
+			It("uses custom renovate image when env var is set", func() {
+				GinkgoT().Setenv(tektonconsts.RenovateImageEnvName, "my-custom-renovate:v99")
+
+				err := nudging.CreateNudgePipelineRun(testCtx, fakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				plrList := &tektonv1.PipelineRunList{}
+				Expect(fakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+
+				image := plrList.Items[0].Spec.PipelineSpec.Tasks[0].TaskSpec.TaskSpec.Steps[0].Image
+				Expect(image).To(Equal("my-custom-renovate:v99"))
+			})
+		})
+
+		Context("with CA bundle", func() {
+			It("mounts the CA ConfigMap volume when a CA bundle exists in build-service namespace", func() {
+				scheme := nudgeTestScheme()
+
+				sa := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: "appstudio-pipeline", Namespace: "test-ns"},
+				}
+
+				caCM := &corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "trusted-ca-bundle",
+						Namespace: tektonconsts.BuildServiceNamespaceName,
+						Labels:    map[string]string{tektonconsts.CaConfigMapLabel: "true"},
+					},
+					Data: map[string]string{
+						tektonconsts.CaConfigMapKey: "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----",
+					},
+				}
+
+				buildNS := &corev1.Namespace{
+					ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.BuildServiceNamespaceName},
+				}
+
+				caFakeClient := fake.NewClientBuilder().
+					WithScheme(scheme).
+					WithObjects(sa, caCM, buildNS).
+					Build()
+
+				err := nudging.CreateNudgePipelineRun(testCtx, caFakeClient, nudgingPLR, targets, buildResult, false)
+				Expect(err).NotTo(HaveOccurred())
+
+				plrList := &tektonv1.PipelineRunList{}
+				Expect(caFakeClient.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+				Expect(plrList.Items).To(HaveLen(1))
+				createdPLR := plrList.Items[0]
+
+				// Verify the CA volume was added
+				volumes := createdPLR.Spec.PipelineSpec.Tasks[0].TaskSpec.Volumes
+				var foundCAVolume bool
+				for _, v := range volumes {
+					if v.Name == tektonconsts.CaVolumeMountName {
+						foundCAVolume = true
+						Expect(v.ConfigMap).NotTo(BeNil())
+					}
+				}
+				Expect(foundCAVolume).To(BeTrue(), "expected CA volume to be present")
+
+				// Verify the CA volume mount was added
+				volumeMounts := createdPLR.Spec.PipelineSpec.Tasks[0].TaskSpec.TaskSpec.Steps[0].VolumeMounts
+				var foundCAMount bool
+				for _, vm := range volumeMounts {
+					if vm.Name == tektonconsts.CaVolumeMountName {
+						foundCAMount = true
+						Expect(vm.MountPath).To(Equal(tektonconsts.CaMountPath))
+						Expect(vm.ReadOnly).To(BeTrue())
+					}
+				}
+				Expect(foundCAMount).To(BeTrue(), "expected CA volume mount to be present")
+
+				// Verify the CA ConfigMap was created in test-ns
+				caConfigMaps := &corev1.ConfigMapList{}
+				Expect(caFakeClient.List(testCtx, caConfigMaps, client.InNamespace("test-ns"))).To(Succeed())
+				// Should have 2 ConfigMaps: the renovate config + the CA
+				Expect(caConfigMaps.Items).To(HaveLen(2))
+
+				var foundCACM bool
+				for _, cm := range caConfigMaps.Items {
+					if _, ok := cm.Data[tektonconsts.CaConfigMapKey]; ok {
+						foundCACM = true
+					}
+				}
+				Expect(foundCACM).To(BeTrue(), "expected CA ConfigMap to be created in test-ns")
+			})
+		})
+	})
+
+	// ------------------------------------------------------------------
+	// ReadCustomRenovateConfigMap
+	// ------------------------------------------------------------------
+	Describe("ReadCustomRenovateConfigMap", func() {
+		var (
+			fakeClient client.Client
+			component  *applicationapiv1alpha1.Component
+			testCtx    context.Context
+		)
+
+		BeforeEach(func() {
+			testCtx = context.Background()
+			component = nudgeSampleComponent("test-comp", "test-ns", nil)
+		})
+
+		It("returns zero-value options when no ConfigMap exists", func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(nudgeTestScheme()).Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts).NotTo(BeNil())
+			Expect(opts.Automerge).To(BeFalse())
+		})
+
+		It("reads from per-component annotation-referenced ConfigMap", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "custom-renovate-cm", Namespace: "test-ns"},
+				Data: map[string]string{
+					"automerge":   "true",
+					"ignoreTests": "true",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			component.Annotations = map[string]string{
+				tektonconsts.CustomRenovateConfigMapAnnotation: "custom-renovate-cm",
+			}
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.Automerge).To(BeTrue())
+			Expect(opts.IgnoreTests).To(BeTrue())
+		})
+
+		It("falls back to namespace-wide ConfigMap when no annotation is set", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"automergeType": "branch",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.AutomergeType).To(Equal("branch"))
+		})
+
+		It("returns zero-value when annotation-referenced ConfigMap does not exist (not-found is not an error)", func() {
+			fakeClient = fake.NewClientBuilder().WithScheme(nudgeTestScheme()).Build()
+
+			component.Annotations = map[string]string{
+				tektonconsts.CustomRenovateConfigMapAnnotation: "nonexistent-cm",
+			}
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts).NotTo(BeNil())
+		})
+
+		It("defaults platformAutomerge to true when key is absent", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data:       map[string]string{},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.PlatformAutomerge).To(BeTrue())
+		})
+
+		It("parses platformAutomerge as false when explicitly set", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"platformAutomerge": "false",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.PlatformAutomerge).To(BeFalse())
+		})
+
+		It("parses comma-separated fileMatch", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"fileMatch": ".*Dockerfile.*, .*.yaml, .*Containerfile.*",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.FileMatch).To(Equal([]string{".*Dockerfile.*", ".*.yaml", ".*Containerfile.*"}))
+		})
+
+		It("parses semicolon-separated automergeSchedule", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"automergeSchedule": "after 10pm; before 5am",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.AutomergeSchedule).To(Equal([]string{"after 10pm", "before 5am"}))
+		})
+
+		It("parses comma-separated labels", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"labels": "label-a, label-b",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.Labels).To(Equal([]string{"label-a", "label-b"}))
+		})
+
+		It("reads commitMessagePrefix and commitMessageSuffix", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"commitMessagePrefix": "chore:",
+					"commitMessageSuffix": "[auto]",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.CommitMessagePrefix).To(Equal("chore:"))
+			Expect(opts.CommitMessageSuffix).To(Equal("[auto]"))
+		})
+
+		It("parses gitLabIgnoreApprovals", func() {
+			cm := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.NamespaceWideRenovateConfigMapName, Namespace: "test-ns"},
+				Data: map[string]string{
+					"gitLabIgnoreApprovals": "true",
+				},
+			}
+			fakeClient = fake.NewClientBuilder().
+				WithScheme(nudgeTestScheme()).
+				WithObjects(cm).
+				Build()
+
+			opts, err := nudging.ReadCustomRenovateConfigMap(testCtx, fakeClient, component)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(opts.GitLabIgnoreApprovals).To(BeTrue())
+		})
+	})
+
+	// ------------------------------------------------------------------
+	// Helper functions (tested via exported API)
+	// ------------------------------------------------------------------
+	Describe("RandomString", func() {
+		It("returns a string of the requested length", func() {
+			s := nudging.RandomString(10)
+			Expect(s).To(HaveLen(10))
+		})
+
+		It("returns different values on successive calls", func() {
+			s1 := nudging.RandomString(16)
+			s2 := nudging.RandomString(16)
+			Expect(s1).NotTo(Equal(s2))
+		})
+
+		It("returns only hex characters", func() {
+			s := nudging.RandomString(20)
+			Expect(s).To(MatchRegexp("^[a-f0-9]+$"))
+		})
+	})
+
+	// joinNudgedComponentNames and extractCommitHash are unexported, so we
+	// test them indirectly through CreateNudgePipelineRun annotations.
+	Describe("unexported helpers (tested indirectly via CreateNudgePipelineRun)", func() {
+		It("joinNudgedComponentNames joins multiple target names with spaces", func() {
+			testCtx := context.Background()
+			scheme := nudgeTestScheme()
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{Name: "appstudio-pipeline", Namespace: "test-ns"},
+			}
+			fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa).Build()
+
+			plr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{Name: "build-plr", Namespace: "test-ns"},
+				Spec:       tektonv1.PipelineRunSpec{},
+			}
+			buildResult := &nudging.NudgeBuildResult{
+				BuiltImageRepository: "quay.io/org/img",
+				BuiltImageTag:        "v1",
+				Digest:               "sha256:aaa",
+				FileMatches:          ".*.yaml",
+				SourceComponentName:  "src",
+				GitRepoAtShaLink:     "https://github.com/o/r/commit/aabbccddaabbccddaabbccddaabbccddaabbccdd",
+			}
+			targets := []nudging.NudgeTarget{
+				{ComponentName: "comp-a", GitProvider: "github", Username: "u", GitAuthor: "A <a@b.c>",
+					Token: "t", Endpoint: "https://api.github.com",
+					Repositories:        []nudging.RenovateRepository{{Repository: "o/a"}},
+					ImageRepositoryHost: "quay.io", ImageRepositoryUsername: "r", ImageRepositoryPassword: "s"},
+				{ComponentName: "comp-b", GitProvider: "github", Username: "u", GitAuthor: "A <a@b.c>",
+					Token: "t", Endpoint: "https://api.github.com",
+					Repositories:        []nudging.RenovateRepository{{Repository: "o/b"}},
+					ImageRepositoryHost: "quay.io", ImageRepositoryUsername: "r", ImageRepositoryPassword: "s"},
+				{ComponentName: "comp-c", GitProvider: "github", Username: "u", GitAuthor: "A <a@b.c>",
+					Token: "t", Endpoint: "https://api.github.com",
+					Repositories:        []nudging.RenovateRepository{{Repository: "o/c"}},
+					ImageRepositoryHost: "quay.io", ImageRepositoryUsername: "r", ImageRepositoryPassword: "s"},
+			}
+
+			Expect(nudging.CreateNudgePipelineRun(testCtx, fc, plr, targets, buildResult, false)).To(Succeed())
+
+			plrList := &tektonv1.PipelineRunList{}
+			Expect(fc.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+			Expect(plrList.Items[0].Annotations[tektonconsts.NudgedComponentsAnnotation]).To(Equal("comp-a comp-b comp-c"))
+		})
+
+		DescribeTable("extractCommitHash tested via nudging-commit annotation",
+			func(gitRepoAtShaLink, expectedCommit string) {
+				testCtx := context.Background()
+				scheme := nudgeTestScheme()
+				sa := &corev1.ServiceAccount{
+					ObjectMeta: metav1.ObjectMeta{Name: "appstudio-pipeline", Namespace: "test-ns"},
+				}
+				fc := fake.NewClientBuilder().WithScheme(scheme).WithObjects(sa).Build()
+
+				plr := &tektonv1.PipelineRun{
+					ObjectMeta: metav1.ObjectMeta{Name: "build-plr", Namespace: "test-ns"},
+					Spec:       tektonv1.PipelineRunSpec{},
+				}
+				buildResult := &nudging.NudgeBuildResult{
+					BuiltImageRepository: "quay.io/org/img",
+					BuiltImageTag:        "v1",
+					Digest:               "sha256:aaa",
+					FileMatches:          ".*.yaml",
+					SourceComponentName:  "src",
+					GitRepoAtShaLink:     gitRepoAtShaLink,
+				}
+				targets := []nudging.NudgeTarget{{
+					ComponentName: "d", GitProvider: "github", Username: "u", GitAuthor: "A <a@b.c>",
+					Token: "t", Endpoint: "https://api.github.com",
+					Repositories:        []nudging.RenovateRepository{{Repository: "o/d"}},
+					ImageRepositoryHost: "quay.io", ImageRepositoryUsername: "r", ImageRepositoryPassword: "s",
+				}}
+
+				Expect(nudging.CreateNudgePipelineRun(testCtx, fc, plr, targets, buildResult, false)).To(Succeed())
+
+				plrList := &tektonv1.PipelineRunList{}
+				Expect(fc.List(testCtx, plrList, client.InNamespace("test-ns"))).To(Succeed())
+				Expect(plrList.Items[0].Annotations[tektonconsts.NudgingCommitAnnotation]).To(Equal(expectedCommit))
+			},
+			Entry("valid GitHub commit URL",
+				"https://github.com/org/repo/commit/aabbccddaabbccddaabbccddaabbccddaabbccdd",
+				"aabbccddaabbccddaabbccddaabbccddaabbccdd",
+			),
+			Entry("URL without a valid hash at the end",
+				"https://github.com/org/repo/tree/main",
+				"",
+			),
+			Entry("empty string",
+				"",
+				"",
+			),
+		)
+	})
+})

--- a/tekton/nudging/nudging_suite_test.go
+++ b/tekton/nudging/nudging_suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2025 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nudging_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNudging(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Nudging Suite")
+}


### PR DESCRIPTION
 ## Summary

  Implements Phase 1 of ADR-0067: migrating component nudging from build-service to integration-service.

  When a post-merge build PipelineRun succeeds, integration-service now reads the NudgeConfig singleton, finds immediate-mode edges where `from` matches the built component, and creates Renovate nudge
  PipelineRuns for each downstream target — producing the exact same PipelineRun shape that build-service creates today.

  ### What's included

  - **`EnsureNudgePipelineRunsExist`** in the build pipeline adapter — orchestrates the full nudge flow: push/success/idempotency guards → NudgeConfig lookup → edge filtering → credential
  resolution → Renovate PLR creation
  - **Renovate PipelineRun builder** (`tekton/nudge_pipeline.go`) — inline PipelineSpec with Renovate task, Secret, ConfigMap, optional CA bundle, owner references, security context — all matching
  build-service's output
  - **Credential resolution** (`tekton/nudge_credentials.go`) — basic auth via namespace-scoped SCM secrets + GitHub App path (stub, returns nil pending JWT implementation) + image registry credentials from SA
  dockercfg secrets
  - **Loader** — `GetNudgeConfig` added to `ObjectLoader` interface with mock support
  - **Constants** — ~40 build-service-compatible annotation/label names and Renovate defaults

  ### Design decisions

  - **No build-service dependency** — Renovate PipelineRun shape is replicated rather than imported, avoiding massive transitive deps
  - **No separate feature gates** — NudgeConfig existence is the only cutover signal. If no NudgeConfig exists in the namespace, nudging does not fire. The migration script controls when NudgeConfig is created per namespace.
  - **Fail-safe on permanent errors** — `ExtractNudgeBuildResult` and `GetImageRegistryCredentials` failures annotate the build PLR and stop (no infinite requeue), since these are permanent config errors that won't self-heal
  - **Idempotency** — `component-nudge-processed` annotation on the build PLR prevents duplicate nudge creation on re-reconciliation
  - **GitHub App auth** — function validates PaC secret structure but returns nil (TODO); basic auth covers the majority of real deployments today

  ### Deferred

  - GitHub App JWT + installation token flow (follow-up)
  - Distribution repository aliases from ReleasePlanAdmission
  - Metrics (`nudge_pipelinerun_created_total`, etc.)

