### PR TITLE
fix(STONEINTG-1705): add missing list/watch RBAC for ServiceAccounts

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -20,7 +20,9 @@ rules:
   verbs:
   - create
   - get
+  - list
   - update
+  - watch
 - apiGroups:
   - appstudio.redhat.com
   resources:
@@ -100,6 +102,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - resolution.tekton.dev
   resources:

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -55,9 +55,9 @@ func NewScenarioReconciler(client client.Client, logger *logr.Logger, scheme *ru
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=applications/status,verbs=get
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=componentgroups/status,verbs=get
-//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;create;update
+//+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create
-//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The cached client requires `list+watch` to create an informer. Without them the reflector retries continuously, adding API server load and contributing to etcd timeouts and leader election loss.

Fixes both `serviceaccounts` and `rolebindings` RBAC markers in the scenario controller — both were missing `list;watch` verbs required by controller-runtime's cached client informer.

For more info: [STONEINTG-1705](https://redhat.atlassian.net/browse/STONEINTG-1705)

Assisted-by: Claude Code, opus 4.6

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


[STONEINTG-1705]: https://redhat.atlassian.net/browse/STONEINTG-1705?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ"