### PR TITLE
feat(STONEINTG-1682): add one-time migration script for build-nudges-ef to NudgeConfig

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,8 @@ RUN if [ "$ENABLE_COVERAGE" = "true" ]; then \
         echo "Building production binary..."; \
         CGO_ENABLED=0 go build -a -o manager ./cmd; \
     fi \
- && CGO_ENABLED=0 go build -a -o snapshotgc cmd/snapshotgc/snapshotgc.go
+ && CGO_ENABLED=0 go build -a -o snapshotgc cmd/snapshotgc/snapshotgc.go \
+ && CGO_ENABLED=0 go build -a -o nudge-migrate cmd/nudge-migrate/nudge_migrate.go
 
 ARG ENABLE_WEBHOOKS=true
 ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
@@ -35,6 +36,7 @@ ENV ENABLE_WEBHOOKS=${ENABLE_WEBHOOKS}
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.8-1782797275
 COPY --from=builder /opt/app-root/src/manager /
 COPY --from=builder /opt/app-root/src/snapshotgc /
+COPY --from=builder /opt/app-root/src/nudge-migrate /
 
 # It is mandatory to set these labels
 LABEL name="integration-service"

--- a/cmd/nudge-migrate/README.md
+++ b/cmd/nudge-migrate/README.md
@@ -1,0 +1,219 @@
+# nudge-migrate
+
+One-time migration script that reads `build-nudges-ref` data from Component CRs
+and creates or merges NudgeConfig CRDs per namespace.
+
+This is part of **ADR-0067 Phase 2** — moving nudge relationship storage from
+`Component.spec.build-nudges-ref` (build-service) to the `NudgeConfig` singleton
+CRD (integration-service).
+
+## Prerequisites
+
+- The **NudgeConfig CRD** must be deployed on the target cluster
+  (STONEINTG-1659, STONEINTG-1660).
+- The **build-service skip patch** (STONEINTG-1672) must be deployed before
+  running a live (non-dry-run) migration. Otherwise both services fire nudges
+  simultaneously.
+- The runner (user or service account) needs RBAC access to:
+  - `list` Namespaces cluster-wide
+  - `list` Components in all tenant namespaces
+  - `get`, `create`, `update` NudgeConfigs in all tenant namespaces
+
+## Usage
+
+```bash
+# Build
+go build -o bin/nudge-migrate ./cmd/nudge-migrate/
+
+# Dry-run all tenant namespaces (recommended first step)
+./bin/nudge-migrate --dry-run
+
+# Dry-run specific namespaces
+./bin/nudge-migrate --dry-run tenant-foo tenant-bar
+
+# Live migration — all tenant namespaces
+./bin/nudge-migrate
+
+# Live migration — specific namespaces
+./bin/nudge-migrate tenant-foo tenant-bar
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dry-run` | `false` | Print what would change without writing to the cluster |
+
+Positional arguments are namespace names. If none are provided, the script
+auto-discovers all tenant namespaces using label selectors.
+
+## How It Works
+
+### Namespace Discovery
+
+When no namespaces are specified, the script discovers tenant namespaces using
+three label queries (matching the `snapshotgc` pattern):
+
+| Label | Value |
+|-------|-------|
+| `toolchain.dev.openshift.com/type` | `tenant` |
+| `konflux.ci/type` | `user` |
+| `konflux-ci.dev/type` | `tenant` |
+
+Results are deduplicated and sorted alphabetically.
+
+### Per-Namespace Logic
+
+For each namespace:
+
+1. **List all Components** in the namespace.
+2. **Collect `build-nudges-ref`** entries from each Component.
+3. **Filter out** invalid entries:
+   - Self-nudges (`from == to`) are silently skipped.
+   - Dangling references (target Component does not exist) are skipped with a
+     warning log.
+   - Duplicate `(from, to)` pairs are deduplicated.
+4. If no valid relationships remain, **skip** the namespace.
+5. **Validate the DAG** — run cycle detection via `dag.ValidateNudgeGraph()`.
+   If a cycle is detected, the namespace is skipped with an error.
+6. **Check cardinality** — if relationships exceed 256 (NudgeConfig CEL max),
+   the namespace is skipped with an error.
+7. **Check for existing NudgeConfig** (`nudge-config`) in the namespace:
+   - **Not found** → create a new NudgeConfig with all relationships.
+   - **Found** → merge: add entries from `build-nudges-ref` that don't already
+     exist, preserving user-added entries.
+8. On merge, re-validate the merged graph for cycles and cardinality.
+
+### Merge Behavior
+
+When a NudgeConfig already exists, the script **merges, never replaces**:
+
+| Entry state | Action |
+|-------------|--------|
+| In `build-nudges-ref` but not in NudgeConfig | **Added** |
+| Already in NudgeConfig (same `from`/`to`) | **Unchanged** |
+| In NudgeConfig but not in `build-nudges-ref` (user-added) | **Preserved** |
+
+This is safe because users may have started editing NudgeConfig directly after
+an earlier script run.
+
+### Migration Metadata
+
+Every NudgeConfig created or updated by the script gets:
+
+| Metadata | Key | Value |
+|----------|-----|-------|
+| Label | `nudging.konflux-ci.dev/owner` | `build-service` |
+| Annotation | `nudging.konflux-ci.dev/migrated-from` | `build-nudges-ref` |
+
+### Idempotency
+
+Running the script twice on the same namespace is safe — the second run detects
+that all relationships are already present and reports "skipped" with no changes.
+
+## Output
+
+### Dry-Run
+
+```
+[DRY RUN] Migration summary
+  namespacesProcessed: 453
+  created: 5
+  updated: 2
+  skipped: 440
+  errors: 6
+  totalRelationshipsMigrated: 23
+```
+
+### Live Run
+
+```
+Migration summary
+  namespacesProcessed: 453
+  created: 5
+  updated: 2
+  skipped: 440
+  errors: 6
+  totalRelationshipsMigrated: 23
+```
+
+The script exits with code 1 if any namespace encountered an error.
+
+Per-namespace actions are logged at info level. Increase verbosity with `-v=1`
+to see individual entries logged during dry-run creates.
+
+## RBAC Requirements
+
+The script must be run with a service account that has the following permissions.
+Running with a personal user kubeconfig will fail with "forbidden" errors on
+namespaces where the user lacks NudgeConfig access.
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: nudge-migrate
+rules:
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["list"]
+  - apiGroups: ["appstudio.redhat.com"]
+    resources: ["components"]
+    verbs: ["list"]
+  - apiGroups: ["appstudio.redhat.com"]
+    resources: ["nudgeconfigs"]
+    verbs: ["get", "create", "update"]
+```
+
+**Note:** The `appstudio-admin-user-actions` role in infra-deployments must also
+be updated to include `nudgeconfigs` verbs for tenant users to view/edit their
+NudgeConfig after migration.
+
+## Rollback
+
+Deleting a NudgeConfig immediately reverts the namespace to build-service
+nudging (assuming STONEINTG-1672 is deployed):
+
+```bash
+kubectl delete nudgeconfig nudge-config -n <namespace>
+```
+
+Build-service resumes nudging via `build-nudges-ref`. Re-run the migration
+script to restore when ready.
+
+## Cluster Test Results
+
+Dry-run results from 2026-07-06 using a personal kubeconfig (limited RBAC):
+
+### Production (`stone-prd-rh01`)
+
+| Metric | Count |
+|--------|-------|
+| Namespaces discovered | 453 |
+| Skipped (no nudges) | 407 |
+| Errors (RBAC forbidden) | 46 |
+| Dangling references | Multiple (filtered correctly) |
+
+### Stage (`stone-stg-rh01`)
+
+| Metric | Count |
+|--------|-------|
+| Namespaces discovered | 3,368 |
+| Skipped (no nudges) | 3,358 |
+| Errors (RBAC forbidden) | 10 |
+
+Stage has far fewer nudge relationships than production (10 vs 46). The bulk of
+stage namespaces are `test-rhtap-*` perfscale test namespaces with no components.
+
+All RBAC errors are expected — the script needs a service account with
+cluster-wide NudgeConfig access, not a personal user kubeconfig.
+
+## Related Jira Issues
+
+| Issue | Description |
+|-------|-------------|
+| STONEINTG-1682 | This migration script |
+| STONEINTG-1659 | NudgeConfig CRD schema + CEL |
+| STONEINTG-1660 | NudgeConfig webhook (cycle detection) |
+| STONEINTG-1671 | Integration-service nudge orchestration |
+| STONEINTG-1672 | Build-service skip when NudgeConfig exists |

--- a/cmd/nudge-migrate/nudge_migrate.go
+++ b/cmd/nudge-migrate/nudge_migrate.go
@@ -1,0 +1,417 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/pkg/dag"
+	zap2 "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	core "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+var (
+	scheme = runtime.NewScheme()
+)
+
+const (
+	MigrationLabel           = "nudging.konflux-ci.dev/owner"
+	MigrationLabelValue      = "build-service"
+	MigrationAnnotation      = "nudging.konflux-ci.dev/migrated-from"
+	MigrationAnnotationValue = "build-nudges-ref"
+	MaxNudgesPerConfig       = 256
+)
+
+func init() {
+	utilruntime.Must(applicationapiv1alpha1.AddToScheme(scheme))
+	utilruntime.Must(integrationv1beta2.AddToScheme(scheme))
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+}
+
+type migrationSummary struct {
+	Namespace                    string
+	ComponentsRead               int
+	RelationshipsFound           int
+	RelationshipsMigrated        int
+	RelationshipsSkippedDangling int
+	RelationshipsAlreadyPresent  int
+	Action                       string // "created", "updated", "skipped", "dry-run:create", "dry-run:update", "dry-run:skip", "error"
+	Errors                       []string
+}
+
+func main() {
+	var dryRun bool
+	flag.BoolVar(&dryRun, "dry-run", false, "Print what would change without writing to the cluster")
+
+	opts := zap.Options{
+		Development: false,
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
+		ZapOpts:     []zap2.Option{zap2.WithCaller(true)},
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	namespaces := flag.Args()
+
+	cl, err := client.New(config.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		logger.Error(err, "Failed to create Kubernetes client")
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	if len(namespaces) == 0 {
+		logger.Info("No namespaces specified, discovering tenant namespaces")
+		namespaces, err = getTenantNamespaces(ctx, cl, logger)
+		if err != nil {
+			logger.Error(err, "Failed to discover tenant namespaces")
+			os.Exit(1)
+		}
+		logger.Info("Discovered tenant namespaces", "count", len(namespaces))
+	}
+
+	summaries := migrateNamespaces(ctx, cl, logger, namespaces, dryRun)
+	printSummary(summaries, logger, dryRun)
+
+	for _, s := range summaries {
+		if len(s.Errors) > 0 {
+			os.Exit(1)
+		}
+	}
+}
+
+func getTenantNamespaces(ctx context.Context, cl client.Client, logger logr.Logger) ([]string, error) {
+	labelQueries := []struct {
+		key   string
+		value string
+	}{
+		{"toolchain.dev.openshift.com/type", "tenant"},
+		{"konflux.ci/type", "user"},
+		{"konflux-ci.dev/type", "tenant"},
+	}
+
+	seen := make(map[string]bool)
+	var result []string
+
+	for _, lq := range labelQueries {
+		req, err := labels.NewRequirement(lq.key, selection.In, []string{lq.value})
+		if err != nil {
+			return nil, fmt.Errorf("building label requirement %s=%s: %w", lq.key, lq.value, err)
+		}
+		selector := labels.NewSelector().Add(*req)
+		nsList := &core.NamespaceList{}
+		if err := cl.List(ctx, nsList, &client.ListOptions{LabelSelector: selector}); err != nil {
+			logger.Error(err, "Failed listing namespaces", "label", lq.key+"="+lq.value)
+			return nil, err
+		}
+		for i := range nsList.Items {
+			name := nsList.Items[i].Name
+			if !seen[name] {
+				seen[name] = true
+				result = append(result, name)
+			}
+		}
+	}
+
+	sort.Strings(result)
+	return result, nil
+}
+
+func migrateNamespaces(ctx context.Context, cl client.Client, logger logr.Logger, namespaces []string, dryRun bool) []migrationSummary {
+	summaries := make([]migrationSummary, 0, len(namespaces))
+	for _, ns := range namespaces {
+		s := migrateNamespace(ctx, cl, logger.WithValues("namespace", ns), ns, dryRun)
+		summaries = append(summaries, s)
+	}
+	return summaries
+}
+
+func migrateNamespace(ctx context.Context, cl client.Client, logger logr.Logger, namespace string, dryRun bool) migrationSummary {
+	summary := migrationSummary{Namespace: namespace}
+
+	componentList := &applicationapiv1alpha1.ComponentList{}
+	if err := cl.List(ctx, componentList, client.InNamespace(namespace)); err != nil {
+		logger.Error(err, "Failed to list Components")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, fmt.Sprintf("list components: %v", err))
+		return summary
+	}
+	summary.ComponentsRead = len(componentList.Items)
+
+	existingComponents := make(map[string]bool, len(componentList.Items))
+	for i := range componentList.Items {
+		existingComponents[componentList.Items[i].Name] = true
+	}
+
+	var relationships []integrationv1beta2.NudgeRelationship
+	seen := make(map[string]bool)
+
+	for i := range componentList.Items {
+		comp := &componentList.Items[i]
+		for _, target := range comp.Spec.BuildNudgesRef {
+			if comp.Name == target {
+				logger.Info("Skipping self-nudge", "component", comp.Name)
+				continue
+			}
+			if !existingComponents[target] {
+				logger.Info("Skipping dangling reference (target component does not exist)",
+					"from", comp.Name, "to", target)
+				summary.RelationshipsSkippedDangling++
+				continue
+			}
+			key := comp.Name + "->" + target
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			relationships = append(relationships, integrationv1beta2.NudgeRelationship{
+				From: comp.Name,
+				To:   target,
+				Mode: integrationv1beta2.NudgeModeImmediate,
+			})
+		}
+	}
+	summary.RelationshipsFound = len(relationships)
+
+	if len(relationships) == 0 {
+		if dryRun {
+			summary.Action = "dry-run:skip"
+		} else {
+			summary.Action = "skipped"
+		}
+		logger.Info("No nudge relationships found, skipping namespace")
+		return summary
+	}
+
+	if err := dag.ValidateNudgeGraph(relationships); err != nil {
+		logger.Error(err, "Cycle detected in nudge relationships, skipping namespace")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, fmt.Sprintf("cycle detected: %v", err))
+		return summary
+	}
+
+	if len(relationships) > MaxNudgesPerConfig {
+		err := fmt.Errorf("found %d relationships, exceeds maximum %d", len(relationships), MaxNudgesPerConfig)
+		logger.Error(err, "Too many nudge relationships, skipping namespace")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, err.Error())
+		return summary
+	}
+
+	existing := &integrationv1beta2.NudgeConfig{}
+	err := cl.Get(ctx, client.ObjectKey{Namespace: namespace, Name: integrationv1beta2.NudgeConfigSingletonName}, existing)
+
+	if apierrors.IsNotFound(err) {
+		return handleCreate(ctx, cl, logger, namespace, relationships, dryRun, summary)
+	}
+	if err != nil {
+		logger.Error(err, "Failed to get existing NudgeConfig")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, fmt.Sprintf("get nudgeconfig: %v", err))
+		return summary
+	}
+
+	return handleMerge(ctx, cl, logger, existing, relationships, dryRun, summary)
+}
+
+func handleCreate(ctx context.Context, cl client.Client, logger logr.Logger, namespace string, relationships []integrationv1beta2.NudgeRelationship, dryRun bool, summary migrationSummary) migrationSummary {
+	nc := buildNudgeConfig(namespace, relationships)
+	summary.RelationshipsMigrated = len(relationships)
+
+	if dryRun {
+		summary.Action = "dry-run:create"
+		logger.Info("Would CREATE NudgeConfig",
+			"entries", len(relationships))
+		for _, r := range relationships {
+			logger.V(1).Info("  entry", "from", r.From, "to", r.To, "mode", r.Mode)
+		}
+		return summary
+	}
+
+	if err := cl.Create(ctx, nc); err != nil {
+		logger.Error(err, "Failed to create NudgeConfig")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, fmt.Sprintf("create nudgeconfig: %v", err))
+		return summary
+	}
+
+	summary.Action = "created"
+	logger.Info("Created NudgeConfig", "entries", len(relationships))
+	return summary
+}
+
+func handleMerge(ctx context.Context, cl client.Client, logger logr.Logger, existing *integrationv1beta2.NudgeConfig, newRelationships []integrationv1beta2.NudgeRelationship, dryRun bool, summary migrationSummary) migrationSummary {
+	merged, addedCount := mergeNudges(existing.Spec.Nudges, newRelationships)
+	summary.RelationshipsMigrated = addedCount
+	summary.RelationshipsAlreadyPresent = len(newRelationships) - addedCount
+
+	if addedCount == 0 {
+		if dryRun {
+			summary.Action = "dry-run:skip"
+		} else {
+			summary.Action = "skipped"
+		}
+		logger.Info("All relationships already present in existing NudgeConfig, no changes needed",
+			"existingEntries", len(existing.Spec.Nudges))
+		return summary
+	}
+
+	if len(merged) > MaxNudgesPerConfig {
+		err := fmt.Errorf("merged count %d exceeds maximum %d", len(merged), MaxNudgesPerConfig)
+		logger.Error(err, "Merged NudgeConfig would exceed max entries, skipping namespace")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, err.Error())
+		return summary
+	}
+
+	if err := dag.ValidateNudgeGraph(merged); err != nil {
+		logger.Error(err, "Cycle detected in merged nudge relationships, skipping namespace")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, fmt.Sprintf("cycle in merged graph: %v", err))
+		return summary
+	}
+
+	if dryRun {
+		summary.Action = "dry-run:update"
+		logger.Info("Would UPDATE NudgeConfig",
+			"existingEntries", len(existing.Spec.Nudges),
+			"entriesToAdd", addedCount)
+		return summary
+	}
+
+	existing.Spec.Nudges = merged
+	setMigrationMetadata(existing)
+	if err := cl.Update(ctx, existing); err != nil {
+		logger.Error(err, "Failed to update NudgeConfig")
+		summary.Action = "error"
+		summary.Errors = append(summary.Errors, fmt.Sprintf("update nudgeconfig: %v", err))
+		return summary
+	}
+
+	summary.Action = "updated"
+	logger.Info("Updated NudgeConfig",
+		"totalEntries", len(merged),
+		"entriesAdded", addedCount)
+	return summary
+}
+
+func buildNudgeConfig(namespace string, nudges []integrationv1beta2.NudgeRelationship) *integrationv1beta2.NudgeConfig {
+	nc := &integrationv1beta2.NudgeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      integrationv1beta2.NudgeConfigSingletonName,
+			Namespace: namespace,
+		},
+		Spec: integrationv1beta2.NudgeConfigSpec{
+			Nudges: nudges,
+		},
+	}
+	setMigrationMetadata(nc)
+	return nc
+}
+
+func setMigrationMetadata(nc *integrationv1beta2.NudgeConfig) {
+	if nc.Labels == nil {
+		nc.Labels = make(map[string]string)
+	}
+	nc.Labels[MigrationLabel] = MigrationLabelValue
+
+	if nc.Annotations == nil {
+		nc.Annotations = make(map[string]string)
+	}
+	nc.Annotations[MigrationAnnotation] = MigrationAnnotationValue
+}
+
+func mergeNudges(existing, incoming []integrationv1beta2.NudgeRelationship) ([]integrationv1beta2.NudgeRelationship, int) {
+	existingSet := make(map[string]bool, len(existing))
+	for _, r := range existing {
+		existingSet[r.From+"->"+r.To] = true
+	}
+
+	merged := make([]integrationv1beta2.NudgeRelationship, len(existing))
+	copy(merged, existing)
+
+	added := 0
+	for _, r := range incoming {
+		key := r.From + "->" + r.To
+		if !existingSet[key] {
+			merged = append(merged, r)
+			existingSet[key] = true
+			added++
+		}
+	}
+
+	return merged, added
+}
+
+func printSummary(summaries []migrationSummary, logger logr.Logger, dryRun bool) {
+	created, updated, skipped, errored := 0, 0, 0, 0
+	totalMigrated := 0
+
+	for _, s := range summaries {
+		switch s.Action {
+		case "created", "dry-run:create":
+			created++
+		case "updated", "dry-run:update":
+			updated++
+		case "skipped", "dry-run:skip":
+			skipped++
+		case "error":
+			errored++
+		}
+		totalMigrated += s.RelationshipsMigrated
+
+		if s.Action == "error" {
+			for _, e := range s.Errors {
+				logger.Error(nil, "Namespace error", "namespace", s.Namespace, "error", e)
+			}
+		}
+	}
+
+	prefix := ""
+	if dryRun {
+		prefix = "[DRY RUN] "
+	}
+
+	logger.Info(fmt.Sprintf("%sMigration summary", prefix),
+		"namespacesProcessed", len(summaries),
+		"created", created,
+		"updated", updated,
+		"skipped", skipped,
+		"errors", errored,
+		"totalRelationshipsMigrated", totalMigrated,
+	)
+}

--- a/cmd/nudge-migrate/nudge_migrate_suite_test.go
+++ b/cmd/nudge-migrate/nudge_migrate_suite_test.go
@@ -1,0 +1,13 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestNudgeMigrate(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "NudgeMigrate Test Suite")
+}

--- a/cmd/nudge-migrate/nudge_migrate_test.go
+++ b/cmd/nudge-migrate/nudge_migrate_test.go
@@ -1,0 +1,440 @@
+package main
+
+import (
+	"bytes"
+	"context"
+
+	"github.com/go-logr/logr"
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/tonglil/buflogr"
+	core "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func makeComponent(namespace, name string, nudgesRef []string) *applicationapiv1alpha1.Component {
+	return &applicationapiv1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: applicationapiv1alpha1.ComponentSpec{
+			ComponentName: name,
+			Application:   "test-app",
+			Source: applicationapiv1alpha1.ComponentSource{
+				ComponentSourceUnion: applicationapiv1alpha1.ComponentSourceUnion{
+					GitSource: &applicationapiv1alpha1.GitSource{
+						URL: "https://github.com/example/" + name,
+					},
+				},
+			},
+			BuildNudgesRef: nudgesRef,
+		},
+	}
+}
+
+func makeNudgeConfig(namespace string, nudges []integrationv1beta2.NudgeRelationship) *integrationv1beta2.NudgeConfig {
+	return &integrationv1beta2.NudgeConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      integrationv1beta2.NudgeConfigSingletonName,
+			Namespace: namespace,
+		},
+		Spec: integrationv1beta2.NudgeConfigSpec{
+			Nudges: nudges,
+		},
+	}
+}
+
+func makeNamespace(name string, labels map[string]string) *core.Namespace {
+	return &core.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+	}
+}
+
+func getNudgeConfig(ctx context.Context, cl client.Client, namespace string) (*integrationv1beta2.NudgeConfig, error) {
+	nc := &integrationv1beta2.NudgeConfig{}
+	err := cl.Get(ctx, client.ObjectKey{
+		Namespace: namespace,
+		Name:      integrationv1beta2.NudgeConfigSingletonName,
+	}, nc)
+	return nc, err
+}
+
+var _ = Describe("NudgeMigrate", func() {
+	var (
+		buf    bytes.Buffer
+		logger logr.Logger
+		ctx    context.Context
+	)
+
+	BeforeEach(func() {
+		buf.Reset()
+		logger = buflogr.NewWithBuffer(&buf)
+		ctx = context.Background()
+	})
+
+	Describe("mergeNudges", func() {
+		It("appends new entries not present in existing", func() {
+			existing := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "b", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			incoming := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "c", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			merged, added := mergeNudges(existing, incoming)
+			Expect(merged).To(HaveLen(2))
+			Expect(added).To(Equal(1))
+		})
+
+		It("does not duplicate entries already present", func() {
+			existing := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "b", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			incoming := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "b", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			merged, added := mergeNudges(existing, incoming)
+			Expect(merged).To(HaveLen(1))
+			Expect(added).To(Equal(0))
+		})
+
+		It("handles empty existing list", func() {
+			incoming := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "b", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			merged, added := mergeNudges(nil, incoming)
+			Expect(merged).To(HaveLen(1))
+			Expect(added).To(Equal(1))
+		})
+
+		It("handles empty incoming list", func() {
+			existing := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "b", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			merged, added := mergeNudges(existing, nil)
+			Expect(merged).To(HaveLen(1))
+			Expect(added).To(Equal(0))
+		})
+	})
+
+	Describe("buildNudgeConfig", func() {
+		It("creates NudgeConfig with correct name, labels, and annotations", func() {
+			nudges := []integrationv1beta2.NudgeRelationship{
+				{From: "a", To: "b", Mode: integrationv1beta2.NudgeModeImmediate},
+			}
+			nc := buildNudgeConfig("test-ns", nudges)
+			Expect(nc.Name).To(Equal(integrationv1beta2.NudgeConfigSingletonName))
+			Expect(nc.Namespace).To(Equal("test-ns"))
+			Expect(nc.Labels).To(HaveKeyWithValue(MigrationLabel, MigrationLabelValue))
+			Expect(nc.Annotations).To(HaveKeyWithValue(MigrationAnnotation, MigrationAnnotationValue))
+			Expect(nc.Spec.Nudges).To(HaveLen(1))
+		})
+	})
+
+	Describe("migrateNamespace", func() {
+		It("skips namespace with no components", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			s := migrateNamespace(ctx, cl, logger, "empty-ns", false)
+			Expect(s.Action).To(Equal("skipped"))
+			Expect(s.ComponentsRead).To(Equal(0))
+			Expect(s.RelationshipsFound).To(Equal(0))
+		})
+
+		It("skips namespace with components but no build-nudges-ref", func() {
+			compA := makeComponent("test-ns", "comp-a", nil)
+			compB := makeComponent("test-ns", "comp-b", nil)
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB).Build()
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("skipped"))
+			Expect(s.ComponentsRead).To(Equal(2))
+			Expect(s.RelationshipsFound).To(Equal(0))
+		})
+
+		It("creates NudgeConfig with correct entries for simple migration", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b", "comp-c"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			compC := makeComponent("test-ns", "comp-c", nil)
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB, compC).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("created"))
+			Expect(s.RelationshipsFound).To(Equal(2))
+			Expect(s.RelationshipsMigrated).To(Equal(2))
+
+			nc, err := getNudgeConfig(ctx, cl, "test-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nc.Spec.Nudges).To(HaveLen(2))
+			Expect(nc.Labels).To(HaveKeyWithValue(MigrationLabel, MigrationLabelValue))
+			Expect(nc.Annotations).To(HaveKeyWithValue(MigrationAnnotation, MigrationAnnotationValue))
+		})
+
+		It("filters out dangling references to non-existent components", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b", "comp-missing"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("created"))
+			Expect(s.RelationshipsFound).To(Equal(1))
+			Expect(s.RelationshipsSkippedDangling).To(Equal(1))
+
+			nc, err := getNudgeConfig(ctx, cl, "test-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nc.Spec.Nudges).To(HaveLen(1))
+			Expect(nc.Spec.Nudges[0].From).To(Equal("comp-a"))
+			Expect(nc.Spec.Nudges[0].To).To(Equal("comp-b"))
+		})
+
+		It("filters out self-nudges", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-a"})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("skipped"))
+			Expect(s.RelationshipsFound).To(Equal(0))
+		})
+
+		It("deduplicates identical (from, to) pairs from different components", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b", "comp-b"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("created"))
+			Expect(s.RelationshipsFound).To(Equal(1))
+
+			nc, err := getNudgeConfig(ctx, cl, "test-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nc.Spec.Nudges).To(HaveLen(1))
+		})
+
+		It("detects cycles and skips namespace", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b"})
+			compB := makeComponent("test-ns", "comp-b", []string{"comp-a"})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("error"))
+			Expect(s.Errors).To(HaveLen(1))
+			Expect(s.Errors[0]).To(ContainSubstring("cycle"))
+		})
+
+		It("merges with existing NudgeConfig, adding only new entries", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b", "comp-c"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			compC := makeComponent("test-ns", "comp-c", nil)
+			existingNC := makeNudgeConfig("test-ns", []integrationv1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b", Mode: integrationv1beta2.NudgeModeImmediate},
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB, compC, existingNC).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("updated"))
+			Expect(s.RelationshipsMigrated).To(Equal(1))
+			Expect(s.RelationshipsAlreadyPresent).To(Equal(1))
+
+			nc, err := getNudgeConfig(ctx, cl, "test-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nc.Spec.Nudges).To(HaveLen(2))
+			Expect(nc.Labels).To(HaveKeyWithValue(MigrationLabel, MigrationLabelValue))
+		})
+
+		It("skips update when all relationships are already present", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			existingNC := makeNudgeConfig("test-ns", []integrationv1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b", Mode: integrationv1beta2.NudgeModeImmediate},
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB, existingNC).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("skipped"))
+			Expect(s.RelationshipsAlreadyPresent).To(Equal(1))
+			Expect(s.RelationshipsMigrated).To(Equal(0))
+		})
+
+		It("preserves user-added entries when merging", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			compC := makeComponent("test-ns", "comp-c", nil)
+			existingNC := makeNudgeConfig("test-ns", []integrationv1beta2.NudgeRelationship{
+				{From: "comp-c", To: "comp-b", Mode: integrationv1beta2.NudgeModeValidated},
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB, compC, existingNC).Build()
+
+			s := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s.Action).To(Equal("updated"))
+
+			nc, err := getNudgeConfig(ctx, cl, "test-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nc.Spec.Nudges).To(HaveLen(2))
+
+			modes := map[string]integrationv1beta2.NudgeModeType{}
+			for _, n := range nc.Spec.Nudges {
+				modes[n.From+"->"+n.To] = n.Mode
+			}
+			Expect(modes).To(HaveKeyWithValue("comp-c->comp-b", integrationv1beta2.NudgeModeValidated))
+			Expect(modes).To(HaveKeyWithValue("comp-a->comp-b", integrationv1beta2.NudgeModeImmediate))
+		})
+
+		Context("dry-run mode", func() {
+			It("does not create NudgeConfig in dry-run mode", func() {
+				compA := makeComponent("test-ns", "comp-a", []string{"comp-b"})
+				compB := makeComponent("test-ns", "comp-b", nil)
+				cl := fake.NewClientBuilder().WithScheme(scheme).
+					WithObjects(compA, compB).Build()
+
+				s := migrateNamespace(ctx, cl, logger, "test-ns", true)
+				Expect(s.Action).To(Equal("dry-run:create"))
+				Expect(s.RelationshipsMigrated).To(Equal(1))
+
+				_, err := getNudgeConfig(ctx, cl, "test-ns")
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("does not update NudgeConfig in dry-run mode", func() {
+				compA := makeComponent("test-ns", "comp-a", []string{"comp-b", "comp-c"})
+				compB := makeComponent("test-ns", "comp-b", nil)
+				compC := makeComponent("test-ns", "comp-c", nil)
+				existingNC := makeNudgeConfig("test-ns", []integrationv1beta2.NudgeRelationship{
+					{From: "comp-a", To: "comp-b", Mode: integrationv1beta2.NudgeModeImmediate},
+				})
+				cl := fake.NewClientBuilder().WithScheme(scheme).
+					WithObjects(compA, compB, compC, existingNC).Build()
+
+				s := migrateNamespace(ctx, cl, logger, "test-ns", true)
+				Expect(s.Action).To(Equal("dry-run:update"))
+				Expect(s.RelationshipsMigrated).To(Equal(1))
+
+				nc, err := getNudgeConfig(ctx, cl, "test-ns")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nc.Spec.Nudges).To(HaveLen(1))
+			})
+		})
+
+		It("is idempotent — running twice produces the same result", func() {
+			compA := makeComponent("test-ns", "comp-a", []string{"comp-b"})
+			compB := makeComponent("test-ns", "comp-b", nil)
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB).Build()
+
+			s1 := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s1.Action).To(Equal("created"))
+
+			s2 := migrateNamespace(ctx, cl, logger, "test-ns", false)
+			Expect(s2.Action).To(Equal("skipped"))
+			Expect(s2.RelationshipsAlreadyPresent).To(Equal(1))
+			Expect(s2.RelationshipsMigrated).To(Equal(0))
+
+			nc, err := getNudgeConfig(ctx, cl, "test-ns")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(nc.Spec.Nudges).To(HaveLen(1))
+		})
+	})
+
+	Describe("migrateNamespaces", func() {
+		It("processes multiple namespaces and returns correct summaries", func() {
+			compA := makeComponent("ns1", "comp-a", []string{"comp-b"})
+			compB := makeComponent("ns1", "comp-b", nil)
+			compC := makeComponent("ns2", "comp-c", nil)
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(compA, compB, compC).Build()
+
+			summaries := migrateNamespaces(ctx, cl, logger, []string{"ns1", "ns2"}, false)
+			Expect(summaries).To(HaveLen(2))
+			Expect(summaries[0].Action).To(Equal("created"))
+			Expect(summaries[1].Action).To(Equal("skipped"))
+		})
+	})
+
+	Describe("getTenantNamespaces", func() {
+		It("discovers namespaces with toolchain tenant label", func() {
+			ns := makeNamespace("tenant-1", map[string]string{
+				"toolchain.dev.openshift.com/type": "tenant",
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(ns).Build()
+
+			result, err := getTenantNamespaces(ctx, cl, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainElement("tenant-1"))
+		})
+
+		It("discovers namespaces with konflux user label", func() {
+			ns := makeNamespace("user-1", map[string]string{
+				"konflux.ci/type": "user",
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(ns).Build()
+
+			result, err := getTenantNamespaces(ctx, cl, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainElement("user-1"))
+		})
+
+		It("discovers namespaces with konflux-ci tenant label", func() {
+			ns := makeNamespace("tenant-2", map[string]string{
+				"konflux-ci.dev/type": "tenant",
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(ns).Build()
+
+			result, err := getTenantNamespaces(ctx, cl, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainElement("tenant-2"))
+		})
+
+		It("deduplicates namespaces matching multiple label selectors", func() {
+			ns := makeNamespace("multi-label", map[string]string{
+				"toolchain.dev.openshift.com/type": "tenant",
+				"konflux-ci.dev/type":              "tenant",
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(ns).Build()
+
+			result, err := getTenantNamespaces(ctx, cl, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveLen(1))
+			Expect(result).To(ContainElement("multi-label"))
+		})
+
+		It("returns sorted namespace names", func() {
+			ns1 := makeNamespace("z-ns", map[string]string{"konflux-ci.dev/type": "tenant"})
+			ns2 := makeNamespace("a-ns", map[string]string{"konflux-ci.dev/type": "tenant"})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(ns1, ns2).Build()
+
+			result, err := getTenantNamespaces(ctx, cl, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal([]string{"a-ns", "z-ns"}))
+		})
+
+		It("returns empty list when no tenant namespaces exist", func() {
+			ns := makeNamespace("regular-ns", map[string]string{
+				"some-label": "some-value",
+			})
+			cl := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(ns).Build()
+
+			result, err := getTenantNamespaces(ctx, cl, logger)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+	})
+})


### PR DESCRIPTION
…

  Implement a standalone binary that reads Component.spec.build-nudges-ref
  data across tenant namespaces and creates or merges NudgeConfig CRDs as
  part of ADR-0067 Phase 2 migration from build-service to integration-service
  owned nudging.

The script supports:
- Automatic tenant namespace discovery via label selectors
- Targeted namespace migration via positional arguments
- Dry-run mode (--dry-run) for safe pre-migration validation
- Merge-not-replace semantics preserving user-added NudgeConfig entries
- Filtering of dangling references, self-nudges, and duplicates
- Client-side DAG cycle detection before API writes
- Idempotent execution (second run is a no-op)
- Migration metadata via labels and annotations for traceability

  Test Plan

  - 25 unit tests covering merge logic, filtering, cycle detection, dry-run, and idempotency
  - Manual dry-run validated against stage and production clusters

  Assisted-By: Claude (Anthropic)

