### PR TITLE
chore: update component version and context prefixes

### DIFF
--- a/api/v1beta2/componentgroup_types.go
+++ b/api/v1beta2/componentgroup_types.go
@@ -82,7 +82,7 @@ type ComponentVersionReference struct {
 	Name string `json:"name"`
 
 	// Name of the git revision for the component version. Used as a
-	// fallback if the `appstudio.openshift.io/version` label is not
+	// fallback if the `build.konflux-ci.dev/version` annotation is not
 	// set on the build PLR
 	// +optional
 	Revision string `json:"version"`

--- a/config/crd/bases/appstudio.redhat.com_componentgroups.yaml
+++ b/config/crd/bases/appstudio.redhat.com_componentgroups.yaml
@@ -77,7 +77,7 @@ spec:
                         version:
                           description: |-
                             Name of the git revision for the component version. Used as a
-                            fallback if the `appstudio.openshift.io/version` label is not
+                            fallback if the `build.konflux-ci.dev/version` annotation is not
                             set on the build PLR
                           type: string
                       required:

--- a/config/samples/appstudio_v1beta2_componentgroup.yaml
+++ b/config/samples/appstudio_v1beta2_componentgroup.yaml
@@ -18,7 +18,7 @@ spec:
   components:
     - name: first-component
       # used to match build PLRs. Will attempt to match
-      # `appstudio.openshift.io/version` label to name field. Will fall back
+      # `build.konflux-ci.dev/version` annotation to name field. Will fall back
       # on matching `target_branch` and `context_dir` annotations to revision
       # and context fields if the revision and context fields are set
       componentVersion:

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -19,6 +19,9 @@ package consts
 import "fmt"
 
 const (
+	// KonfluxBuildLabelPrefix is the prefix that the build service uses for its labels and annotations
+	KonfluxBuildLabelPrefix = "build.konflux-ci.dev"
+
 	// PipelinesLabelPrefix is the prefix of the pipelines label
 	PipelinesLabelPrefix = "pipelines.appstudio.openshift.io"
 
@@ -119,9 +122,9 @@ const (
 	PipelineRunComponentLabel = "appstudio.openshift.io/component"
 
 	// PipelineRunComponentVersionAnnotation denotes the componentVersion for the build
-	PipelineRunComponentVersionAnnotation = "appstudio.openshift.io/version"
+	PipelineRunComponentVersionAnnotation = KonfluxBuildLabelPrefix + "/version"
 
-	PipelineRunComponentVersionContextAnnotation = "appstudio.openshift.io/context"
+	PipelineRunComponentVersionContextAnnotation = KonfluxBuildLabelPrefix + "/context"
 
 	// PipelineRunApplicationLabel is the label denoting the application.
 	PipelineRunApplicationLabel = "appstudio.openshift.io/application"


### PR DESCRIPTION
The build service is currently migrating from using the `appstudio.openshift.io` prefix to the `build.konflux-ci.dev` prefix for apiVersions, labels, and annotations. Since the context and version annotations are new, they are using the new prefix immediately rather than migrating later. This commit switches those annotations over to the new prefix so that ComponentGroups can be matched with their appropriate build PipelineRuns.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
