### PR TITLE
feat(STONEINTG-1681): detect stale nudge references

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -90,6 +90,13 @@ rules:
   - list
   - watch
 - apiGroups:
+  - appstudio.redhat.com
+  resources:
+  - nudgeconfigs/status
+  verbs:
+  - get
+  - patch
+- apiGroups:
   - pipelinesascode.tekton.dev
   resources:
   - repositories

--- a/helpers/nudges.go
+++ b/helpers/nudges.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 Red Hat Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers
+
+import (
+	"fmt"
+	"strings"
+
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+)
+
+const (
+	// StaleReferencesStatusCondition is the status condition indicating if a given NudgeConfig has stale Component references
+	StaleReferencesStatusCondition = "StaleReferences"
+	// StaleReferencesDetectedReason is the status condition reason indicating that stale references were detected in the NudgeConfig
+	StaleReferencesDetectedReason = "StaleReferencesDetected"
+	// NoStaleReferencesReason is the status condition reason indicating that no stale references were detected in the NudgeConfig
+	NoStaleReferencesReason = "NoStaleReferences"
+)
+
+// FindMissingNudgeConfigReferences returns a boolean indicating any missing nudgeConfig references and an accompanying message
+// for a given list of components and nudge relationships
+func FindMissingNudgeConfigReferences(components []applicationapiv1alpha1.Component, nudges []v1beta2.NudgeRelationship, namespace string) (bool, string) {
+	existing := make(map[string]struct{}, len(components))
+	for i := range components {
+		existing[components[i].Name] = struct{}{}
+	}
+
+	var missingFrom, missingTo []string
+	seenFrom, seenTo := map[string]struct{}{}, map[string]struct{}{}
+	for _, n := range nudges {
+		if _, ok := existing[n.From]; !ok {
+			if _, dup := seenFrom[n.From]; !dup {
+				seenFrom[n.From] = struct{}{}
+				missingFrom = append(missingFrom, n.From)
+			}
+		}
+		if _, ok := existing[n.To]; !ok {
+			if _, dup := seenTo[n.To]; !dup {
+				seenTo[n.To] = struct{}{}
+				missingTo = append(missingTo, n.To)
+			}
+		}
+	}
+
+	if len(missingFrom) == 0 && len(missingTo) == 0 {
+		return false, ""
+	}
+
+	msg := fmt.Sprintf("NudgeConfig references non-existent Component(s) in namespace %q", namespace)
+	if len(missingFrom) > 0 {
+		msg += fmt.Sprintf("; missing 'from' component(s): %s", strings.Join(missingFrom, ", "))
+	}
+	if len(missingTo) > 0 {
+		msg += fmt.Sprintf("; missing 'to' component(s): %s", strings.Join(missingTo, ", "))
+	}
+	return true, msg
+}

