### PR TITLE
chore(STONEINTG-1696): add Aine Phelan to codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @dirgim @jsztuka @Josh-Everett @kasemAlem @sonam1412 @14rcole @jencull @NigelByrne1
+* @dirgim @jsztuka @Josh-Everett @kasemAlem @sonam1412 @14rcole @jencull @NigelByrne1 @ainephelan365


### PR DESCRIPTION
Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
