### PR TITLE
fix: remove unreliable instance types

### DIFF
--- a/integration-tests/pipelines/konflux-e2e-tests.yaml
+++ b/integration-tests/pipelines/konflux-e2e-tests.yaml
@@ -95,7 +95,7 @@ spec:
         - name: spot
           value: "false"
         - name: compute-sizes
-          value: "m5a.large,m6a.large,m7i-flex.12xlarge,m5.12xlarge,m6i.12xlarge"
+          value: "m7i-flex.12xlarge,m5.12xlarge,m6i.12xlarge"
     - name: deploy-konflux
       runAfter:
         - provision-kind-cluster


### PR DESCRIPTION
### JIRA
https://redhat.atlassian.net/browse/KONFLUX-14875

### Description
After analysing the latest failures in CI
they are all related to .large instances
Removing them from the list should help
with stabilizing the cluster provision

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