--- a/helpers/nudges_test.go
+++ b/helpers/nudges_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Red Hat Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers_test
+
+import (
+	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func newComponent(name string) applicationapiv1alpha1.Component {
+	return applicationapiv1alpha1.Component{
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+	}
+}
+
+var _ = Describe("Helpers for nudges", func() {
+
+	Context("FindMissingNudgeConfigReferences", func() {
+		const namespace = "test-namespace"
+
+		It("returns false and an empty message when all nudge references exist", func() {
+			components := []applicationapiv1alpha1.Component{
+				newComponent("comp-a"),
+				newComponent("comp-b"),
+			}
+			nudges := []v1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(components, nudges, namespace)
+			Expect(missing).To(BeFalse())
+			Expect(msg).To(BeEmpty())
+		})
+
+		It("returns false and an empty message when nudges is empty", func() {
+			components := []applicationapiv1alpha1.Component{
+				newComponent("comp-a"),
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(components, nil, namespace)
+			Expect(missing).To(BeFalse())
+			Expect(msg).To(BeEmpty())
+		})
+
+		It("returns false and an empty message when both components and nudges are empty", func() {
+			missing, msg := helpers.FindMissingNudgeConfigReferences(nil, nil, namespace)
+			Expect(missing).To(BeFalse())
+			Expect(msg).To(BeEmpty())
+		})
+
+		It("reports missing 'from' component(s)", func() {
+			components := []applicationapiv1alpha1.Component{
+				newComponent("comp-b"),
+			}
+			nudges := []v1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(components, nudges, namespace)
+			Expect(missing).To(BeTrue())
+			Expect(msg).To(ContainSubstring(`NudgeConfig references non-existent Component(s) in namespace "test-namespace"`))
+			Expect(msg).To(ContainSubstring("missing 'from' component(s): comp-a"))
+			Expect(msg).NotTo(ContainSubstring("missing 'to'"))
+		})
+
+		It("reports missing 'to' component(s)", func() {
+			components := []applicationapiv1alpha1.Component{
+				newComponent("comp-a"),
+			}
+			nudges := []v1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(components, nudges, namespace)
+			Expect(missing).To(BeTrue())
+			Expect(msg).To(ContainSubstring(`NudgeConfig references non-existent Component(s) in namespace "test-namespace"`))
+			Expect(msg).To(ContainSubstring("missing 'to' component(s): comp-b"))
+			Expect(msg).NotTo(ContainSubstring("missing 'from'"))
+		})
+
+		It("reports both missing 'from' and 'to' component(s)", func() {
+			components := []applicationapiv1alpha1.Component{
+				newComponent("comp-existing"),
+			}
+			nudges := []v1beta2.NudgeRelationship{
+				{From: "missing-from", To: "missing-to"},
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(components, nudges, namespace)
+			Expect(missing).To(BeTrue())
+			Expect(msg).To(ContainSubstring("missing 'from' component(s): missing-from"))
+			Expect(msg).To(ContainSubstring("missing 'to' component(s): missing-to"))
+		})
+
+		It("deduplicates repeated missing 'from' and 'to' references", func() {
+			components := []applicationapiv1alpha1.Component{}
+			nudges := []v1beta2.NudgeRelationship{
+				{From: "ghost-a", To: "ghost-b"},
+				{From: "ghost-a", To: "ghost-c"},
+				{From: "ghost-d", To: "ghost-b"},
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(components, nudges, namespace)
+			Expect(missing).To(BeTrue())
+			Expect(msg).To(ContainSubstring("missing 'from' component(s): ghost-a, ghost-d"))
+			Expect(msg).To(ContainSubstring("missing 'to' component(s): ghost-b, ghost-c"))
+		})
+
+		It("reports all missing references when components list is empty", func() {
+			nudges := []v1beta2.NudgeRelationship{
+				{From: "comp-a", To: "comp-b"},
+			}
+
+			missing, msg := helpers.FindMissingNudgeConfigReferences(nil, nudges, namespace)
+			Expect(missing).To(BeTrue())
+			Expect(msg).To(Equal(
+				`NudgeConfig references non-existent Component(s) in namespace "test-namespace"; missing 'from' component(s): comp-a; missing 'to' component(s): comp-b`,
+			))
+		})
+	})
+})

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -26,6 +26,7 @@ import (
 	"strings"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/utils/strings/slices"
 
@@ -171,6 +172,12 @@ func (a *Adapter) EnsureNudgePipelineRunsExist() (controller.OperationResult, er
 		}
 		a.logger.Error(err, "Failed to get NudgeConfig")
 		return controller.RequeueWithError(err)
+	}
+
+	// Check the NudgeConfig for stale references and update if possible - best effort.
+	// Done before nudge PipelineRun creation so early returns still refresh status.
+	if staleErr := a.checkNudgeConfigForStaleReferences(nudgeConfig, a.pipelineRun.Namespace); staleErr != nil {
+		a.logger.Error(staleErr, "Failed to check nudge config for stale references, skipping")
 	}
 
 	componentName := a.component.Name
@@ -1604,4 +1611,50 @@ func (a *Adapter) emitBuildTimingSpans() {
 	if patched != nil {
 		a.pipelineRun = patched
 	}
+}
+
+// checkNudgeConfigForStaleReferences checks if the given NudgeConfig has stale references and updates its
+// stale references status condition to reflect that
+func (a *Adapter) checkNudgeConfigForStaleReferences(nudgeConfig *v1beta2.NudgeConfig, namespace string) error {
+	nudges := nudgeConfig.Spec.Nudges
+	existingStatusCondition := meta.FindStatusCondition(nudgeConfig.Status.Conditions, h.StaleReferencesStatusCondition)
+	// Short-circuit only when there is genuinely nothing to do: no nudges to check and no prior True condition to clean up.
+	// We intentionally fall through when existingStatusCondition is nil so that a fresh NudgeConfig gets an explicit
+	// StaleReferences=False condition rather than leaving the field absent. Absent is ambiguous (unknown vs healthy); False is an affirmative health signal.
+	if len(nudges) == 0 && existingStatusCondition != nil && existingStatusCondition.Status == metav1.ConditionFalse {
+		return nil
+	}
+
+	components, err := a.loader.GetAllComponentsInNamespace(a.context, a.client, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to list Components in namespace %q: %w", namespace, err)
+	}
+
+	foundMissing, msg := h.FindMissingNudgeConfigReferences(*components, nudges, namespace)
+	var newConditionStatus metav1.ConditionStatus
+	var newConditionReason string
+	if foundMissing {
+		newConditionStatus = metav1.ConditionTrue
+		newConditionReason = h.StaleReferencesDetectedReason
+	} else {
+		newConditionStatus = metav1.ConditionFalse
+		newConditionReason = h.NoStaleReferencesReason
+		msg = "All Components referenced in the NudgeConfig are present, no stale references found."
+	}
+
+	if existingStatusCondition == nil || (existingStatusCondition.Status != newConditionStatus || existingStatusCondition.Message != msg) {
+		patch := client.MergeFrom(nudgeConfig.DeepCopy())
+		meta.SetStatusCondition(&nudgeConfig.Status.Conditions, metav1.Condition{
+			Type:    h.StaleReferencesStatusCondition,
+			Status:  newConditionStatus,
+			Reason:  newConditionReason,
+			Message: msg,
+		})
+
+		err = a.client.Status().Patch(a.context, nudgeConfig, patch)
+		if err != nil {
+			return fmt.Errorf("failed to patch nudge config status: %w", err)
+		}
+	}
+	return nil
 }

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -44,6 +44,7 @@ import (
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.uber.org/mock/gomock"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/strings/slices"
 
@@ -4220,6 +4221,270 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
 				g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("no-matching-edges"))
 			}, time.Second*5).Should(Succeed())
+		})
+
+		Context("when checking NudgeConfig for stale Component references", func() {
+			var nudgeConfig *v1beta2.NudgeConfig
+
+			BeforeEach(func() {
+				nudgeConfig = &v1beta2.NudgeConfig{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      v1beta2.NudgeConfigSingletonName,
+						Namespace: "default",
+					},
+					Spec: v1beta2.NudgeConfigSpec{
+						Nudges: []v1beta2.NudgeRelationship{
+							{From: "other-component", To: "ghost-component", Mode: v1beta2.NudgeModeImmediate},
+						},
+					},
+				}
+				Expect(k8sClient.Create(ctx, nudgeConfig)).Should(Succeed())
+				Eventually(func(g Gomega) {
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), nudgeConfig)).To(Succeed())
+				}, time.Second*5).Should(Succeed())
+			})
+
+			AfterEach(func() {
+				err := k8sClient.Delete(ctx, nudgeConfig)
+				Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+			})
+
+			It("sets StaleReferences to True for orphaned references before continuing with no-matching-edges", func() {
+				pushPLR := makePushPLR()
+				adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+					{
+						ContextKey: loader.NudgeConfigContextKey,
+						Resource:   nudgeConfig,
+					},
+					{
+						ContextKey: loader.NamespaceComponentsContextKey,
+						Resource: []applicationapiv1alpha1.Component{
+							*hasComp,
+						},
+					},
+				})
+
+				result, err := adapter.EnsureNudgePipelineRunsExist()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.CancelRequest).To(BeFalse())
+				Expect(result.RequeueRequest).To(BeFalse())
+
+				Eventually(func(g Gomega) {
+					updated := &v1beta2.NudgeConfig{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), updated)).To(Succeed())
+					cond := meta.FindStatusCondition(updated.Status.Conditions, helpers.StaleReferencesStatusCondition)
+					g.Expect(cond).NotTo(BeNil())
+					g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+					g.Expect(cond.Reason).To(Equal(helpers.StaleReferencesDetectedReason))
+					g.Expect(cond.Message).To(ContainSubstring("missing 'from' component(s): other-component"))
+					g.Expect(cond.Message).To(ContainSubstring("missing 'to' component(s): ghost-component"))
+				}, time.Second*5).Should(Succeed())
+
+				Eventually(func(g Gomega) {
+					updatedPLR := &tektonv1.PipelineRun{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+					g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("no-matching-edges"))
+				}, time.Second*5).Should(Succeed())
+			})
+
+			It("continues processing when the stale-references status update fails", func() {
+				pushPLR := makePushPLR()
+				Expect(k8sClient.Delete(ctx, nudgeConfig)).Should(Succeed())
+				Eventually(func() bool {
+					err := k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), &v1beta2.NudgeConfig{})
+					return k8serrors.IsNotFound(err)
+				}, time.Second*5).Should(BeTrue())
+
+				adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+				adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+					{
+						ContextKey: loader.NudgeConfigContextKey,
+						Resource:   nudgeConfig,
+					},
+					{
+						ContextKey: loader.NamespaceComponentsContextKey,
+						Resource: []applicationapiv1alpha1.Component{
+							*hasComp,
+						},
+					},
+				})
+
+				result, err := adapter.EnsureNudgePipelineRunsExist()
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.CancelRequest).To(BeFalse())
+				Expect(result.RequeueRequest).To(BeFalse())
+
+				Eventually(func(g Gomega) {
+					updatedPLR := &tektonv1.PipelineRun{}
+					g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(buildPipelineRun), updatedPLR)).To(Succeed())
+					g.Expect(updatedPLR.Annotations[tektonconsts.NudgeProcessedAnnotation]).To(Equal("no-matching-edges"))
+				}, time.Second*5).Should(Succeed())
+			})
+		})
+	})
+
+	When("checkNudgeConfigForStaleReferences is called", func() {
+		var nudgeConfig *v1beta2.NudgeConfig
+
+		BeforeEach(func() {
+			nudgeConfig = &v1beta2.NudgeConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      v1beta2.NudgeConfigSingletonName,
+					Namespace: "default",
+				},
+				Spec: v1beta2.NudgeConfigSpec{
+					Nudges: []v1beta2.NudgeRelationship{
+						{From: hasComp.Name, To: hasComp2.Name, Mode: v1beta2.NudgeModeImmediate},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, nudgeConfig)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), nudgeConfig)).To(Succeed())
+			}, time.Second*5).Should(Succeed())
+
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+		})
+
+		AfterEach(func() {
+			err := k8sClient.Delete(ctx, nudgeConfig)
+			Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+		})
+
+		It("sets the initial condition when NudgeConfig has no nudge relationships and no stale references status condition", func() {
+			nudgeConfig.Spec.Nudges = nil
+			Expect(adapter.checkNudgeConfigForStaleReferences(nudgeConfig, "default")).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &v1beta2.NudgeConfig{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, helpers.StaleReferencesStatusCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(helpers.NoStaleReferencesReason))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("returns nil when NudgeConfig has no nudge relationships and already has the stale references status condition", func() {
+			nudgeConfig.Spec.Nudges = nil
+
+			meta.SetStatusCondition(&nudgeConfig.Status.Conditions, metav1.Condition{
+				Type:    helpers.StaleReferencesStatusCondition,
+				Status:  metav1.ConditionFalse,
+				Reason:  helpers.NoStaleReferencesReason,
+				Message: "All Components referenced in the NudgeConfig are present, no stale references found.",
+			})
+
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NamespaceComponentsContextKey,
+					Err:        fmt.Errorf("list components failed"),
+				},
+			})
+			Expect(adapter.checkNudgeConfigForStaleReferences(nudgeConfig, "default")).To(Succeed())
+		})
+
+		It("sets the StaleReferences condition to ConditionTrue when orphaned references exist", func() {
+			nudgeConfig.Spec.Nudges = []v1beta2.NudgeRelationship{
+				{From: hasComp.Name, To: "missing-component", Mode: v1beta2.NudgeModeImmediate},
+			}
+			Expect(k8sClient.Update(ctx, nudgeConfig)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), nudgeConfig)).To(Succeed())
+				nudge := nudgeConfig.Spec.Nudges[0]
+				g.Expect(nudge.To).To(Equal("missing-component"))
+			}, time.Second*5).Should(Succeed())
+
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NamespaceComponentsContextKey,
+					Resource: []applicationapiv1alpha1.Component{
+						*hasComp,
+					},
+				},
+			})
+			Expect(adapter.checkNudgeConfigForStaleReferences(nudgeConfig, "default")).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &v1beta2.NudgeConfig{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, helpers.StaleReferencesStatusCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+				g.Expect(cond.Reason).To(Equal(helpers.StaleReferencesDetectedReason))
+				g.Expect(cond.Message).To(ContainSubstring("missing 'to' component(s): missing-component"))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("sets the StaleReferences condition to ConditionFalse when all references are valid", func() {
+			meta.SetStatusCondition(&nudgeConfig.Status.Conditions, metav1.Condition{
+				Type:    helpers.StaleReferencesStatusCondition,
+				Status:  metav1.ConditionTrue,
+				Reason:  "StaleReferences",
+				Message: "previously stale",
+			})
+			Expect(k8sClient.Status().Update(ctx, nudgeConfig)).Should(Succeed())
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), nudgeConfig)).To(Succeed())
+				g.Expect(meta.FindStatusCondition(nudgeConfig.Status.Conditions, helpers.StaleReferencesStatusCondition).Status).To(Equal(metav1.ConditionTrue))
+			}, time.Second*5).Should(Succeed())
+
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NamespaceComponentsContextKey,
+					Resource: []applicationapiv1alpha1.Component{
+						*hasComp,
+						*hasComp2,
+					},
+				},
+			})
+			Expect(adapter.checkNudgeConfigForStaleReferences(nudgeConfig, "default")).To(Succeed())
+
+			Eventually(func(g Gomega) {
+				updated := &v1beta2.NudgeConfig{}
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), updated)).To(Succeed())
+				cond := meta.FindStatusCondition(updated.Status.Conditions, helpers.StaleReferencesStatusCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionFalse))
+				g.Expect(cond.Reason).To(Equal(helpers.NoStaleReferencesReason))
+				g.Expect(cond.Message).To(Equal("All Components referenced in the NudgeConfig are present, no stale references found."))
+			}, time.Second*5).Should(Succeed())
+		})
+
+		It("returns an error when listing Components fails", func() {
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NamespaceComponentsContextKey,
+					Err:        fmt.Errorf("list components failed"),
+				},
+			})
+			err := adapter.checkNudgeConfigForStaleReferences(nudgeConfig, "default")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(`failed to list Components in namespace "default"`))
+		})
+
+		It("returns an error when the status patch fails", func() {
+			Expect(k8sClient.Delete(ctx, nudgeConfig)).Should(Succeed())
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), &v1beta2.NudgeConfig{})
+				return k8serrors.IsNotFound(err)
+			}, time.Second*5).Should(BeTrue())
+
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.NamespaceComponentsContextKey,
+					Resource: []applicationapiv1alpha1.Component{
+						*hasComp,
+					},
+				},
+			})
+			nudgeConfig.Spec.Nudges = []v1beta2.NudgeRelationship{
+				{From: hasComp.Name, To: "missing-component", Mode: v1beta2.NudgeModeImmediate},
+			}
+			err := adapter.checkNudgeConfigForStaleReferences(nudgeConfig, "default")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to patch nudge config status"))
 		})
 	})
 

