### PR TITLE
fix(STONEINTG-1677partial): add HTTP 400 and :run from :running 400

### DIFF
--- a/status/reporter_forgejo.go
+++ b/status/reporter_forgejo.go
@@ -416,7 +416,9 @@ func (r *ForgejoReporter) ReportStatus(ctx context.Context, report TestReport) (
 }
 
 func (r *ForgejoReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized ||
+		statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound ||
+		statusCode == http.StatusUnprocessableEntity
 }
 
 // GenerateForgejoCommitState transforms internal integration test state into Forgejo state

--- a/status/reporter_gitlab.go
+++ b/status/reporter_gitlab.go
@@ -276,6 +276,9 @@ func (r *GitLabReporter) setCommitStatus(report TestReport) (int, error) {
 	} else if strings.Contains(targetProjectErr.Error(), "Cannot transition status via :enqueue from :pending") {
 		r.logger.Info("Ignoring the error when transition from pending to pending when the commitStatus might be created/updated in multiple threads at the same time occasionally")
 		return http.StatusOK, nil
+	} else if strings.Contains(targetProjectErr.Error(), "Cannot transition status via :run from :running") {
+		r.logger.Info("Ignoring redundant running→running commit status update on target project", "scenario.name", report.ScenarioName)
+		return http.StatusOK, nil
 	} else {
 		r.logger.Error(targetProjectErr, "failed to set commit status to gitlab target project, will try to set commit status to gitlab source project",
 			"sourceProjectID", r.sourceProjectID, "targetProjectID", r.targetProjectID, "sha", r.sha,
@@ -292,6 +295,10 @@ func (r *GitLabReporter) setCommitStatus(report TestReport) (int, error) {
 	}
 	if strings.Contains(sourceProjectErr.Error(), "Cannot transition status via :enqueue from :pending") {
 		r.logger.Info("Ignoring the error when transition from pending to pending when the commitStatus might be created/updated in multiple threads at the same time occasionally")
+		return http.StatusOK, nil
+	}
+	if strings.Contains(sourceProjectErr.Error(), "Cannot transition status via :run from :running") {
+		r.logger.Info("Ignoring redundant running→running commit status update on source project", "scenario.name", report.ScenarioName)
 		return http.StatusOK, nil
 	}
 
@@ -509,7 +516,9 @@ func (r *GitLabReporter) ReportStatus(ctx context.Context, report TestReport) (i
 }
 
 func (r *GitLabReporter) ReturnCodeIsUnrecoverable(statusCode int) bool {
-	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized || statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound
+	return statusCode == http.StatusForbidden || statusCode == http.StatusUnauthorized ||
+		statusCode == http.StatusBadRequest || statusCode == http.StatusNotFound ||
+		statusCode == http.StatusUnprocessableEntity
 }
 
 // GenerateGitlabCommitState transforms internal integration test state into Gitlab state

--- a/status/reporter_gitlab_test.go
+++ b/status/reporter_gitlab_test.go
@@ -467,7 +467,7 @@ var _ = Describe("GitLabReporter", func() {
 		})
 
 		// Note: GitLab Go client has internal retryablehttp that retries on >= 500,
-		// so we use 422 (not in the unrecoverable list) to test our retry.OnError logic
+		// so we use 409 (not in the unrecoverable list) to test our retry.OnError logic
 		// without interference from the client's internal retries.
 		It("retries on recoverable error and succeeds on retry", func() {
 			var sourceCallCount int32
@@ -479,8 +479,8 @@ var _ = Describe("GitLabReporter", func() {
 			mux.HandleFunc(sourcePath, func(rw http.ResponseWriter, r *http.Request) {
 				call := atomic.AddInt32(&sourceCallCount, 1)
 				if call == 1 {
-					rw.WriteHeader(http.StatusUnprocessableEntity)
-					fmt.Fprintf(rw, `{"error": "unprocessable"}`)
+					rw.WriteHeader(http.StatusConflict)
+					fmt.Fprintf(rw, `{"error": "conflict"}`)
 					return
 				}
 				rw.WriteHeader(http.StatusCreated)
@@ -489,8 +489,8 @@ var _ = Describe("GitLabReporter", func() {
 
 			targetPath := fmt.Sprintf("/projects/%s/statuses/%s", targetProjectID, digest)
 			mux.HandleFunc(targetPath, func(rw http.ResponseWriter, r *http.Request) {
-				rw.WriteHeader(http.StatusUnprocessableEntity)
-				fmt.Fprintf(rw, `{"error": "unprocessable"}`)
+				rw.WriteHeader(http.StatusConflict)
+				fmt.Fprintf(rw, `{"error": "conflict"}`)
 			})
 
 			statusCode, err := reporter.ReportStatus(context.TODO(), status.TestReport{
@@ -577,14 +577,14 @@ var _ = Describe("GitLabReporter", func() {
 			sourcePath := fmt.Sprintf("/projects/%s/statuses/%s", sourceProjectID, digest)
 			mux.HandleFunc(sourcePath, func(rw http.ResponseWriter, r *http.Request) {
 				atomic.AddInt32(&sourceCallCount, 1)
-				rw.WriteHeader(http.StatusUnprocessableEntity)
-				fmt.Fprintf(rw, `{"error": "unprocessable"}`)
+				rw.WriteHeader(http.StatusConflict)
+				fmt.Fprintf(rw, `{"error": "conflict"}`)
 			})
 
 			targetPath := fmt.Sprintf("/projects/%s/statuses/%s", targetProjectID, digest)
 			mux.HandleFunc(targetPath, func(rw http.ResponseWriter, r *http.Request) {
-				rw.WriteHeader(http.StatusUnprocessableEntity)
-				fmt.Fprintf(rw, `{"error": "unprocessable"}`)
+				rw.WriteHeader(http.StatusConflict)
+				fmt.Fprintf(rw, `{"error": "conflict"}`)
 			})
 
 			statusCode, err := reporter.ReportStatus(context.TODO(), status.TestReport{
@@ -595,7 +595,7 @@ var _ = Describe("GitLabReporter", func() {
 			})
 
 			Expect(err).To(HaveOccurred())
-			Expect(statusCode).To(Equal(http.StatusUnprocessableEntity))
+			Expect(statusCode).To(Equal(http.StatusConflict))
 			Expect(atomic.LoadInt32(&sourceCallCount)).To(BeNumerically("==", 3))
 			Expect(buf.String()).To(ContainSubstring("failed to set gitlab commit status after all retries"))
 		})


### PR DESCRIPTION
 as unrecoverable GitLab errors
HTTP 422 from GitLab indicates the pipeline job limit has been exceeded. The service was not treating this as unrecoverable, causing retry storms (100k+ errors over 90 days) and wasting reconcile queue capacity. "Cannot transition status via :run from :running" (HTTP 400) occurs when multiple concurrent reconciles attempt to set the same commit status to its current state. Unlike the existing :enqueue from :pending handling, this variant was not caught, causing the scenario loop to abort early and leave srs timestamps unwritten — making affected scenarios appear stale on every subsequent reconcile and amplifying the error rate. Both codes are now treated as no-ops: 422 added to ReturnCodeIsUnrecoverable (stops retries immediately), :run from :running returns StatusOK like its :enqueue from :pending counterpart (loop continues, srs is written correctly). The same 422 fix is applied to the Forgejo reporter for consistency and will be required when the rest of 1677 is implemented.

Assisted by: Cursor AI

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
