### PR TITLE
feat(STONEINTG-1661): validate Component for NudgeConfig nudges

### DIFF
--- a/api/v1beta2/nudgeconfig_types.go
+++ b/api/v1beta2/nudgeconfig_types.go
@@ -93,7 +93,8 @@ type NudgeConfigStatus struct {
 
 // NudgeConfig is a namespace-scoped singleton CRD that stores component nudging relationships.
 // Exactly one NudgeConfig named "nudge-config" may exist per namespace.
-// Validation rules are enforced stateless by the API server via CEL expressions with no webhook overhead.
+// Structural and singleton rules are enforced by the API server via CEL expressions;
+// graph-cycle and cross-resource Component-existence checks are enforced by a validating webhook.
 type NudgeConfig struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/appstudio.redhat.com_nudgeconfigs.yaml
+++ b/config/crd/bases/appstudio.redhat.com_nudgeconfigs.yaml
@@ -26,7 +26,8 @@ spec:
         description: |-
           NudgeConfig is a namespace-scoped singleton CRD that stores component nudging relationships.
           Exactly one NudgeConfig named "nudge-config" may exist per namespace.
-          Validation rules are enforced stateless by the API server via CEL expressions with no webhook overhead.
+          Structural and singleton rules are enforced by the API server via CEL expressions;
+          graph-cycle and cross-resource Component-existence checks are enforced by a validating webhook.
         properties:
           apiVersion:
             description: |-

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -4,3 +4,6 @@ resources:
 
 configurations:
 - kustomizeconfig.yaml
+
+patches:
+- path: patches/nudgeconfig_namespace_selector.yaml

--- a/config/webhook/patches/nudgeconfig_namespace_selector.yaml
+++ b/config/webhook/patches/nudgeconfig_namespace_selector.yaml
@@ -1,0 +1,11 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validating-webhook-configuration
+webhooks:
+- name: vnudgeconfig.kb.io
+  namespaceSelector:
+    matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: NotIn
+      values: [kube-system, kube-public, kube-node-lease]

--- a/dist/chart/templates/webhook/webhooks.yaml
+++ b/dist/chart/templates/webhook/webhooks.yaml
@@ -57,6 +57,11 @@ webhooks:
     sideEffects: None
     admissionReviewVersions:
       - v1
+    namespaceSelector:
+      matchExpressions:
+        - key: kubernetes.io/metadata.name
+          operator: NotIn
+          values: [kube-system, kube-public, kube-node-lease]
     rules:
       - operations:
           - CREATE

--- a/internal/webhook/v1beta2/nudgeconfig_webhook.go
+++ b/internal/webhook/v1beta2/nudgeconfig_webhook.go
@@ -18,9 +18,12 @@ package v1beta2
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 	"github.com/konflux-ci/integration-service/pkg/dag"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -31,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// nolint:unused
 var nudgeconfiglog = logf.Log.WithName("nudgeconfig-webhook")
 
 func SetupNudgeConfigWebhookWithManager(mgr ctrl.Manager) error {
@@ -65,6 +67,10 @@ func (v *NudgeConfigCustomValidator) ValidateCreate(ctx context.Context, obj run
 		}
 	}
 
+	if err := v.validateComponentsExist(ctx, nudgeConfig.Namespace, nudgeConfig.Spec.Nudges); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
@@ -80,6 +86,9 @@ func (v *NudgeConfigCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 
 	nudgeconfiglog.Info("Validating NudgeConfig upon update", "name", newNudgeConfig.Name)
 
+	// Cycle detection: whole-graph validation when anything changes.
+	// A new edge can close a cycle through pre-existing edges, so the
+	// entire graph must be re-validated.
 	if !reflect.DeepEqual(oldNudgeConfig.Spec.Nudges, newNudgeConfig.Spec.Nudges) {
 		if len(newNudgeConfig.Spec.Nudges) > 0 {
 			if err := dag.ValidateNudgeGraph(newNudgeConfig.Spec.Nudges); err != nil {
@@ -88,9 +97,81 @@ func (v *NudgeConfigCustomValidator) ValidateUpdate(ctx context.Context, oldObj,
 		}
 	}
 
+	// Existence: per-pair validation of only newly-added (from,to) pairs.
+	// Pre-existing pairs are NOT re-validated — a Component deleted after
+	// its entry was added does not block updates; pruning references to
+	// deleted Components is intentionally out of scope for this webhook.
+	oldKeys := nudgeKeySet(oldNudgeConfig.Spec.Nudges)
+	var added []v1beta2.NudgeRelationship
+	for _, n := range newNudgeConfig.Spec.Nudges {
+		if _, existed := oldKeys[nudgeKey(n)]; !existed {
+			added = append(added, n)
+		}
+	}
+	if err := v.validateComponentsExist(ctx, newNudgeConfig.Namespace, added); err != nil {
+		return nil, err
+	}
+
 	return nil, nil
 }
 
-func (v *NudgeConfigCustomValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+func (v *NudgeConfigCustomValidator) ValidateDelete(_ context.Context, _ runtime.Object) (admission.Warnings, error) {
 	return nil, nil
+}
+
+func (v *NudgeConfigCustomValidator) validateComponentsExist(ctx context.Context, namespace string, nudges []v1beta2.NudgeRelationship) error {
+	if len(nudges) == 0 {
+		return nil
+	}
+
+	componentList := &applicationapiv1alpha1.ComponentList{}
+	if err := v.Client.List(ctx, componentList, client.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("failed to list Components in namespace %q: %w", namespace, err)
+	}
+
+	existing := make(map[string]struct{}, len(componentList.Items))
+	for i := range componentList.Items {
+		existing[componentList.Items[i].Name] = struct{}{}
+	}
+
+	var missingFrom, missingTo []string
+	seenFrom, seenTo := map[string]struct{}{}, map[string]struct{}{}
+	for _, n := range nudges {
+		if _, ok := existing[n.From]; !ok {
+			if _, dup := seenFrom[n.From]; !dup {
+				seenFrom[n.From] = struct{}{}
+				missingFrom = append(missingFrom, n.From)
+			}
+		}
+		if _, ok := existing[n.To]; !ok {
+			if _, dup := seenTo[n.To]; !dup {
+				seenTo[n.To] = struct{}{}
+				missingTo = append(missingTo, n.To)
+			}
+		}
+	}
+
+	if len(missingFrom) == 0 && len(missingTo) == 0 {
+		return nil
+	}
+
+	msg := fmt.Sprintf("NudgeConfig references non-existent Component(s) in namespace %q", namespace)
+	if len(missingFrom) > 0 {
+		msg += fmt.Sprintf("; missing 'from' component(s): %s", strings.Join(missingFrom, ", "))
+	}
+	if len(missingTo) > 0 {
+		msg += fmt.Sprintf("; missing 'to' component(s): %s", strings.Join(missingTo, ", "))
+	}
+	nudgeconfiglog.V(1).Info(msg)
+	return errors.New(msg)
+}
+
+func nudgeKey(n v1beta2.NudgeRelationship) string { return n.From + "\x00" + n.To }
+
+func nudgeKeySet(nudges []v1beta2.NudgeRelationship) map[string]struct{} {
+	keys := make(map[string]struct{}, len(nudges))
+	for _, n := range nudges {
+		keys[nudgeKey(n)] = struct{}{}
+	}
+	return keys
 }

--- a/internal/webhook/v1beta2/nudgeconfig_webhook_test.go
+++ b/internal/webhook/v1beta2/nudgeconfig_webhook_test.go
@@ -17,24 +17,62 @@ limitations under the License.
 package v1beta2
 
 import (
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	appstudiov1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("NudgeConfig webhook", Ordered, func() {
+func newComponent(name, namespace string) *applicationapiv1alpha1.Component {
+	return &applicationapiv1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: applicationapiv1alpha1.ComponentSpec{
+			ComponentName: name,
+			Application:   "test-app",
+			Source: applicationapiv1alpha1.ComponentSource{
+				ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+					GitSource: &applicationapiv1alpha1.GitSource{URL: "https://example.com/repo"},
+				},
+			},
+		},
+	}
+}
+
+func newNudgeConfig(namespace string, nudges []appstudiov1beta2.NudgeRelationship) *appstudiov1beta2.NudgeConfig {
+	return &appstudiov1beta2.NudgeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      appstudiov1beta2.NudgeConfigSingletonName,
+			Namespace: namespace,
+		},
+		Spec: appstudiov1beta2.NudgeConfigSpec{
+			Nudges: nudges,
+		},
+	}
+}
+
+var _ = Describe("NudgeConfig webhook - cycle detection", Ordered, func() {
 	var (
 		validator   *NudgeConfigCustomValidator
 		nudgeConfig *appstudiov1beta2.NudgeConfig
+		cycleNs     *corev1.Namespace
 	)
+
+	BeforeAll(func() {
+		cycleNs = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "nudge-cycle-"}}
+		Expect(k8sClient.Create(ctx, cycleNs)).To(Succeed())
+		for _, name := range []string{"a", "b", "c", "d", "component-a", "component-b", "component-c", "component-d"} {
+			Expect(k8sClient.Create(ctx, newComponent(name, cycleNs.Name))).To(Succeed())
+		}
+	})
 
 	BeforeEach(func() {
 		validator = &NudgeConfigCustomValidator{Client: k8sClient}
 		nudgeConfig = &appstudiov1beta2.NudgeConfig{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      appstudiov1beta2.NudgeConfigSingletonName,
-				Namespace: "default",
+				Namespace: cycleNs.Name,
 			},
 			Spec: appstudiov1beta2.NudgeConfigSpec{},
 		}
@@ -173,6 +211,191 @@ var _ = Describe("NudgeConfig webhook", Ordered, func() {
 			warnings, err := validator.ValidateDelete(ctx, nudgeConfig)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(warnings).To(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("NudgeConfig webhook - component existence", func() {
+	var (
+		validator *NudgeConfigCustomValidator
+		ns        *corev1.Namespace
+	)
+
+	BeforeEach(func() {
+		validator = &NudgeConfigCustomValidator{Client: k8sClient}
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "nudge-test-"}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+	})
+
+	When("creating a NudgeConfig", func() {
+		It("rejects when 'from' references a non-existent Component [AC1]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-b", ns.Name))).To(Succeed())
+			nc := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "missing-comp", To: "comp-b"},
+			})
+
+			_, err := validator.ValidateCreate(ctx, nc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing-comp"))
+			Expect(err.Error()).To(ContainSubstring("missing 'from' component(s)"))
+		})
+
+		It("rejects when 'to' references a non-existent Component [AC2]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-a", ns.Name))).To(Succeed())
+			nc := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "missing-comp"},
+			})
+
+			_, err := validator.ValidateCreate(ctx, nc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing-comp"))
+			Expect(err.Error()).To(ContainSubstring("missing 'to' component(s)"))
+		})
+
+		It("succeeds when all referenced Components exist [AC5]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-a", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-b", ns.Name))).To(Succeed())
+			nc := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			})
+
+			_, err := validator.ValidateCreate(ctx, nc)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("rejects when both 'from' and 'to' are absent [E1]", func() {
+			nc := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "no-from", To: "no-to"},
+			})
+
+			_, err := validator.ValidateCreate(ctx, nc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no-from"))
+			Expect(err.Error()).To(ContainSubstring("no-to"))
+			Expect(err.Error()).To(ContainSubstring("missing 'from' component(s)"))
+			Expect(err.Error()).To(ContainSubstring("missing 'to' component(s)"))
+		})
+
+		It("aggregates all missing components across multiple entries [E2]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("real-comp", ns.Name))).To(Succeed())
+			nc := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "ghost-a", To: "real-comp"},
+				{From: "real-comp", To: "ghost-b"},
+				{From: "ghost-c", To: "ghost-d"},
+			})
+
+			_, err := validator.ValidateCreate(ctx, nc)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ghost-a"))
+			Expect(err.Error()).To(ContainSubstring("ghost-b"))
+			Expect(err.Error()).To(ContainSubstring("ghost-c"))
+			Expect(err.Error()).To(ContainSubstring("ghost-d"))
+		})
+
+		It("succeeds with empty nudges [E3]", func() {
+			nc := newNudgeConfig(ns.Name, nil)
+			_, err := validator.ValidateCreate(ctx, nc)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	When("updating a NudgeConfig", func() {
+		It("rejects when a newly-added entry references a non-existent Component [AC3]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-a", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-b", ns.Name))).To(Succeed())
+
+			oldNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			})
+			newNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+				{From: "ghost-x", To: "comp-b"},
+			})
+
+			_, err := validator.ValidateUpdate(ctx, oldNC, newNC)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("ghost-x"))
+		})
+
+		It("allows update when a pre-existing entry references a now-deleted Component [AC4]", func() {
+			compA := newComponent("comp-a", ns.Name)
+			Expect(k8sClient.Create(ctx, compA)).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-b", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-c", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-d", ns.Name))).To(Succeed())
+
+			oldNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			})
+
+			Expect(k8sClient.Delete(ctx, compA)).To(Succeed())
+
+			newNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+				{From: "comp-c", To: "comp-d"},
+			})
+
+			_, err := validator.ValidateUpdate(ctx, oldNC, newNC)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("allows update that only changes mode of a pre-existing entry [AC4b]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-a", ns.Name))).To(Succeed())
+			compB := newComponent("comp-b", ns.Name)
+			Expect(k8sClient.Create(ctx, compB)).To(Succeed())
+
+			oldNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b", Mode: appstudiov1beta2.NudgeModeImmediate},
+			})
+
+			Expect(k8sClient.Delete(ctx, compB)).To(Succeed())
+
+			newNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b", Mode: appstudiov1beta2.NudgeModeValidated},
+			})
+
+			_, err := validator.ValidateUpdate(ctx, oldNC, newNC)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("succeeds when all referenced Components exist [AC5]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-a", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-b", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-c", ns.Name))).To(Succeed())
+
+			oldNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			})
+			newNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+				{From: "comp-b", To: "comp-c"},
+			})
+
+			_, err := validator.ValidateUpdate(ctx, oldNC, newNC)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("handles old nudges being nil when new adds a valid entry [E5]", func() {
+			Expect(k8sClient.Create(ctx, newComponent("comp-a", ns.Name))).To(Succeed())
+			Expect(k8sClient.Create(ctx, newComponent("comp-b", ns.Name))).To(Succeed())
+
+			oldNC := newNudgeConfig(ns.Name, nil)
+			newNC := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			})
+
+			_, err := validator.ValidateUpdate(ctx, oldNC, newNC)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	When("deleting a NudgeConfig", func() {
+		It("always succeeds [E4]", func() {
+			nc := newNudgeConfig(ns.Name, []appstudiov1beta2.NudgeRelationship{
+				{From: "anything", To: "whatever"},
+			})
+			_, err := validator.ValidateDelete(ctx, nc)
+			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })

--- a/internal/webhook/v1beta2/webhook_suite_test.go
+++ b/internal/webhook/v1beta2/webhook_suite_test.go
@@ -35,6 +35,7 @@ import (
 	toolkit "github.com/konflux-ci/operator-toolkit/test"
 	admissionv1 "k8s.io/api/admission/v1"
 	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -72,6 +73,9 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	scheme := apimachineryruntime.NewScheme()
+	err = clientgoscheme.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
 	err = appstudiov1beta2.AddToScheme(scheme)
 	Expect(err).NotTo(HaveOccurred())
 

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1558,7 +1558,7 @@ var _ = Describe("Loader", Ordered, func() {
 	It("can get all componentGroups in the namespace", func() {
 		componentGroups, err := loader.GetAllComponentGroupsInNamespace(ctx, k8sClient, "default")
 		Expect(err).NotTo(HaveOccurred())
-		Expect(componentGroups).To(HaveLen(5))
+		Expect(componentGroups).To(HaveLen(6))
 	})
 
 	It("can get componentGroups that contain another componentGroup", func() {


### PR DESCRIPTION
Add a Go ValidatingWebhook that rejects NudgeConfig CREATE/UPDATE when spec.nudges[].from or spec.nudges[].to references a Component that does not exist in the namespace. Pre-existing entries are not re-validated on update (staleness is the stale-reference controller's responsibility).