--- a/internal/controller/buildpipeline/buildpipeline_controller.go
+++ b/internal/controller/buildpipeline/buildpipeline_controller.go
@@ -65,6 +65,7 @@ func NewIntegrationReconciler(client client.Client, logger *logr.Logger, scheme 
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch
 //+kubebuilder:rbac:groups=pipelinesascode.tekton.dev,resources=repositories,verbs=get;list;watch
 //+kubebuilder:rbac:groups=appstudio.redhat.com,resources=nudgeconfigs,verbs=get;list;watch
+//+kubebuilder:rbac:groups=appstudio.redhat.com,resources=nudgeconfigs/status,verbs=get;patch
 //+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list
 

--- a/internal/webhook/v1beta2/nudgeconfig_webhook.go
+++ b/internal/webhook/v1beta2/nudgeconfig_webhook.go
@@ -21,10 +21,10 @@ import (
 	"errors"
 	"fmt"
 	"reflect"
-	"strings"
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
 	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/helpers"
 	"github.com/konflux-ci/integration-service/pkg/dag"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -129,41 +129,13 @@ func (v *NudgeConfigCustomValidator) validateComponentsExist(ctx context.Context
 		return fmt.Errorf("failed to list Components in namespace %q: %w", namespace, err)
 	}
 
-	existing := make(map[string]struct{}, len(componentList.Items))
-	for i := range componentList.Items {
-		existing[componentList.Items[i].Name] = struct{}{}
-	}
+	hasStaleReferences, msg := helpers.FindMissingNudgeConfigReferences(componentList.Items, nudges, namespace)
 
-	var missingFrom, missingTo []string
-	seenFrom, seenTo := map[string]struct{}{}, map[string]struct{}{}
-	for _, n := range nudges {
-		if _, ok := existing[n.From]; !ok {
-			if _, dup := seenFrom[n.From]; !dup {
-				seenFrom[n.From] = struct{}{}
-				missingFrom = append(missingFrom, n.From)
-			}
-		}
-		if _, ok := existing[n.To]; !ok {
-			if _, dup := seenTo[n.To]; !dup {
-				seenTo[n.To] = struct{}{}
-				missingTo = append(missingTo, n.To)
-			}
-		}
+	if hasStaleReferences {
+		nudgeconfiglog.V(1).Info(msg)
+		return errors.New(msg)
 	}
-
-	if len(missingFrom) == 0 && len(missingTo) == 0 {
-		return nil
-	}
-
-	msg := fmt.Sprintf("NudgeConfig references non-existent Component(s) in namespace %q", namespace)
-	if len(missingFrom) > 0 {
-		msg += fmt.Sprintf("; missing 'from' component(s): %s", strings.Join(missingFrom, ", "))
-	}
-	if len(missingTo) > 0 {
-		msg += fmt.Sprintf("; missing 'to' component(s): %s", strings.Join(missingTo, ", "))
-	}
-	nudgeconfiglog.V(1).Info(msg)
-	return errors.New(msg)
+	return nil
 }
 
 func nudgeKey(n v1beta2.NudgeRelationship) string { return n.From + "\x00" + n.To }

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -44,6 +44,7 @@ import (
 type ObjectLoader interface {
 	GetReleasesWithSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*[]releasev1alpha1.Release, error)
 	GetAllApplicationComponents(ctx context.Context, c client.Client, application *applicationapiv1alpha1.Application) (*[]applicationapiv1alpha1.Component, error)
+	GetAllComponentsInNamespace(ctx context.Context, c client.Client, namespace string) (*[]applicationapiv1alpha1.Component, error)
 	GetAllComponentGroupComponents(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) (*[]applicationapiv1alpha1.Component, error)
 	GetApplicationFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*applicationapiv1alpha1.Application, error)
 	GetComponentGroupFromSnapshot(ctx context.Context, c client.Client, snapshot *applicationapiv1alpha1.Snapshot) (*v1beta2.ComponentGroup, error)
@@ -128,6 +129,21 @@ func (l *loader) GetAllApplicationComponents(ctx context.Context, c client.Clien
 	}
 
 	return &applicationComponents.Items, nil
+}
+
+// GetAllComponentsInNamespace loads from the cluster all Components located in the given namespace.
+func (l *loader) GetAllComponentsInNamespace(ctx context.Context, c client.Client, namespace string) (*[]applicationapiv1alpha1.Component, error) {
+	namespaceComponents := &applicationapiv1alpha1.ComponentList{}
+	opts := []client.ListOption{
+		client.InNamespace(namespace),
+	}
+
+	err := c.List(ctx, namespaceComponents, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &namespaceComponents.Items, nil
 }
 
 func (l *loader) GetAllComponentGroupComponents(ctx context.Context, c client.Client, componentGroup *v1beta2.ComponentGroup) (*[]applicationapiv1alpha1.Component, error) {

--- a/loader/loader_mock.go
+++ b/loader/loader_mock.go
@@ -77,6 +77,7 @@ const (
 	GetPushComponentSnapshotsForComponentContextKey
 	ComponentGroupComponentsContextKey
 	NudgeConfigContextKey
+	NamespaceComponentsContextKey
 )
 
 func NewMockLoader() ObjectLoader {
@@ -100,6 +101,15 @@ func (l *mockLoader) GetAllApplicationComponents(ctx context.Context, c client.C
 		return l.loader.GetAllApplicationComponents(ctx, c, application)
 	}
 	components, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, ApplicationComponentsContextKey, []applicationapiv1alpha1.Component{})
+	return &components, err
+}
+
+// GetAllComponentsInNamespace returns the resource and error passed as values of the context.
+func (l *mockLoader) GetAllComponentsInNamespace(ctx context.Context, c client.Client, namespace string) (*[]applicationapiv1alpha1.Component, error) {
+	if ctx.Value(NamespaceComponentsContextKey) == nil {
+		return l.loader.GetAllComponentsInNamespace(ctx, c, namespace)
+	}
+	components, err := toolkit.GetMockedResourceAndErrorFromContext(ctx, NamespaceComponentsContextKey, []applicationapiv1alpha1.Component{})
 	return &components, err
 }
 

--- a/loader/loader_mock_test.go
+++ b/loader/loader_mock_test.go
@@ -67,6 +67,21 @@ var _ = Describe("Release Adapter", Ordered, func() {
 		})
 	})
 
+	Context("When calling GetAllComponentsInNamespace", func() {
+		It("returns resource and error from the context", func() {
+			namespaceComponents := []applicationapiv1alpha1.Component{}
+			mockContext := toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: NamespaceComponentsContextKey,
+					Resource:   namespaceComponents,
+				},
+			})
+			resource, err := loader.GetAllComponentsInNamespace(mockContext, nil, "default")
+			Expect(resource).To(Equal(&namespaceComponents))
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
 	Context("When calling GetAllComponentGroupComponents", func() {
 		It("returns resource and error from the context", func() {
 			groupComponents := []applicationapiv1alpha1.Component{}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -692,6 +692,12 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(applicationComponents).NotTo(BeNil())
 	})
 
+	It("ensures the Components in Namespace can be found ", func() {
+		namespaceComponents, err := loader.GetAllComponentsInNamespace(ctx, k8sClient, namespace)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(namespaceComponents).NotTo(BeNil())
+	})
+
 	It("ensures the ComponentGroup Components can be found ", func() {
 		componentGroupComponents, err := loader.GetAllComponentGroupComponents(ctx, k8sClient, hasComponentGroup1)
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
* Add stale reference handling - detect orphaned entries in NudgeConfig after Component deletion
* Consolildate the logic for this so it can be used both in webhooks and controllers

Assisted-by: Cursor

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
