### PR TITLE
feat(stoneintg-1692): support basic e2e tests for ComponentGroup

### DIFF
--- a/e2e-tests/pkg/clients/has/componentgroups.go
+++ b/e2e-tests/pkg/clients/has/componentgroups.go
@@ -1,0 +1,104 @@
+package has
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/konflux-ci/integration-service/api/v1beta2"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+	rclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// GetComponentGroup returns a component group given a name and namespace from kubernetes cluster.
+func (h *HasController) GetComponentGroup(name string, namespace string) (*v1beta2.ComponentGroup, error) {
+	componentGroup := v1beta2.ComponentGroup{
+		Spec: v1beta2.ComponentGroupSpec{},
+	}
+	if err := h.KubeRest().Get(context.Background(), types.NamespacedName{Name: name, Namespace: namespace}, &componentGroup); err != nil {
+		return nil, err
+	}
+
+	return &componentGroup, nil
+}
+
+// CreateComponentGroup creates a ComponentGroup object with a default timeout of
+// 10 minutes. The timeout covers only the API write; controller reconciliation
+// (status.globalCandidateList population) happens asynchronously and must be waited on separately.
+func (h *HasController) CreateComponentGroup(name string, namespace string, components []v1beta2.ComponentReference) (*v1beta2.ComponentGroup, error) {
+	return h.CreateComponentGroupWithTimeout(name, namespace, components, time.Minute*10)
+}
+
+// CreateComponentGroupWithTimeout creates a component group in the kubernetes cluster with a custom default time for creation.
+func (h *HasController) CreateComponentGroupWithTimeout(name string, namespace string, components []v1beta2.ComponentReference, timeout time.Duration) (*v1beta2.ComponentGroup, error) {
+	componentGroup := &v1beta2.ComponentGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: v1beta2.ComponentGroupSpec{
+			Components: components,
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	if err := h.KubeRest().Create(ctx, componentGroup); err != nil {
+		return nil, err
+	}
+
+	return componentGroup, nil
+}
+
+// DeleteComponentGroup delete a ComponentGroup resource from the namespace.
+// Optionally, it can avoid returning an error if the resource did not exist:
+// - specify 'false', if it's likely the ComponentGroup has already been deleted (for example, because the Namespace was deleted)
+func (h *HasController) DeleteComponentGroup(name string, namespace string, reportErrorOnNotFound bool) error {
+	componentGroup := v1beta2.ComponentGroup{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+	if err := h.KubeRest().Delete(context.Background(), &componentGroup); err != nil {
+		if !k8sErrors.IsNotFound(err) || (k8sErrors.IsNotFound(err) && reportErrorOnNotFound) {
+			return fmt.Errorf("error deleting a component group: %+v", err)
+		}
+	}
+	return utils.WaitUntil(h.ComponentGroupDeleted(&componentGroup), 1*time.Minute)
+}
+
+// ComponentGroupDeleted check if a given componentGroup object was deleted successfully from the kubernetes cluster.
+func (h *HasController) ComponentGroupDeleted(componentGroup *v1beta2.ComponentGroup) wait.ConditionFunc {
+	return func() (bool, error) {
+		_, err := h.GetComponentGroup(componentGroup.Name, componentGroup.Namespace)
+		return err != nil && k8sErrors.IsNotFound(err), nil
+	}
+}
+
+// DeleteAllComponentGroupsInASpecificNamespace removes all componentGroup CRs from a specific namespace. Useful when creating a lot of resources and want to remove all of them
+func (h *HasController) DeleteAllComponentGroupsInASpecificNamespace(namespace string, timeout time.Duration) error {
+	if err := h.KubeRest().DeleteAllOf(context.Background(), &v1beta2.ComponentGroup{}, rclient.InNamespace(namespace)); err != nil {
+		return fmt.Errorf("error deleting componentGroups from the namespace %s: %+v", namespace, err)
+	}
+
+	return utils.WaitUntil(func() (done bool, err error) {
+		componentGroupList, err := h.ListAllComponentGroups(namespace)
+		if err != nil {
+			return false, nil
+		}
+		return len(componentGroupList.Items) == 0, nil
+	}, timeout)
+}
+
+// ListAllComponentGroups returns a list of all ComponentGroups in a given namespace.
+func (h *HasController) ListAllComponentGroups(namespace string) (*v1beta2.ComponentGroupList, error) {
+	componentGroupList := &v1beta2.ComponentGroupList{}
+	err := h.KubeRest().List(context.Background(), componentGroupList, &rclient.ListOptions{Namespace: namespace})
+
+	return componentGroupList, err
+}

--- a/e2e-tests/pkg/clients/has/components.go
+++ b/e2e-tests/pkg/clients/has/components.go
@@ -59,13 +59,13 @@ func (h *HasController) GetComponentByApplicationName(applicationName string, na
 }
 
 // GetComponentPipeline returns first pipeline run for a given component labels
-func (h *HasController) GetComponentPipelineRun(componentName, applicationName, namespace, sha string) (*pipeline.PipelineRun, error) {
-	return h.GetComponentPipelineRunWithType(componentName, applicationName, namespace, "", sha, "")
+func (h *HasController) GetComponentPipelineRun(componentName, namespace, sha string) (*pipeline.PipelineRun, error) {
+	return h.GetComponentPipelineRunWithType(componentName, namespace, "", sha, "")
 }
 
 // GetComponentPipelineRunWithType returns first pipeline run for a given component labels with pipeline type within label "pipelines.appstudio.openshift.io/type" ("build", "test")
-func (h *HasController) GetComponentPipelineRunWithType(componentName string, applicationName string, namespace, pipelineType string, sha string, eventType string) (*pipeline.PipelineRun, error) {
-	prs, err := h.GetComponentPipelineRunsWithType(componentName, applicationName, namespace, pipelineType, sha, eventType)
+func (h *HasController) GetComponentPipelineRunWithType(componentName string, namespace, pipelineType string, sha string, eventType string) (*pipeline.PipelineRun, error) {
+	prs, err := h.GetComponentPipelineRunsWithType(componentName, namespace, pipelineType, sha, eventType)
 	if err != nil {
 		return nil, err
 	} else {
@@ -75,8 +75,8 @@ func (h *HasController) GetComponentPipelineRunWithType(componentName string, ap
 }
 
 // GetComponentPipelineRunsWithType returns all pipeline runs for a given component labels with pipeline type within label "pipelines.appstudio.openshift.io/type" ("build", "test")
-func (h *HasController) GetComponentPipelineRunsWithType(componentName string, applicationName string, namespace, pipelineType string, sha string, eventType string) (*[]pipeline.PipelineRun, error) {
-	pipelineRunLabels := map[string]string{tektonconsts.PipelineRunComponentLabel: componentName, tektonconsts.PipelineRunApplicationLabel: applicationName}
+func (h *HasController) GetComponentPipelineRunsWithType(componentName string, namespace, pipelineType string, sha string, eventType string) (*[]pipeline.PipelineRun, error) {
+	pipelineRunLabels := map[string]string{tektonconsts.PipelineRunComponentLabel: componentName}
 	if pipelineType != "" {
 		pipelineRunLabels[tektonconsts.PipelineRunTypeLabel] = pipelineType
 	}
@@ -182,7 +182,6 @@ type RetryOptions struct {
 // If there's no intention for using the original PLR object later in the test, use `nil` instead of the pointer.
 func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservice.Component, pipelineType, sha, eventType string, t *tekton.TektonController, r *RetryOptions, prToUpdate *pipeline.PipelineRun) error {
 	attempts := 1
-	app := component.Spec.Application
 	pr := &pipeline.PipelineRun{}
 
 	// Fail fast if the PipelineRun is never created.
@@ -195,7 +194,7 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 		prFound := false
 
 		err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-			pr, err = h.GetComponentPipelineRunWithType(component.GetName(), app, component.GetNamespace(), pipelineType, sha, eventType)
+			pr, err = h.GetComponentPipelineRunWithType(component.GetName(), component.GetNamespace(), pipelineType, sha, eventType)
 
 			if err != nil {
 				if !prFound && time.Now().After(creationDeadline) {
@@ -269,10 +268,10 @@ func (h *HasController) WaitForComponentPipelineToBeFinished(component *appservi
 }
 
 // Universal method to create a component in the kubernetes clusters.
-func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, namespace string, outputContainerImage string, secret string, applicationName string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
+func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, name, namespace string, outputContainerImage string, secret string, applicationName string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
 	componentObject := &appservice.Component{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      componentSpec.ComponentName,
+			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
 				"skip-initial-checks": strconv.FormatBool(skipInitialChecks),
@@ -280,8 +279,12 @@ func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, 
 		},
 		Spec: componentSpec,
 	}
-	componentObject.Spec.Secret = secret
-	componentObject.Spec.Application = applicationName
+	// TODO: remove when we remove support for applications
+	// Also remove applicationName and secret parameters from function
+	if applicationName != "" {
+		componentObject.Spec.Application = applicationName
+		componentObject.Spec.Secret = secret
+	}
 
 	if len(annotations) > 0 {
 		componentObject.Annotations = utils.MergeMaps(componentObject.Annotations, annotations)
@@ -308,15 +311,15 @@ func (h *HasController) CreateComponent(componentSpec appservice.ComponentSpec, 
 }
 
 // Create a component and check image repository gets created.
-func (h *HasController) CreateComponentCheckImageRepository(componentSpec appservice.ComponentSpec, namespace string, outputContainerImage string, secret string, applicationName string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
-	componentObject, err := h.CreateComponent(componentSpec, namespace, outputContainerImage, secret, applicationName, skipInitialChecks, annotations)
+func (h *HasController) CreateComponentCheckImageRepository(componentSpec appservice.ComponentSpec, name, namespace string, outputContainerImage string, secret string, applicationName string, skipInitialChecks bool, annotations map[string]string) (*appservice.Component, error) {
+	componentObject, err := h.CreateComponent(componentSpec, name, namespace, outputContainerImage, secret, applicationName, skipInitialChecks, annotations)
 	if err != nil {
 		return nil, err
 	}
 
 	// Decrease the timeout to 5 mins, when the issue https://issues.redhat.com/browse/STONEBLD-3552 is fixed
-	if err := utils.WaitUntilWithInterval(h.CheckImageRepositoryExists(namespace, componentSpec.ComponentName), time.Second*10, time.Minute*15); err != nil {
-		return nil, fmt.Errorf("timed out waiting for image repository to be ready for component %s in namespace %s: %+v", componentSpec.ComponentName, namespace, err)
+	if err := utils.WaitUntilWithInterval(h.CheckImageRepositoryExists(namespace, name), time.Second*10, time.Minute*15); err != nil {
+		return nil, fmt.Errorf("timed out waiting for image repository to be ready for component %s in namespace %s: %+v", name, namespace, err)
 	}
 
 	return componentObject, nil

--- a/e2e-tests/pkg/clients/integration/integration_test_scenarios.go
+++ b/e2e-tests/pkg/clients/integration/integration_test_scenarios.go
@@ -13,7 +13,8 @@ import (
 )
 
 // CreateIntegrationTestScenario creates beta1 version integrationTestScenario.
-func (i *IntegrationController) CreateIntegrationTestScenario(itsName, applicationName, namespace, gitURL, revision, pathInRepo, kind string, contexts []string) (*integrationv1beta2.IntegrationTestScenario, error) {
+// TODO: when we remove application-specific code, remove usingComponentGroups param and change parentName to componentGroupName
+func (i *IntegrationController) CreateIntegrationTestScenario(itsName, parentName, namespace, gitURL, revision, pathInRepo, kind string, contexts []string, usingComponentGroups bool) (*integrationv1beta2.IntegrationTestScenario, error) {
 	if itsName == "" {
 		itsName = "integration-test-" + utils.GenerateRandomString(4)
 	}
@@ -40,13 +41,17 @@ func (i *IntegrationController) CreateIntegrationTestScenario(itsName, applicati
 			Labels:    constants.IntegrationTestScenarioDefaultLabels,
 		},
 		Spec: integrationv1beta2.IntegrationTestScenarioSpec{
-			Application: applicationName,
 			ResolverRef: integrationv1beta2.ResolverRef{
 				Resolver: "git",
 				Params:   params,
 			},
 			Contexts: []integrationv1beta2.TestContext{},
 		},
+	}
+	if usingComponentGroups {
+		integrationTestScenario.Spec.ComponentGroup = parentName
+	} else {
+		integrationTestScenario.Spec.Application = parentName
 	}
 
 	// Add kind parameter if provided and is "pipelineRun"
@@ -71,7 +76,8 @@ func (i *IntegrationController) CreateIntegrationTestScenario(itsName, applicati
 
 // CreateOptionalIntegrationTestScenario creates a beta1 version integrationTestScenario with optional: true label.
 // This function is identical to CreateIntegrationTestScenario except it sets the optional label to "true".
-func (i *IntegrationController) CreateOptionalIntegrationTestScenario(itsName, applicationName, namespace, gitURL, revision, pathInRepo, kind string, contexts []string) (*integrationv1beta2.IntegrationTestScenario, error) {
+// TODO: when we remove application-specific code, remove usingComponentGroups param and change parentName to componentGroupName
+func (i *IntegrationController) CreateOptionalIntegrationTestScenario(itsName, parentName, namespace, gitURL, revision, pathInRepo, kind string, contexts []string, usingComponentGroups bool) (*integrationv1beta2.IntegrationTestScenario, error) {
 	if itsName == "" {
 		itsName = "integration-test-" + utils.GenerateRandomString(4)
 	}
@@ -98,13 +104,17 @@ func (i *IntegrationController) CreateOptionalIntegrationTestScenario(itsName, a
 			Labels:    map[string]string{tektonconsts.OptionalLabel: "true"},
 		},
 		Spec: integrationv1beta2.IntegrationTestScenarioSpec{
-			Application: applicationName,
 			ResolverRef: integrationv1beta2.ResolverRef{
 				Resolver: "git",
 				Params:   params,
 			},
 			Contexts: []integrationv1beta2.TestContext{},
 		},
+	}
+	if usingComponentGroups {
+		integrationTestScenario.Spec.ComponentGroup = parentName
+	} else {
+		integrationTestScenario.Spec.Application = parentName
 	}
 
 	// Add kind parameter if provided and is "pipelineRun"
@@ -128,7 +138,8 @@ func (i *IntegrationController) CreateOptionalIntegrationTestScenario(itsName, a
 }
 
 // Get return the status from the Application Custom Resource object.
-func (i *IntegrationController) GetIntegrationTestScenarios(applicationName, namespace string) (*[]integrationv1beta2.IntegrationTestScenario, error) {
+// TODO: when we remove application-specific code, remove usingComponentGroups param and change parentName to componentGroupName
+func (i *IntegrationController) GetIntegrationTestScenarios(parentName, namespace string, usingComponentGroups bool) (*[]integrationv1beta2.IntegrationTestScenario, error) {
 	opts := []client.ListOption{
 		client.InNamespace(namespace),
 	}
@@ -141,8 +152,14 @@ func (i *IntegrationController) GetIntegrationTestScenarios(applicationName, nam
 
 	items := make([]integrationv1beta2.IntegrationTestScenario, 0)
 	for _, t := range integrationTestScenarioList.Items {
-		if t.Spec.Application == applicationName {
-			items = append(items, t)
+		if usingComponentGroups {
+			if t.Spec.ComponentGroup == parentName {
+				items = append(items, t)
+			}
+		} else {
+			if t.Spec.Application == parentName {
+				items = append(items, t)
+			}
 		}
 	}
 	return &items, nil

--- a/e2e-tests/pkg/clients/integration/pipelineruns.go
+++ b/e2e-tests/pkg/clients/integration/pipelineruns.go
@@ -32,11 +32,16 @@ var (
 
 // GetComponentPipeline returns the pipeline for a given component labels.
 // In case of failure, this function retries till it gets timed out.
-func (i *IntegrationController) GetBuildPipelineRun(componentName, applicationName, namespace string, pacBuild bool, sha string) (*tektonv1.PipelineRun, error) {
+// TODO: when we remove the old application-specific code, remove the usingComponentGroups, parentName, and pacBuild parameters
+// NOTE: build PLRs do not set a componentGroup label
+func (i *IntegrationController) GetBuildPipelineRun(componentName, parentName, namespace string, pacBuild bool, sha string, usingComponentGroups bool) (*tektonv1.PipelineRun, error) {
 	var pipelineRun *tektonv1.PipelineRun
 
 	err := wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, superLongTimeout, true, func(ctx context.Context) (done bool, err error) {
-		pipelineRunLabels := map[string]string{tektonconsts.PipelineRunComponentLabel: componentName, tektonconsts.PipelineRunApplicationLabel: applicationName, tektonconsts.PipelineRunTypeLabel: tektonconsts.PipelineRunBuildType}
+		pipelineRunLabels := map[string]string{tektonconsts.PipelineRunComponentLabel: componentName, tektonconsts.PipelineRunTypeLabel: tektonconsts.PipelineRunBuildType}
+		if !usingComponentGroups {
+			pipelineRunLabels[tektonconsts.PipelineRunApplicationLabel] = parentName
+		}
 
 		if sha != "" {
 			pipelineRunLabels["pipelinesascode.tekton.dev/sha"] = sha
@@ -61,7 +66,7 @@ func (i *IntegrationController) GetBuildPipelineRun(componentName, applicationNa
 		}
 
 		pipelineRun = &tektonv1.PipelineRun{}
-		ginkgo.GinkgoWriter.Printf("no pipelinerun found for component %s %s", componentName, utils.GetAdditionalInfo(applicationName, namespace))
+		ginkgo.GinkgoWriter.Printf("no pipelinerun found for component %s %s", componentName, utils.GetAdditionalInfo(parentName, namespace))
 		return false, nil
 	})
 
@@ -151,10 +156,10 @@ func (i *IntegrationController) isScenarioInExpectedScenarios(testScenario *inte
 }
 
 // WaitForAllIntegrationPipelinesToBeFinished wait for all integration pipelines to finish.
-func (i *IntegrationController) WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName string, snapshot *appstudioApi.Snapshot, expectedTestScenarios []string) error {
-	integrationTestScenarios, err := i.GetIntegrationTestScenarios(applicationName, testNamespace)
+func (i *IntegrationController) WaitForAllIntegrationPipelinesToBeFinished(testNamespace, parentName string, snapshot *appstudioApi.Snapshot, expectedTestScenarios []string, usingComponentGroups bool) error {
+	integrationTestScenarios, err := i.GetIntegrationTestScenarios(parentName, testNamespace, usingComponentGroups)
 	if err != nil {
-		return fmt.Errorf("unable to get IntegrationTestScenarios for Application %s/%s. Error: %v", testNamespace, applicationName, err)
+		return fmt.Errorf("unable to get IntegrationTestScenarios for Application %s/%s. Error: %v", testNamespace, parentName, err)
 	}
 
 	for _, testScenario := range *integrationTestScenarios {
@@ -174,10 +179,10 @@ func (i *IntegrationController) WaitForAllIntegrationPipelinesToBeFinished(testN
 // WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns waits for
 // the given finalizer to get removed from all integration pipelinesruns
 // that are related to the given application and namespace.
-func (i *IntegrationController) WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName string, snapshot *appstudioApi.Snapshot, expectedTestScenarios []string) error {
-	integrationTestScenarios, err := i.GetIntegrationTestScenarios(applicationName, testNamespace)
+func (i *IntegrationController) WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, parentName string, snapshot *appstudioApi.Snapshot, expectedTestScenarios []string, usingComponentGroups bool) error {
+	integrationTestScenarios, err := i.GetIntegrationTestScenarios(parentName, testNamespace, usingComponentGroups)
 	if err != nil {
-		return fmt.Errorf("unable to get IntegrationTestScenarios for Application %s/%s. Error: %v", testNamespace, applicationName, err)
+		return fmt.Errorf("unable to get IntegrationTestScenarios for Application %s/%s. Error: %v", testNamespace, parentName, err)
 	}
 
 	for _, testScenario := range *integrationTestScenarios {
@@ -212,8 +217,8 @@ func (i *IntegrationController) WaitForFinalizerToGetRemovedFromIntegrationPipel
 }
 
 // GetAnnotationIfExists returns the value of a given annotation within a pipelinerun, if it exists.
-func (i *IntegrationController) GetAnnotationIfExists(testNamespace, applicationName, componentName, annotationKey string) (string, error) {
-	pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+func (i *IntegrationController) GetAnnotationIfExists(testNamespace, parentName, componentName, annotationKey string, usingComponentGroups bool) (string, error) {
+	pipelineRun, err := i.GetBuildPipelineRun(componentName, parentName, testNamespace, false, "", usingComponentGroups)
 	if err != nil {
 		return "", fmt.Errorf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)
 	}
@@ -222,15 +227,15 @@ func (i *IntegrationController) GetAnnotationIfExists(testNamespace, application
 
 // WaitForBuildPipelineRunToGetAnnotated waits for given build pipeline to get annotated with a specific annotation.
 // In case of failure, this function retries till it gets timed out.
-func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, annotationKey string) error {
+func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamespace, parentName, componentName, annotationKey string, usingComponentGroups bool) error {
 	return wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 5*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "")
+		pipelineRun, err := i.GetBuildPipelineRun(componentName, parentName, testNamespace, false, "", usingComponentGroups)
 		if err != nil {
 			ginkgo.GinkgoWriter.Printf("pipelinerun for Component %s/%s can't be gotten successfully. Error: %v", testNamespace, componentName, err)
 			return false, nil
 		}
 
-		annotationValue, _ := i.GetAnnotationIfExists(testNamespace, applicationName, componentName, annotationKey)
+		annotationValue, _ := i.GetAnnotationIfExists(testNamespace, parentName, componentName, annotationKey, usingComponentGroups)
 		if annotationValue == "" {
 			ginkgo.GinkgoWriter.Printf("build pipelinerun %s/%s doesn't contain annotation %s yet", testNamespace, pipelineRun.Name, annotationKey)
 			return false, nil
@@ -241,12 +246,12 @@ func (i *IntegrationController) WaitForBuildPipelineRunToGetAnnotated(testNamesp
 
 // WaitForBuildPipelineToBeFinished wait for given build pipeline to finish.
 // It exposes the error message from the failed task to the end user when the pipelineRun failed.
-func (i *IntegrationController) WaitForBuildPipelineToBeFinished(testNamespace, applicationName, componentName, sha string) (string, error) {
+func (i *IntegrationController) WaitForBuildPipelineToBeFinished(testNamespace, parentName, componentName, sha string, usingComponentGroups bool) (string, error) {
 	var logs string
 	return logs, wait.PollUntilContextTimeout(context.Background(), constants.PipelineRunPollingInterval, 30*time.Minute, true, func(ctx context.Context) (done bool, err error) {
-		pipelineRun, err := i.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, sha)
+		pipelineRun, err := i.GetBuildPipelineRun(componentName, parentName, testNamespace, false, sha, usingComponentGroups)
 		if err != nil {
-			ginkgo.GinkgoWriter.Println("Build pipelineRun has not been created yet for app %s/%s, and component %s", testNamespace, applicationName, componentName)
+			ginkgo.GinkgoWriter.Println("Build pipelineRun has not been created yet for app %s/%s, and component %s", testNamespace, parentName, componentName)
 			return false, nil
 		}
 		for _, condition := range pipelineRun.Status.Conditions {

--- a/e2e-tests/pkg/clients/integration/snapshots.go
+++ b/e2e-tests/pkg/clients/integration/snapshots.go
@@ -19,7 +19,8 @@ import (
 )
 
 // CreateSnapshotWithComponents creates a Snapshot using the given parameters.
-func (i *IntegrationController) CreateSnapshotWithComponents(snapshotName, componentName, applicationName, namespace string, snapshotComponents []appstudioApi.SnapshotComponent) (*appstudioApi.Snapshot, error) {
+// TODO: When we remove application-specific code, remove usingComponentGroups parameter and rename parentName to componentGroupName
+func (i *IntegrationController) CreateSnapshotWithComponents(snapshotName, componentName, parentName, namespace string, snapshotComponents []appstudioApi.SnapshotComponent, usingComponentGroups bool) (*appstudioApi.Snapshot, error) {
 	snapshot := &appstudioApi.Snapshot{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      snapshotName,
@@ -31,23 +32,36 @@ func (i *IntegrationController) CreateSnapshotWithComponents(snapshotName, compo
 			},
 		},
 		Spec: appstudioApi.SnapshotSpec{
-			Application: applicationName,
-			Components:  snapshotComponents,
+			Components: snapshotComponents,
 		},
+	}
+	if usingComponentGroups {
+		snapshot.Spec.ComponentGroup = parentName
+	} else {
+		snapshot.Spec.Application = parentName
 	}
 	return snapshot, i.KubeRest().Create(context.Background(), snapshot)
 }
 
 // CreateSnapshotWithImage creates a snapshot using an image.
-func (i *IntegrationController) CreateSnapshotWithImage(componentName, applicationName, namespace, containerImage string) (*appstudioApi.Snapshot, error) {
+// version should match the ComponentVersion.Name used for the Component's ComponentReference within its
+// ComponentGroup (usually the component's base branch name); it is required for the GlobalCandidateList entry
+// to be found and updated. It is unused (and can be left blank) for the application model, since Components
+// there aren't versioned.
+// TODO: When we remove application-specific code, remove usingComponentGroups parameter and rename parentName to componentGroupName
+func (i *IntegrationController) CreateSnapshotWithImage(componentName, parentName, namespace, containerImage, version string, usingComponentGroups bool) (*appstudioApi.Snapshot, error) {
 	snapshotComponents := []appstudioApi.SnapshotComponent{
 		{
 			Name:           componentName,
 			ContainerImage: containerImage,
 		},
 	}
+	// TODO: remove if block and put assignment in block above when we remove application support
+	if version != "" {
+		snapshotComponents[0].Version = version
+	}
 	snapshotName := "snapshot-sample-" + utils.GenerateRandomString(4)
-	return i.CreateSnapshotWithComponents(snapshotName, componentName, applicationName, namespace, snapshotComponents)
+	return i.CreateSnapshotWithComponents(snapshotName, componentName, parentName, namespace, snapshotComponents, usingComponentGroups)
 }
 
 // GetSnapshot returns the Snapshot in the namespace and nil if it's not found
@@ -90,7 +104,10 @@ func (i *IntegrationController) GetSnapshot(snapshotName, pipelineRunName, compo
 
 // DeleteSnapshot removes given snapshot from specified namespace.
 func (i *IntegrationController) DeleteSnapshot(hasSnapshot *appstudioApi.Snapshot, namespace string) error {
-	return i.KubeRest().Delete(context.Background(), hasSnapshot)
+	if hasSnapshot != nil {
+		return i.KubeRest().Delete(context.Background(), hasSnapshot)
+	}
+	return nil
 }
 
 // PatchSnapshot patches the given snapshot with the provided patch.

--- a/e2e-tests/pkg/clients/release/plans.go
+++ b/e2e-tests/pkg/clients/release/plans.go
@@ -12,7 +12,9 @@ import (
 )
 
 // CreateReleasePlan creates a new ReleasePlan using the given parameters.
-func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targetNamespace, autoReleaseLabel string, data *runtime.RawExtension, tenantPipeline *tektonutils.ParameterizedPipeline, finalPipeline *tektonutils.ParameterizedPipeline) (*releaseApi.ReleasePlan, error) {
+// TODO: when we delete the old application-specific code, go back to setting ComponentGroup in the spec definition
+// Also remove usingComponentGroups parameter and rename parent parameter to componentGroup
+func (r *ReleaseController) CreateReleasePlan(name, namespace, parent, targetNamespace, autoReleaseLabel string, data *runtime.RawExtension, tenantPipeline *tektonutils.ParameterizedPipeline, finalPipeline *tektonutils.ParameterizedPipeline, usingComponentGroups bool) (*releaseApi.ReleasePlan, error) {
 	releasePlan := &releaseApi.ReleasePlan{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: name,
@@ -24,13 +26,18 @@ func (r *ReleaseController) CreateReleasePlan(name, namespace, application, targ
 			},
 		},
 		Spec: releaseApi.ReleasePlanSpec{
-			Application:    application,
 			Data:           data,
 			TenantPipeline: tenantPipeline,
 			FinalPipeline:  finalPipeline,
 			Target:         targetNamespace,
 		},
 	}
+	if usingComponentGroups {
+		releasePlan.Spec.ComponentGroup = parent
+	} else {
+		releasePlan.Spec.Application = parent
+	}
+
 	if autoReleaseLabel == "" || autoReleaseLabel == "true" {
 		releasePlan.Labels[releaseMetadata.AutoReleaseLabel] = "true"
 	} else {

--- a/e2e-tests/tests/integration-service/README.md
+++ b/e2e-tests/tests/integration-service/README.md
@@ -6,7 +6,10 @@ The Integration Service manages the lifecycle, deployment, and integration testi
 
 ## Test Suites
 
-### 1. Basic E2E Tests within `integration.go`
+> **Note**: Some of the e2e tests suites have parallel Application and ComponentGroup versions. These will remain until we complete the migration from the Application model
+to the ComponentGroup model. Until then, any changes to _testfile.go_ should also be made to _testfile-application.go_
+
+### 1. Basic E2E Tests within `integration.go` and `integration-application.go`
 These tests cover the end-to-end integration service workflow, verifying the successful execution of key processes such as component creation, pipeline runs, snapshot generation, and release management under ideal conditions.
 
 **Repositories:**
@@ -55,7 +58,7 @@ This suite tests the integration service's pipeline resolution functionality, fo
 
 Happy path testing describes tests that focus on the most common scenarios while assuming there are no exceptions or errors.
 
-### 1. Happy Path Tests within `integration.go`
+### 1. Happy Path Tests within `integration.go` and `integration-application.go`
 Checkpoints:
 - Testing for successful creation of applications and components.
 - Checking if the BuildPipelineRun is successfully triggered, contains the finalizer, and was completed.
@@ -185,7 +188,7 @@ Checkpoints:
 
 - [Prepare the cluster.](https://github.com/redhat-appstudio/e2e-tests#install-appstudio-in-e2e-mode)
 
-- To run service-level E2E test suite: `integration.go`
+- To run service-level E2E test suite: `integration.go` and `integration-application.go`
 
 ```
  ./bin/e2e-appstudio --ginkgo.focus="integration-service-suite" –ginkgo.vv

--- a/e2e-tests/tests/integration-service/forgejo-integration-reporting-application.go
+++ b/e2e-tests/tests/integration-service/forgejo-integration-reporting-application.go
@@ -22,7 +22,7 @@ import (
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of Integration tests", ginkgo.Label("integration-service", "forgejo-status-reporting"), func() {
+var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of Integration tests", ginkgo.Label("integration-service", "applications", "forgejo-status-reporting"), func() {
 	defer ginkgo.GinkgoRecover()
 
 	var f *framework.Framework
@@ -43,7 +43,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 
 	ginkgo.AfterEach(framework.ReportFailure(&f))
 
-	ginkgo.Describe("Forgejo with status reporting of Integration tests in the associated merge request", ginkgo.Ordered, func() {
+	ginkgo.Describe("[APPLICATION] Forgejo with status reporting of Integration tests in the associated merge request", ginkgo.Ordered, func() {
 		ginkgo.BeforeAll(func() {
 			if os.Getenv(constants.SKIP_PAC_TESTS_ENV) == "true" {
 				ginkgo.Skip("Skipping this test due to configuration issue with Spray proxy")
@@ -65,7 +65,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 			}, time.Minute*2, time.Second*5).Should(gomega.Succeed(),
 				fmt.Sprintf("Application %s should be available in namespace %s", applicationName, testNamespace))
 
-			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{})
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 			componentName = fmt.Sprintf("%s-%s", "test-comp-pac-forgejo", utils.GenerateRandomString(6))
@@ -107,7 +107,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 			}
 		})
 
-		ginkgo.When("a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
+		ginkgo.When("[APPLICATION] a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
 			ginkgo.BeforeAll(func() {
 				componentObj := appstudioApi.ComponentSpec{
 					ComponentName: componentName,
@@ -125,7 +125,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 				buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuildOciTAMin)
 				gitProviderAnnotation := map[string]string{"git-provider": "forgejo"}
 
-				component, err = f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, testNamespace, "", "", applicationName, false,
+				component, err = f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, componentName, testNamespace, "", "", applicationName, false,
 					utils.MergeMaps(
 						utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation),
 						gitProviderAnnotation,
@@ -155,9 +155,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 					fmt.Sprintf("timed out waiting for PaC init PR (branch %s) to be created in %s", pacBranchName, reportingRepository))
 			})
 
-			ginkgo.It("triggers a Build PipelineRun", func() {
+			ginkgo.It("[APPLICATION] triggers a Build PipelineRun", func() {
 				gomega.Eventually(func() error {
-					buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+					buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, "")
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
@@ -169,16 +169,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", testNamespace, componentName))
 			})
 
-			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+			ginkgo.It("[APPLICATION] does not contain an annotation with a Snapshot Name", func() {
 				gomega.Expect(buildPipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			})
 
-			ginkgo.It("should lead to build PipelineRun finishing successfully", func() {
+			ginkgo.It("[APPLICATION] should lead to build PipelineRun finishing successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "",
 					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, buildPipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("should have a related PaC init MR created", func() {
+			ginkgo.It("[APPLICATION] should have a related PaC init MR created", func() {
 				gomega.Eventually(func() bool {
 					prs, err := git.ListPullRequestsWithRetry(gitClient, reportingRepository)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -193,33 +193,33 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 					return false
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC MR (branch name '%s') to be created in %s repository", pacBranchName, reportingRepository))
 
-				buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mrSha)
+				buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, mrSha)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It(fmt.Sprintf("the PipelineRun should eventually finish successfully for component %s", componentName), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] the PipelineRun should eventually finish successfully for component %s", componentName), func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(gomega.Succeed())
 			})
 		})
 
-		ginkgo.When("the PaC build pipelineRun run succeeded", func() {
-			ginkgo.It("checks if the BuildPipelineRun has the annotation of chains signed", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(gomega.Succeed())
+		ginkgo.When("[APPLICATION] the PaC build pipelineRun run succeeded", func() {
+			ginkgo.It("[APPLICATION] checks if the BuildPipelineRun has the annotation of chains signed", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the Snapshot is created", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation, false)).To(gomega.Succeed())
 			})
 		})
 
-		ginkgo.When("the Snapshot was created", func() {
-			ginkgo.It("should find the Integration Test Scenario PipelineRun", func() {
+		ginkgo.When("[APPLICATION] the Snapshot was created", func() {
+			ginkgo.It("[APPLICATION] should find the Integration Test Scenario PipelineRun", func() {
 				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
@@ -227,19 +227,19 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 			})
 		})
 
-		ginkgo.When("Integration PipelineRun is created", func() {
-			ginkgo.It("should eventually complete successfully", func() {
+		ginkgo.When("[APPLICATION] Integration PipelineRun is created", func() {
+			ginkgo.It("[APPLICATION] should eventually complete successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
 					fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 			})
 
-			ginkgo.It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
 				gomega.Expect(
 					forgejoGitClient.GetCommitStatusConclusion(integrationTestScenarioPass.Name, reportingRepository, mrSha, mrID),
 				).To(gomega.Equal(integrationPipelineRunCommitStatusSuccess))
 			})
 
-			ginkgo.It("validates at least one MR comment contains the final integration test result", func() {
+			ginkgo.It("[APPLICATION] validates at least one MR comment contains the final integration test result", func() {
 				gomega.Eventually(func() bool {
 					owner, repo, ok := strings.Cut(reportingRepository, "/")
 					if !ok {
@@ -268,7 +268,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 					fmt.Sprintf("no MR comment found containing integration test result for PR #%d in project %s", mrID, reportingRepository))
 			})
 
-			ginkgo.It("merging the PR should be successful", func() {
+			ginkgo.It("[APPLICATION] merging the PR should be successful", func() {
 				var mergeResult *git.PullRequest
 				gomega.Eventually(func() error {
 					mergeResult, err = gitClient.MergePullRequest(reportingRepository, mrID)
@@ -283,9 +283,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 				ginkgo.GinkgoWriter.Printf("merged result sha: %s for MR #%d\n", mergeResultSha, mrID)
 			})
 
-			ginkgo.It("leads to triggering a push PipelineRun", func() {
+			ginkgo.It("[APPLICATION] leads to triggering a push PipelineRun", func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
+					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, mergeResultSha)
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Push PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
@@ -299,13 +299,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Forgejo Status Reporting of I
 			})
 		})
 
-		ginkgo.When("Run integration tests after Merged MR", func() {
-			ginkgo.It("should eventually complete successfully", func() {
+		ginkgo.When("[APPLICATION] Run integration tests after Merged MR", func() {
+			ginkgo.It("[APPLICATION] should eventually complete successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
 					fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 			})
 
-			ginkgo.It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
 				gomega.Expect(
 					forgejoGitClient.GetCommitStatusConclusion(integrationTestScenarioPass.Name, reportingRepository, mrSha, mrID),
 				).To(gomega.Equal(integrationPipelineRunCommitStatusSuccess))

--- a/e2e-tests/tests/integration-service/gitlab-integration-reporting-application.go
+++ b/e2e-tests/tests/integration-service/gitlab-integration-reporting-application.go
@@ -5,7 +5,7 @@ import (
 	"os"
 
 	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils/build"
-	"gitlab.com/gitlab-org/api/client-go/v2"
+	gitlab "gitlab.com/gitlab-org/api/client-go/v2"
 
 	"strings"
 	"time"
@@ -22,7 +22,7 @@ import (
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 )
 
-var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of Integration tests", ginkgo.Label("integration-service", "gitlab-status-reporting"), func() {
+var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of Integration tests", ginkgo.Label("integration-service", "applications", "gitlab-status-reporting"), func() {
 	defer ginkgo.GinkgoRecover()
 
 	var f *framework.Framework
@@ -40,7 +40,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 
 	ginkgo.AfterEach(framework.ReportFailure(&f))
 
-	ginkgo.Describe("Gitlab with status reporting of Integration tests in the assosiated merge request", ginkgo.Ordered, func() {
+	ginkgo.Describe("[APPLICATION] Gitlab with status reporting of Integration tests in the assosiated merge request", ginkgo.Ordered, func() {
 		ginkgo.BeforeAll(func() {
 			if os.Getenv(constants.SKIP_PAC_TESTS_ENV) == "true" {
 				ginkgo.Skip("Skipping this test due to configuration issue with Spray proxy")
@@ -63,10 +63,10 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 			}, time.Minute*2, time.Second*5).Should(gomega.Succeed(),
 				fmt.Sprintf("Application %s should be available in namespace %s", applicationName, testNamespace))
 
-			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{})
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{})
+			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 			componentName = fmt.Sprintf("%s-%s", "test-comp-pac-gitlab", utils.GenerateRandomString(6))
@@ -104,7 +104,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 
 		})
 
-		ginkgo.When("a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
+		ginkgo.When("[APPLICATION] a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
 			ginkgo.BeforeAll(func() {
 				componentObj := appstudioApi.ComponentSpec{
 					ComponentName: componentName,
@@ -122,13 +122,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				// get the build pipeline bundle annotation
 				buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 				// Create a component with Git Source URL, a specified git branch
-				component, err = f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
+				component, err = f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, componentName, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("triggers a Build PipelineRun", func() {
+			ginkgo.It("[APPLICATION] triggers a Build PipelineRun", func() {
 				gomega.Eventually(func() error {
-					buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, "")
+					buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, "")
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
@@ -140,16 +140,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the component %s/%s", testNamespace, componentName))
 			})
 
-			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+			ginkgo.It("[APPLICATION] does not contain an annotation with a Snapshot Name", func() {
 				gomega.Expect(buildPipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			})
 
-			ginkgo.It("should lead to build PipelineRun finishing successfully", func() {
+			ginkgo.It("[APPLICATION] should lead to build PipelineRun finishing successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "",
 					"", f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, buildPipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("should have a related PaC init MR is created", func() {
+			ginkgo.It("[APPLICATION] should have a related PaC init MR is created", func() {
 				gomega.Eventually(func() bool {
 					mrs, err := f.AsKubeAdmin.CommonController.Gitlab.GetMergeRequests(projectID)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -165,32 +165,32 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC MR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
-				buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mrSha)
+				buildPipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, mrSha)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
-			ginkgo.It(fmt.Sprintf("the PipelineRun should eventually finish successfully for component %s", componentName), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] the PipelineRun should eventually finish successfully for component %s", componentName), func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.WaitForComponentPipelineToBeFinished(component, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, nil)).To(gomega.Succeed())
 			})
 		})
 
-		ginkgo.When("the PaC build pipelineRun run succeeded", func() {
-			ginkgo.It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(gomega.Succeed())
+		ginkgo.When("[APPLICATION] the PaC build pipelineRun run succeeded", func() {
+			ginkgo.It("[APPLICATION] checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the Snapshot is created", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation, false)).To(gomega.Succeed())
 			})
 		})
 
-		ginkgo.When("the Snapshot was created", func() {
-			ginkgo.It("should find the Integration Test Scenario PipelineRun", func() {
+		ginkgo.When("[APPLICATION] the Snapshot was created", func() {
+			ginkgo.It("[APPLICATION] should find the Integration Test Scenario PipelineRun", func() {
 				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
@@ -201,14 +201,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 			})
 		})
 
-		ginkgo.When("Integration PipelineRun is created", func() {
+		ginkgo.When("[APPLICATION] Integration PipelineRun is created", func() {
 
-			ginkgo.It("should eventually complete successfully", func() {
+			ginkgo.It("[APPLICATION] should eventually complete successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioFail, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 			})
 
-			ginkgo.It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it pass", func() {
+			ginkgo.It("[APPLICATION] validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it pass", func() {
 				gomega.Eventually(func() string {
 					commitStatuses, _, err := f.AsKubeAdmin.CommonController.Gitlab.GetClient().Commits.GetCommitStatuses(projectID, mrSha, nil)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -225,11 +225,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Equal(integrationPipelineRunCommitStatusSuccess), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			ginkgo.It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioPass.Name, projectID, mrSha, mrID)).To(gomega.Equal(integrationPipelineRunCommitStatusSuccess))
 			})
 
-			ginkgo.It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
+			ginkgo.It("[APPLICATION] validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
 				gomega.Eventually(func() string {
 					commitStatuses, _, err := f.AsKubeAdmin.CommonController.Gitlab.GetClient().Commits.GetCommitStatuses(projectID, mrSha, nil)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -246,11 +246,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(gomega.Equal(integrationPipelineRunCommitStatusFail), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			ginkgo.It("eventually leads to the integration test PipelineRun's Fail status reported at MR commit status", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the integration test PipelineRun's Fail status reported at MR commit status", func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioFail.Name, projectID, mrSha, mrID)).To(gomega.Equal(integrationPipelineRunCommitStatusFail))
 			})
 
-			ginkgo.It("validates at least one MR note contains the final integration test result", func() {
+			ginkgo.It("[APPLICATION] validates at least one MR note contains the final integration test result", func() {
 				gomega.Eventually(func() bool {
 					notes, _, err := f.AsKubeAdmin.CommonController.Gitlab.GetClient().Notes.ListMergeRequestNotes(projectID, mrID, nil)
 					if err != nil {
@@ -274,7 +274,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("no MR note found containing integration test result for MR #%d in project %s", mrID, componentRepoNameForStatusReporting))
 			})
 
-			ginkgo.It("merging the PR should be successful", func() {
+			ginkgo.It("[APPLICATION] merging the PR should be successful", func() {
 				gomega.Eventually(func() error {
 					mergeResult, err = f.AsKubeAdmin.CommonController.Gitlab.AcceptMergeRequest(projectID, mrID)
 					return err
@@ -284,9 +284,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				ginkgo.GinkgoWriter.Printf("merged result sha: %s for MR #%d\n", mergeResultSha, mrID)
 
 			})
-			ginkgo.It("leads to triggering on push PipelineRun", func() {
+			ginkgo.It("[APPLICATION] leads to triggering on push PipelineRun", func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
+					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, mergeResultSha)
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Push PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
@@ -298,13 +298,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the PipelineRun to start for the component %s/%s", testNamespace, componentName))
 			})
 		})
-		ginkgo.When("Run integration tests after Merged MR", func() {
-			ginkgo.It("should eventually complete successfully", func() {
+		ginkgo.When("[APPLICATION] Run integration tests after Merged MR", func() {
+			ginkgo.It("[APPLICATION] should eventually complete successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioFail, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 			})
 
-			ginkgo.It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it pass", func() {
+			ginkgo.It("[APPLICATION] validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it pass", func() {
 				gomega.Eventually(func() string {
 					commitStatuses, _, err := f.AsKubeAdmin.CommonController.Gitlab.GetClient().Commits.GetCommitStatuses(projectID, mrSha, nil)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -321,11 +321,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Equal(integrationPipelineRunCommitStatusSuccess), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			ginkgo.It("eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the integration test PipelineRun's Pass status reported at MR commit status", func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioPass.Name, projectID, mrSha, mrID)).To(gomega.Equal(constants.CheckrunConclusionSuccess))
 			})
 
-			ginkgo.It("validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
+			ginkgo.It("[APPLICATION] validates the Integration test scenario PipelineRun is reported to merge request CommitStatus, and it fails", func() {
 				gomega.Eventually(func() string {
 					commitStatuses, _, err := f.AsKubeAdmin.CommonController.Gitlab.GetClient().Commits.GetCommitStatuses(projectID, mrSha, nil)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -342,7 +342,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Gitlab Status Reporting of In
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Equal(integrationPipelineRunCommitStatusFail), fmt.Sprintf("timed out when waiting for expected commitStatus to be created for sha %s in %s repository", mrSha, componentRepoNameForStatusReporting))
 			})
 
-			ginkgo.It("eventually leads to the integration test PipelineRun's Fail status reported at MR commit status", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the integration test PipelineRun's Fail status reported at MR commit status", func() {
 				gomega.Expect(f.AsKubeAdmin.HasController.GitLab.GetCommitStatusConclusion(integrationTestScenarioFail.Name, projectID, mrSha, mrID)).To(gomega.Equal(integrationPipelineRunCommitStatusFail))
 			})
 		})

--- a/e2e-tests/tests/integration-service/group-snapshots-tests-application.go
+++ b/e2e-tests/tests/integration-service/group-snapshots-tests-application.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots for monorepo and multiple repos", ginkgo.Label("integration-service", "group-snapshot-creation"), func() {
+var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots for monorepo and multiple repos", ginkgo.Label("integration-service", "applications", "group-snapshot-creation"), func() {
 	defer ginkgo.GinkgoRecover()
 
 	var f *framework.Framework
@@ -49,7 +49,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 	ginkgo.AfterEach(framework.ReportFailure(&f))
 
-	ginkgo.Describe("with status reporting of Integration tests in CheckRuns", ginkgo.Ordered, func() {
+	ginkgo.Describe("[APPLICATION] with status reporting of Integration tests in CheckRuns", ginkgo.Ordered, func() {
 		// Lock configuration for preventing concurrent test runs from colliding on the same GitHub repository.
 		// Multiple jobs running simultaneously can trigger race condition when registering Repository CRDs
 		// for the same repository URL. This lock ensures only one test uses the repository at a time.
@@ -142,13 +142,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 			//Branch for creating pull request
 			multiComponentPRBranchName = fmt.Sprintf("%s-%s", "pr-branch", utils.GenerateRandomString(6))
 
-			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPassPipelinerun, "pipelinerun", []string{})
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPassPipelinerun, "pipelinerun", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.AfterAll(func() {
 			if !ginkgo.CurrentSpecReport().Failed() {
-				cleanup(*f, testNamespace, applicationName, componentA.Name, snapshot)
+				cleanup(*f, testNamespace, applicationName, componentA.Name, snapshot, false)
 			}
 
 			// Delete new branches created by PaC and a testing branch used as a component's base branch
@@ -201,8 +201,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 		  / /\ \
 		 / ____ \
 		/_/    \_\ */
-		ginkgo.When("we start creation of a new Component A", func() {
-			ginkgo.It("creates the Component A successfully", func() {
+		ginkgo.When("[APPLICATION] we start creation of a new Component A", func() {
+			ginkgo.It("[APPLICATION] creates the Component A successfully", func() {
 				componentA = createComponentWithCustomBranch(*f, testNamespace, applicationName, multiComponentContextDirs[0]+"-"+utils.GenerateRandomString(6), multiComponentGitSourceURLForGroupSnapshotA, multiComponentBaseBranchName, multiComponentContextDirs[0])
 
 				// Record the PaC branch names for cleanup
@@ -210,9 +210,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				pacBranchNames = append(pacBranchNames, pacBranchName)
 			})
 
-			ginkgo.It(fmt.Sprintf("triggers a Build PipelineRun for componentA %s", multiComponentContextDirs[0]), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] triggers a Build PipelineRun for componentA %s", multiComponentContextDirs[0]), func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, applicationName, testNamespace, "")
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, testNamespace, "")
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the componentA %s/%s\n", testNamespace, componentA.Name)
 						return err
@@ -224,16 +224,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the componentA %s/%s", testNamespace, componentA.Name))
 			})
 
-			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+			ginkgo.It("[APPLICATION] does not contain an annotation with a Snapshot Name", func() {
 				gomega.Expect(pipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			})
 
-			ginkgo.It("should lead to build PipelineRunA finishing successfully", func() {
+			ginkgo.It("[APPLICATION] should lead to build PipelineRunA finishing successfully", func() {
 				gomega.Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(componentA, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It(fmt.Sprintf("should lead to a PaC PR creation for componentA %s", multiComponentContextDirs[0]), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] should lead to a PaC PR creation for componentA %s", multiComponentContextDirs[0]), func() {
 				gomega.Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(multiComponentRepoNameForGroupSnapshot)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -249,32 +249,32 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[0], multiComponentRepoNameForGroupSnapshot))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, applicationName, testNamespace, prHeadSha)
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentA.Name, testNamespace, prHeadSha)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 		})
 
-		ginkgo.When("the Build PLRA is finished successfully", func() {
-			ginkgo.It("checks if the Snapshot is created", func() {
+		ginkgo.When("[APPLICATION] the Build PLRA is finished successfully", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", pipelineRun.Name, componentA.Name, testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("should find the related Integration PipelineRuns", func() {
+			ginkgo.It("[APPLICATION] should find the related Integration PipelineRuns", func() {
 				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
 				gomega.Expect(testPipelinerun.Labels[scenarioAnnotation]).To(gomega.ContainSubstring(integrationTestScenarioPass.Name))
 			})
 
-			ginkgo.It("integration pipeline should end up with success", func() {
+			ginkgo.It("[APPLICATION] integration pipeline should end up with success", func() {
 				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
 					fmt.Sprintf("timed out waiting for integration pipeline to succeed for componentA %s/%s", testNamespace, componentA.Name))
 			})
 		})
 
-		ginkgo.When("the Snapshot testing is completed successfully", func() {
-			ginkgo.It("should merge the init PaC PR successfully", func() {
+		ginkgo.When("[APPLICATION] the Snapshot testing is completed successfully", func() {
+			ginkgo.It("[APPLICATION] should merge the init PaC PR successfully", func() {
 				gomega.Eventually(func() error {
 					mergeResult, err = f.AsKubeAdmin.CommonController.Github.MergePullRequest(multiComponentRepoNameForGroupSnapshot, prNumber)
 					return err
@@ -292,8 +292,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 		|  _ <
 		| |_) |
 		|____/ */
-		ginkgo.When("we start creation of a new Component B", func() {
-			ginkgo.It("creates the Component B successfully", func() {
+		ginkgo.When("[APPLICATION] we start creation of a new Component B", func() {
+			ginkgo.It("[APPLICATION] creates the Component B successfully", func() {
 				componentB = createComponentWithCustomBranch(*f, testNamespace, applicationName, multiComponentContextDirs[1]+"-"+utils.GenerateRandomString(6), multiComponentGitSourceURLForGroupSnapshotB, multiComponentBaseBranchName, multiComponentContextDirs[1])
 
 				// Recording the PaC branch names so they can cleaned in the AfterAll block
@@ -301,9 +301,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				pacBranchNames = append(pacBranchNames, pacBranchName)
 			})
 
-			ginkgo.It(fmt.Sprintf("triggers a Build PipelineRun for component %s", multiComponentContextDirs[1]), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] triggers a Build PipelineRun for component %s", multiComponentContextDirs[1]), func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, applicationName, testNamespace, "")
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, testNamespace, "")
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the componentB %s/%s\n", testNamespace, componentB.Name)
 						return err
@@ -315,16 +315,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the componentB %s/%s", testNamespace, componentB.Name))
 			})
 
-			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+			ginkgo.It("[APPLICATION] does not contain an annotation with a Snapshot Name", func() {
 				gomega.Expect(pipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			})
 
-			ginkgo.It("should lead to build PipelineRun finishing successfully", func() {
+			ginkgo.It("[APPLICATION] should lead to build PipelineRun finishing successfully", func() {
 				gomega.Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(componentB, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It(fmt.Sprintf("should lead to a PaC PR creation for component %s", multiComponentContextDirs[1]), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] should lead to a PaC PR creation for component %s", multiComponentContextDirs[1]), func() {
 				gomega.Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(multiComponentRepoNameForGroupSnapshot)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -340,32 +340,32 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[1], multiComponentRepoNameForGroupSnapshot))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, applicationName, testNamespace, prHeadSha)
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentB.Name, testNamespace, prHeadSha)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 		})
 
-		ginkgo.When("the Build PLR is finished successfully", func() {
-			ginkgo.It("checks if the Snapshot is created", func() {
+		ginkgo.When("[APPLICATION] the Build PLR is finished successfully", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", pipelineRun.Name, componentB.Name, testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("should find the related Integration PipelineRuns", func() {
+			ginkgo.It("[APPLICATION] should find the related Integration PipelineRuns", func() {
 				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
 				gomega.Expect(testPipelinerun.Labels[scenarioAnnotation]).To(gomega.ContainSubstring(integrationTestScenarioPass.Name))
 			})
 
-			ginkgo.It("integration pipeline should end up with success", func() {
+			ginkgo.It("[APPLICATION] integration pipeline should end up with success", func() {
 				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
 					fmt.Sprintf("timed out waiting for integration pipeline to succeed for componentB %s/%s", testNamespace, componentB.Name))
 			})
 		})
 
-		ginkgo.When("the Snapshot testing is completed successfully", func() {
-			ginkgo.It("should merge the init PaC PR successfully", func() {
+		ginkgo.When("[APPLICATION] the Snapshot testing is completed successfully", func() {
+			ginkgo.It("[APPLICATION] should merge the init PaC PR successfully", func() {
 				gomega.Eventually(func() error {
 					mergeResult, err = f.AsKubeAdmin.CommonController.Github.MergePullRequest(multiComponentRepoNameForGroupSnapshot, prNumber)
 					return err
@@ -383,8 +383,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 		//  | |____
 		//   \_____|*/
 
-		ginkgo.When("we start creation of a new Component C", func() {
-			ginkgo.It("creates the Component C successfully", func() {
+		ginkgo.When("[APPLICATION] we start creation of a new Component C", func() {
+			ginkgo.It("[APPLICATION] creates the Component C successfully", func() {
 				componentC = createComponentWithCustomBranch(*f, testNamespace, applicationName, componentRepoNameForGroupIntegration+"-"+utils.GenerateRandomString(6), componentGitSourceURLForGroupIntegration, multiComponentBaseBranchName, "")
 
 				// Recording the PaC branch names so they can cleaned in the AfterAll block
@@ -392,9 +392,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				pacBranchNames = append(pacBranchNames, pacBranchName)
 			})
 
-			ginkgo.It(fmt.Sprintf("triggers a Build PipelineRun for componentC %s", componentRepoNameForGroupIntegration), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] triggers a Build PipelineRun for componentC %s", componentRepoNameForGroupIntegration), func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, applicationName, testNamespace, "")
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, testNamespace, "")
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the componentC %s/%s\n", testNamespace, componentC.Name)
 						return err
@@ -406,16 +406,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the build PipelineRun to start for the componentC %s/%s", testNamespace, componentC.Name))
 			})
 
-			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+			ginkgo.It("[APPLICATION] does not contain an annotation with a Snapshot Name", func() {
 				gomega.Expect(pipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			})
 
-			ginkgo.It("should lead to build PipelineRun finishing successfully", func() {
+			ginkgo.It("[APPLICATION] should lead to build PipelineRun finishing successfully", func() {
 				gomega.Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(componentC, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It(fmt.Sprintf("should lead to a PaC PR creation for componentC %s", componentRepoNameForGroupIntegration), func() {
+			ginkgo.It(fmt.Sprintf("[APPLICATION] should lead to a PaC PR creation for componentC %s", componentRepoNameForGroupIntegration), func() {
 				gomega.Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGroupIntegration)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -431,32 +431,32 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchNames[2], componentRepoNameForGroupIntegration))
 
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, applicationName, testNamespace, prHeadSha)
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentC.Name, testNamespace, prHeadSha)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 		})
 
-		ginkgo.When("the Build PLR is finished successfully", func() {
-			ginkgo.It("checks if the Snapshot is created", func() {
+		ginkgo.When("[APPLICATION] the Build PLR is finished successfully", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", pipelineRun.Name, componentC.Name, testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("should find the related Integration PipelineRuns", func() {
+			ginkgo.It("[APPLICATION] should find the related Integration PipelineRuns", func() {
 				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
 				gomega.Expect(testPipelinerun.Labels[scenarioAnnotation]).To(gomega.ContainSubstring(integrationTestScenarioPass.Name))
 			})
 
-			ginkgo.It("integration pipeline should end up with success", func() {
+			ginkgo.It("[APPLICATION] integration pipeline should end up with success", func() {
 				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(),
 					fmt.Sprintf("timed out waiting for integration pipeline to succeed for componentC %s/%s", testNamespace, componentC.Name))
 			})
 		})
 
-		ginkgo.When("the Snapshot testing is completed successfully", func() {
-			ginkgo.It("should merge the init PaC PR successfully", func() {
+		ginkgo.When("[APPLICATION] the Snapshot testing is completed successfully", func() {
+			ginkgo.It("[APPLICATION] should merge the init PaC PR successfully", func() {
 				gomega.Eventually(func() error {
 					mergeResult, err = f.AsKubeAdmin.CommonController.Github.MergePullRequest(componentRepoNameForGroupIntegration, prNumber)
 					return err
@@ -475,8 +475,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 		// | |     _| |_| |\  |
 		// |_|    |_____|_| \_|
 
-		ginkgo.When("both the init PaC PRs are merged", func() {
-			ginkgo.It("should make change to the root folder", func() {
+		ginkgo.When("[APPLICATION] both the init PaC PRs are merged", func() {
+			ginkgo.It("[APPLICATION] should make change to the root folder", func() {
 
 				//Create the ref, add the files and create the PR - monorepo
 				err = f.AsKubeAdmin.CommonController.Github.CreateRef(multiComponentRepoNameForGroupSnapshot, multiComponentDefaultBranch, mergeResultSha, multiComponentPRBranchName)
@@ -495,7 +495,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				prShaMonorepo = pr.Head.GetSHA()
 				ginkgo.GinkgoWriter.Printf("PR #%d got created with sha %s\n", pr.GetNumber(), prShaMonorepo)
 			})
-			ginkgo.It("should make change to the multiple-repo", func() {
+			ginkgo.It("[APPLICATION] should make change to the multiple-repo", func() {
 				// Delete all the pipelineruns in the namespace before sending PR
 				//gomega.Expect(f.AsKubeAdmin.TektonController.DeleteAllPipelineRunsInASpecificNamespace(testNamespace)).To(gomega.Succeed())
 
@@ -512,7 +512,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				prShaMultirepo = pr.Head.GetSHA()
 				ginkgo.GinkgoWriter.Printf("PR #%d got created with sha %s\n", pr.GetNumber(), prShaMultirepo)
 			})
-			ginkgo.It("wait for the last components build to finish", func() {
+			ginkgo.It("[APPLICATION] wait for the last components build to finish", func() {
 				componentsList = []*appstudioApi.Component{componentA, componentB, componentC}
 				for _, component := range []*appstudioApi.Component{componentA, componentB} {
 					gomega.Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(component, "", prShaMonorepo, "",
@@ -522,7 +522,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("wait for all component snapshots to be created with proper PR group annotations", func() {
+			ginkgo.It("[APPLICATION] wait for all component snapshots to be created with proper PR group annotations", func() {
 				gomega.Eventually(func() error {
 					componentSnapshots, err := f.AsKubeAdmin.HasController.GetAllComponentSnapshotsForApplication(applicationName, testNamespace)
 					if err != nil {
@@ -557,7 +557,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, time.Minute*10, 15*time.Second).Should(gomega.Succeed(), "Timeout while waiting for component snapshots with PR group annotations")
 			})
 
-			ginkgo.It("get all group snapshots and check if pr-group annotation contains all components", func() {
+			ginkgo.It("[APPLICATION] get all group snapshots and check if pr-group annotation contains all components", func() {
 				// Wait for group snapshots with enhanced debugging and retry logic
 				gomega.Eventually(func() error {
 					ginkgo.GinkgoWriter.Printf("Attempting to find group snapshots for application %s in namespace %s\n", applicationName, testNamespace)
@@ -636,9 +636,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 				ginkgo.GinkgoWriter.Printf("Group snapshot validation completed successfully\n")
 			})
-			ginkgo.It("make sure that group snapshot contains last build pipelinerun for each component", func() {
+			ginkgo.It("[APPLICATION] make sure that group snapshot contains last build pipelinerun for each component", func() {
 				for _, component := range componentsList {
-					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(component.Name, applicationName, testNamespace, false, "")
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(component.Name, applicationName, testNamespace, false, "", false)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					annotation := groupSnapshots.Items[0].GetAnnotations()
 					if annotation, ok := annotation[testGroupSnapshotAnnotation]; ok {
@@ -648,14 +648,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 			})
 		})
 
-		ginkgo.When("Older snapshot and integration pipelinerun should be cancelled once new snapshot is created", func() {
-			ginkgo.It("make change to the multiple-repo to trigger a new cycle of testing", func() {
+		ginkgo.When("[APPLICATION] Older snapshot and integration pipelinerun should be cancelled once new snapshot is created", func() {
+			ginkgo.It("[APPLICATION] make change to the multiple-repo to trigger a new cycle of testing", func() {
 				newFile, err := f.AsKubeAdmin.HasController.Github.CreateFile(multiComponentRepoNameForGroupSnapshot, utils.GenerateRandomString(5), "test", multiComponentPRBranchName)
 				secondFileSha = newFile.GetSHA()
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred(), fmt.Sprintf("error while creating file in multirepo: %s", secondFileSha))
 			})
 
-			ginkgo.It("wait for the components A and B build to finish", func() {
+			ginkgo.It("[APPLICATION] wait for the components A and B build to finish", func() {
 				ginkgo.GinkgoWriter.Printf("Waiting for build pipelineRun to be created for app %s/%s, sha: %s\n", testNamespace, applicationName, secondFileSha)
 				componentsList = []*appstudioApi.Component{componentA, componentB}
 				for _, component := range componentsList {
@@ -664,7 +664,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}
 			})
 
-			ginkgo.It("get all component snapshots for component A and check if older snapshot has been cancelled", func() {
+			ginkgo.It("[APPLICATION] get all component snapshots for component A and check if older snapshot has been cancelled", func() {
 				// get all component snapshots for component A
 				gomega.Eventually(func() error {
 					componentSnapshots, err = f.AsKubeAdmin.HasController.GetAllComponentSnapshotsForApplicationAndComponent(applicationName, testNamespace, componentA.Name)
@@ -691,7 +691,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, superLongTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), "timeout while waiting for component snapshot and integration pipelinerun to be cancelled")
 			})
 
-			ginkgo.It("get all group snapshots and check if older group snapshot is cancelled", func() {
+			ginkgo.It("[APPLICATION] get all group snapshots and check if older group snapshot is cancelled", func() {
 				// get all group snapshots
 				gomega.Eventually(func() error {
 					groupSnapshots, err = f.AsKubeAdmin.HasController.GetAllGroupSnapshotsForApplication(applicationName, testNamespace)
@@ -720,8 +720,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 
 		})
 
-		ginkgo.When("ResolutionRequest is deleted after pipeline completes", func() {
-			ginkgo.It("verifies that ResolutionRequest is deleted after pipeline resolution", func() {
+		ginkgo.When("[APPLICATION] ResolutionRequest is deleted after pipeline completes", func() {
+			ginkgo.It("[APPLICATION] verifies that ResolutionRequest is deleted after pipeline resolution", func() {
 				gomega.Eventually(func() error {
 					relatedResolutionRequests, err := f.AsKubeDeveloper.IntegrationController.GetRelatedResolutionRequests(testNamespace, integrationTestScenarioPass)
 					if err != nil {
@@ -741,7 +741,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), "ResolutionRequest objects should be cleaned up after pipeline resolution is complete")
 			})
 
-			ginkgo.It("verifies that no orphaned ResolutionRequests remain in namespace after test completion", func() {
+			ginkgo.It("[APPLICATION] verifies that no orphaned ResolutionRequests remain in namespace after test completion", func() {
 				// Check for any ResolutionRequests that might have been left behind
 				relatedResolutionRequests, err := f.AsKubeDeveloper.IntegrationController.GetRelatedResolutionRequests(testNamespace, integrationTestScenarioPass)
 				if err != nil {
@@ -775,13 +775,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Creation of group snapshots f
 			})
 		})
 
-		ginkgo.When("IntegrationTestScenario reference to task as pipelinerun resolution", func() {
+		ginkgo.When("[APPLICATION] IntegrationTestScenario reference to task as pipelinerun resolution", func() {
 			ginkgo.BeforeAll(func() {
-				invalidIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "pipelinerun", []string{"application"})
+				invalidIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "pipelinerun", []string{"application"}, false)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("trigger pipelinerun for invalid integrationTestScenario by annotating snapshot and verify failing to create integration pipelinerun", func() {
+			ginkgo.It("[APPLICATION] trigger pipelinerun for invalid integrationTestScenario by annotating snapshot and verify failing to create integration pipelinerun", func() {
 				groupSnapshot = &groupSnapshots.Items[0]
 				gomega.Eventually(func() error {
 					err = f.AsKubeAdmin.IntegrationController.AddIntegrationTestRerunLabel(groupSnapshot, invalidIntegrationTestScenario.Name)

--- a/e2e-tests/tests/integration-service/helpers.go
+++ b/e2e-tests/tests/integration-service/helpers.go
@@ -1,0 +1,114 @@
+// TODO: when we remove old application-specific code:
+//   - change parentName to componentGroupName
+//   - remove usingComponentGroups parameters
+//   - Delete application-specific function calls such as HasController.DeleteApplication
+package integration
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+
+	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/image-controller/pkg/quay"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/constants"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/framework"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils"
+	"github.com/konflux-ci/integration-service/e2e-tests/pkg/utils/build"
+	ginkgo "github.com/onsi/ginkgo/v2"
+	gomega "github.com/onsi/gomega"
+)
+
+func cleanup(f framework.Framework, testNamespace, parentName, componentName string, snapshot *appstudioApi.Snapshot, usingComponentGroups bool) {
+	if !ginkgo.CurrentSpecReport().Failed() {
+		gomega.Expect(f.AsKubeAdmin.IntegrationController.DeleteSnapshot(snapshot, testNamespace)).To(gomega.Succeed())
+		integrationTestScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(parentName, testNamespace, usingComponentGroups)
+		gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+
+		for _, testScenario := range *integrationTestScenarios {
+			gomega.Expect(f.AsKubeAdmin.IntegrationController.DeleteIntegrationTestScenario(&testScenario, testNamespace)).To(gomega.Succeed())
+		}
+		gomega.Expect(f.AsKubeAdmin.HasController.DeleteComponent(componentName, testNamespace, false)).To(gomega.Succeed())
+		if usingComponentGroups {
+			gomega.Expect(f.AsKubeAdmin.HasController.DeleteComponentGroup(parentName, testNamespace, false)).To(gomega.Succeed())
+		} else {
+			gomega.Expect(f.AsKubeAdmin.HasController.DeleteApplication(parentName, testNamespace, false)).To(gomega.Succeed())
+		}
+		err = deleteQuayRepo(componentName, testNamespace)
+		gomega.Expect(err).NotTo(gomega.HaveOccurred())
+	}
+}
+
+func deleteQuayRepo(componentName string, testNamespace string) error {
+	quayOrgToken := os.Getenv("DEFAULT_QUAY_ORG_TOKEN")
+	if quayOrgToken == "" {
+		return fmt.Errorf("%s", "DEFAULT_QUAY_ORG_TOKEN env var was not found")
+	}
+	quayOrg := utils.GetEnv("DEFAULT_QUAY_ORG", "redhat-appstudio-qe")
+
+	quayClient := quay.NewQuayClient(&http.Client{Transport: utils.NewRetryTransport(&http.Transport{})}, quayOrgToken, "https://quay.io/api/v1")
+
+	r, err := regexp.Compile(fmt.Sprintf(`^(%s)`, testNamespace))
+	if err != nil {
+		return err
+	}
+
+	repos, err := quayClient.GetAllRepositories(quayOrg)
+	if err != nil {
+		return err
+	}
+	// Key is the repo name without slashes which is the same as robot name
+	// Value is the repo name with slashes
+	reposMap := make(map[string]string)
+
+	for _, repo := range repos {
+		if r.MatchString(repo.Name) {
+			sanitizedRepoName := strings.ReplaceAll(repo.Name, "/", "") // repo name without slashes
+			reposMap[sanitizedRepoName] = repo.Name
+		}
+	}
+
+	sanitizedName := testNamespace + componentName
+	if repo, exists := reposMap[sanitizedName]; exists {
+		deleted, err := quayClient.DeleteRepository(quayOrg, repo)
+		if err != nil {
+			return fmt.Errorf("failed to delete repository %s, error: %s", repo, err)
+		}
+		if !deleted {
+			fmt.Printf("repository %s has already been deleted, skipping\n", repo)
+		}
+	}
+	return nil
+}
+
+// NOTE: this function is only used in the group test e2e tests
+// TODO: update this function to be backward-compatible when we create componentGroup e2e tests for group testing
+func createComponentWithCustomBranch(f framework.Framework, testNamespace, applicationName, componentName, componentRepoURL string, toBranchName string, contextDir string) *appstudioApi.Component {
+	// get the build pipeline bundle annotation
+	buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
+	dockerFileURL := constants.DockerFilePath
+	if contextDir == "" {
+		dockerFileURL = "Dockerfile"
+	}
+	componentObj := appstudioApi.ComponentSpec{
+		ComponentName: componentName,
+		Application:   applicationName,
+		Source: appstudioApi.ComponentSource{
+			ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
+				GitSource: &appstudioApi.GitSource{
+					URL:           componentRepoURL,
+					Revision:      toBranchName,
+					Context:       contextDir,
+					DockerfileURL: dockerFileURL,
+				},
+			},
+		},
+	}
+
+	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, componentName, testNamespace, "", "", applicationName, true, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
+	gomega.Expect(err).NotTo(gomega.HaveOccurred())
+
+	return originalComponent
+}

--- a/e2e-tests/tests/integration-service/integration-application.go
+++ b/e2e-tests/tests/integration-service/integration-application.go
@@ -15,7 +15,7 @@ import (
 	pipeline "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
-	"github.com/konflux-ci/integration-service/api/v1beta2"
+	integrationv1beta2 "github.com/konflux-ci/integration-service/api/v1beta2"
 	intgteststat "github.com/konflux-ci/integration-service/pkg/integrationteststatus"
 
 	appstudioApi "github.com/konflux-ci/application-api/api/v1alpha1"
@@ -24,47 +24,45 @@ import (
 	gomega "github.com/onsi/gomega"
 )
 
-// TODO: remove "componentgroups" label when we delete old application-specific code
-var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests", ginkgo.Label("integration-service", "componentgroups"), func() {
+var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests", ginkgo.Label("integration-service", "applications"), func() {
 	defer ginkgo.GinkgoRecover()
 
 	var f *framework.Framework
 	var err error
 
 	var prHeadSha string
-	var integrationTestScenario *v1beta2.IntegrationTestScenario
-	var newIntegrationTestScenario *v1beta2.IntegrationTestScenario
-	var skippedIntegrationTestScenario *v1beta2.IntegrationTestScenario
+	var integrationTestScenario *integrationv1beta2.IntegrationTestScenario
+	var newIntegrationTestScenario *integrationv1beta2.IntegrationTestScenario
+	var skippedIntegrationTestScenario *integrationv1beta2.IntegrationTestScenario
 	var timeout, interval time.Duration
 	var originalComponent *appstudioApi.Component
 	var pipelineRun *pipeline.PipelineRun
 	var snapshot *appstudioApi.Snapshot
 	var snapshotPush *appstudioApi.Snapshot
-	var componentGroupName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
+	var applicationName, componentName, componentBaseBranchName, pacBranchName, testNamespace string
 
 	ginkgo.AfterEach(framework.ReportFailure(&f))
 
-	ginkgo.Describe("with happy path for general flow of Integration service", ginkgo.Ordered, func() {
+	ginkgo.Describe("[APPLICATION] with happy path for general flow of Integration service", ginkgo.Ordered, func() {
 		ginkgo.BeforeAll(func() {
 			// Initialize the tests controllers
 			f, err = framework.NewFramework(utils.GetGeneratedNamespace("integration1"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			testNamespace = f.UserNamespace
 
-			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
-			ref := createComponentReference(componentName, "component", componentBaseBranchName)
-			componentGroupName = createCompGroup(*f, testNamespace, []v1beta2.ComponentReference{ref})
+			applicationName = createApp(*f, testNamespace)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponentApplication(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
 
-			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", componentGroupName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{"componentgroup"}, true)
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{"application"}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			skippedIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("skipped-its", componentGroupName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{"push"}, true)
+			skippedIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("skipped-its", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{"push"}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.AfterAll(func() {
 			if !ginkgo.CurrentSpecReport().Failed() {
-				cleanup(*f, testNamespace, componentGroupName, componentName, snapshotPush, true)
+				cleanup(*f, testNamespace, applicationName, componentName, snapshotPush, false)
 			}
 
 			// Delete new branches created by PaC and a testing branch used as a component's base branch
@@ -78,15 +76,15 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			}
 		})
 
-		ginkgo.When("a new Component is created", func() {
-			ginkgo.It("triggers a build PipelineRun", ginkgo.Label("integration-service"), func() {
-				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, "", testNamespace, false, "", true)
+		ginkgo.When("[APPLICATION] a new Component is created", func() {
+			ginkgo.It("[APPLICATION] triggers a build PipelineRun", ginkgo.Label("integration-service"), func() {
+				pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "", false)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("verifies if the build PipelineRun contains the finalizer", ginkgo.Label("integration-service"), func() {
+			ginkgo.It("[APPLICATION] verifies if the build PipelineRun contains the finalizer", ginkgo.Label("integration-service"), func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, "", testNamespace, false, "", true)
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "", false)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					if !controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
 						return fmt.Errorf("build pipelineRun %s/%s doesn't contain the finalizer: %s yet", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
@@ -95,13 +93,13 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, 1*time.Minute, 1*time.Second).Should(gomega.Succeed(), "timeout when waiting for finalizer to be added")
 			})
 
-			ginkgo.It("waits for build PipelineRun to succeed", ginkgo.Label("integration-service"), func() {
+			ginkgo.It("[APPLICATION] waits for build PipelineRun to succeed", ginkgo.Label("integration-service"), func() {
 				gomega.Expect(pipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 				gomega.Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", "", "",
 					f.AsKubeAdmin.TektonController, &has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("should have a related PaC init PR created", func() {
+			ginkgo.It("[APPLICATION] should have a related PaC init PR created", func() {
 				gomega.Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGeneralIntegration)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -121,25 +119,25 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			})
 		})
 
-		ginkgo.When("the build pipelineRun run succeeded", func() {
-			ginkgo.It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, componentGroupName, componentName, chainsSignedAnnotation, true)).To(gomega.Succeed())
+		ginkgo.When("[APPLICATION] the build pipelineRun run succeeded", func() {
+			ginkgo.It("[APPLICATION] checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the Snapshot is created", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, componentGroupName, componentName, snapshotAnnotation, true)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("verifies that the finalizer has been removed from the build pipelinerun", func() {
+			ginkgo.It("[APPLICATION] verifies that the finalizer has been removed from the build pipelinerun", func() {
 				timeout := "60s"
 				interval := "1s"
 				gomega.Eventually(func() error {
-					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, "", testNamespace, false, "", true)
+					pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "", false)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 					if controllerutil.ContainsFinalizer(pipelineRun, pipelinerunFinalizerByIntegrationService) {
 						return fmt.Errorf("build pipelineRun %s/%s still contains the finalizer: %s", pipelineRun.GetNamespace(), pipelineRun.GetName(), pipelinerunFinalizerByIntegrationService)
@@ -148,11 +146,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, timeout, interval).Should(gomega.Succeed(), "timeout when waiting for finalizer to be removed")
 			})
 
-			ginkgo.It("checks if all of the integrationPipelineRuns passed", ginkgo.Label("slow"), func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, componentGroupName, snapshot, []string{integrationTestScenario.Name}, true)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if all of the integrationPipelineRuns passed", ginkgo.Label("slow"), func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot, []string{integrationTestScenario.Name}, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the passed status of integration test is reported in the Snapshot", func() {
+			ginkgo.It("[APPLICATION] checks if the passed status of integration test is reported in the Snapshot", func() {
 				gomega.Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -167,7 +165,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the skipped integration test is absent from the Snapshot's status annotation", func() {
+			ginkgo.It("[APPLICATION] checks if the skipped integration test is absent from the Snapshot's status annotation", func() {
 				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -177,82 +175,46 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				gomega.Expect(statusDetail).To(gomega.BeNil())
 			})
 
-			ginkgo.It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, componentGroupName, snapshot, []string{integrationTestScenario.Name}, true)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName, snapshot, []string{integrationTestScenario.Name}, false)).To(gomega.Succeed())
 			})
 		})
 
-		ginkgo.It("creates a ReleasePlan", func() {
-			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlan(autoReleasePlan, testNamespace, componentGroupName, targetReleaseNamespace, "", nil, nil, nil, true)
+		ginkgo.It("[APPLICATION] creates a ReleasePlan", func() {
+			_, err = f.AsKubeAdmin.ReleaseController.CreateReleasePlan(autoReleasePlan, testNamespace, applicationName, targetReleaseNamespace, "", nil, nil, nil, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			testScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(componentGroupName, testNamespace, true)
+			testScenarios, err := f.AsKubeAdmin.IntegrationController.GetIntegrationTestScenarios(applicationName, testNamespace, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			for _, testScenario := range *testScenarios {
 				ginkgo.GinkgoWriter.Printf("IntegrationTestScenario %s is found\n", testScenario.Name)
 			}
 		})
 
-		ginkgo.It("creates an snapshot of push event", func() {
+		ginkgo.It("[APPLICATION] creates an snapshot of push event", func() {
 			sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-			// version must match the ComponentVersion.Name used for this Component's ComponentReference
-			// (see createComponentReference below), otherwise the GlobalCandidateList entry won't be found and updated.
-			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, componentGroupName, testNamespace, sampleImage, componentBaseBranchName, true)
+			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage, "", false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		ginkgo.When("An snapshot of push event is created", func() {
-			ginkgo.It("checks if the global candidate is updated after push event", func() {
+		ginkgo.When("[APPLICATION] An snapshot of push event is created", func() {
+			ginkgo.It("[APPLICATION] checks if the global candidate is updated after push event", func() {
 				gomega.Eventually(func() error {
 					snapshotPush, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshotPush.Name, "", "", testNamespace)
-					if err != nil {
-						return err
-					}
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-					componentGroup, err := f.AsKubeAdmin.HasController.GetComponentGroup(componentGroupName, testNamespace)
-					if err != nil {
-						return err
-					}
-
-					if len(componentGroup.Status.GlobalCandidateList) < 1 {
-						return fmt.Errorf("expected GlobalCandidateList to have at least 1 entry, got %d", len(componentGroup.Status.GlobalCandidateList))
-					}
-
-					var gclEntry *v1beta2.ComponentState
-					for i := range componentGroup.Status.GlobalCandidateList {
-						if componentGroup.Status.GlobalCandidateList[i].Name == componentName {
-							gclEntry = &componentGroup.Status.GlobalCandidateList[i]
-							break
-						}
-					}
-					if gclEntry == nil {
-						return fmt.Errorf("component %s not found in GlobalCandidateList", componentName)
-					}
-
-					snapshotImage := ""
-					for _, comp := range snapshotPush.Spec.Components {
-						if comp.Name == componentName {
-							snapshotImage = comp.ContainerImage
-							break
-						}
-					}
-					if snapshotImage == "" {
-						return fmt.Errorf("component %s not found in push snapshot", componentName)
-					}
-
-					if gclEntry.LastPromotedImage != snapshotImage {
-						return fmt.Errorf("expected GCL LastPromotedImage %q to match snapshot image %q", gclEntry.LastPromotedImage, snapshotImage)
-					}
-
+					component, err := f.AsKubeAdmin.HasController.GetComponentByApplicationName(applicationName, testNamespace)
+					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
+					gomega.Expect(component.Spec.ContainerImage).ToNot(gomega.Equal(originalComponent.Spec.ContainerImage))
 					return nil
 
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("time out when waiting for updating the global candidate in %s namespace", testNamespace))
 			})
 
-			ginkgo.It("checks if all of the integrationPipelineRuns created by push event passed", ginkgo.Label("slow"), func() {
-				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, componentGroupName, snapshotPush, []string{integrationTestScenario.Name}, true)).To(gomega.Succeed(), "Error when waiting for one of the integration pipelines to finish in %s namespace", testNamespace)
+			ginkgo.It("[APPLICATION] checks if all of the integrationPipelineRuns created by push event passed", ginkgo.Label("slow"), func() {
+				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshotPush, []string{integrationTestScenario.Name}, false)).To(gomega.Succeed(), "Error when waiting for one of the integration pipelines to finish in %s namespace", testNamespace)
 			})
 
-			ginkgo.It("checks if a Release is created successfully", func() {
+			ginkgo.It("[APPLICATION] checks if a Release is created successfully", func() {
 				timeout = time.Second * 60
 				interval = time.Second * 5
 				gomega.Eventually(func() error {
@@ -263,26 +225,26 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 		})
 	})
 
-	ginkgo.Describe("with an integration test fail", ginkgo.Ordered, func() {
+	ginkgo.Describe("[APPLICATION] with an integration test fail", ginkgo.Ordered, func() {
 		ginkgo.BeforeAll(func() {
 			// Initialize the tests controllers
 			f, err = framework.NewFramework(utils.GetGeneratedNamespace("integration2"))
 			gomega.Expect(err).NotTo(gomega.HaveOccurred())
 			testNamespace = f.UserNamespace
 
-			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
-			ref := createComponentReference(componentName, "component", componentBaseBranchName)
-			componentGroupName = createCompGroup(*f, testNamespace, []v1beta2.ComponentReference{ref})
-			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", componentGroupName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{"pull_request"}, true)
+			applicationName = createApp(*f, testNamespace)
+			originalComponent, componentName, pacBranchName, componentBaseBranchName = createComponentApplication(*f, testNamespace, applicationName, componentRepoNameForGeneralIntegration, componentGitSourceURLForGeneralIntegration)
+
+			integrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{"pull_request"}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
-			skippedIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("skipped-its-fail", componentGroupName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{"group"}, true)
+			skippedIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("skipped-its-fail", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{"group"}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
 		ginkgo.AfterAll(func() {
 			if !ginkgo.CurrentSpecReport().Failed() {
-				cleanup(*f, testNamespace, componentGroupName, componentName, snapshotPush, true)
+				cleanup(*f, testNamespace, applicationName, componentName, snapshotPush, false)
 			}
 
 			// Delete new branches created by PaC and a testing branch used as a component's base branch
@@ -296,14 +258,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			}
 		})
 
-		ginkgo.It("triggers a build PipelineRun", ginkgo.Label("integration-service"), func() {
-			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, "", testNamespace, false, "", true)
+		ginkgo.It("[APPLICATION] triggers a build PipelineRun", ginkgo.Label("integration-service"), func() {
+			pipelineRun, err = f.AsKubeDeveloper.IntegrationController.GetBuildPipelineRun(componentName, applicationName, testNamespace, false, "", false)
 			gomega.Expect(pipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			gomega.Expect(f.AsKubeDeveloper.HasController.WaitForComponentPipelineToBeFinished(originalComponent, "", "", "", f.AsKubeAdmin.TektonController,
 				&has.RetryOptions{Retries: 2, Always: true}, pipelineRun)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("should have a related PaC init PR created", func() {
+		ginkgo.It("[APPLICATION] should have a related PaC init PR created", func() {
 			gomega.Eventually(func() bool {
 				prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForGeneralIntegration)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -322,24 +284,24 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
-			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, componentGroupName, componentName, chainsSignedAnnotation, true)).To(gomega.Succeed())
+		ginkgo.It("[APPLICATION] checks if the BuildPipelineRun have the annotation of chains signed", func() {
+			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation, false)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("checks if the Snapshot is created", func() {
+		ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 			snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", pipelineRun.Name, componentName, testNamespace)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, componentGroupName, componentName, snapshotAnnotation, true)).To(gomega.Succeed())
+		ginkgo.It("[APPLICATION] checks if the Build PipelineRun got annotated with Snapshot name", func() {
+			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation, false)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("checks if all of the integrationPipelineRuns finished", ginkgo.Label("slow"), func() {
-			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, componentGroupName, snapshot, []string{integrationTestScenario.Name}, true)).To(gomega.Succeed())
+		ginkgo.It("[APPLICATION] checks if all of the integrationPipelineRuns finished", ginkgo.Label("slow"), func() {
+			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot, []string{integrationTestScenario.Name}, false)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("checks if the failed status of integration test is reported in the Snapshot", func() {
+		ginkgo.It("[APPLICATION] checks if the failed status of integration test is reported in the Snapshot", func() {
 			gomega.Eventually(func() error {
 				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -354,7 +316,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed())
 		})
 
-		ginkgo.It("checks if the skipped integration test is absent from the Snapshot's status annotation", func() {
+		ginkgo.It("[APPLICATION] checks if the skipped integration test is absent from the Snapshot's status annotation", func() {
 			snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
@@ -364,22 +326,22 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			gomega.Expect(statusDetail).To(gomega.BeNil())
 		})
 
-		ginkgo.It("checks if snapshot is marked as failed", ginkgo.FlakeAttempts(3), func() {
+		ginkgo.It("[APPLICATION] checks if snapshot is marked as failed", ginkgo.FlakeAttempts(3), func() {
 			snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			gomega.Expect(gitops.HaveAppStudioTestsSucceeded(snapshot)).To(gomega.BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
 		})
 
-		ginkgo.It("checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
-			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, componentGroupName, snapshot, []string{integrationTestScenario.Name}, true)).To(gomega.Succeed())
+		ginkgo.It("[APPLICATION] checks if the finalizer was removed from all of the related Integration pipelineRuns", func() {
+			gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromAllIntegrationPipelineRuns(testNamespace, applicationName, snapshot, []string{integrationTestScenario.Name}, false)).To(gomega.Succeed())
 		})
 
-		ginkgo.It("creates a new IntegrationTestScenario", func() {
-			newIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", componentGroupName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{}, true)
+		ginkgo.It("[APPLICATION] creates a new IntegrationTestScenario", func() {
+			newIntegrationTestScenario, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		ginkgo.It("updates the Snapshot with the re-run label for the new scenario", ginkgo.FlakeAttempts(3), func() {
+		ginkgo.It("[APPLICATION] updates the Snapshot with the re-run label for the new scenario", ginkgo.FlakeAttempts(3), func() {
 			updatedSnapshot := snapshot.DeepCopy()
 			err := metadata.AddLabels(updatedSnapshot, map[string]string{snapshotRerunLabel: newIntegrationTestScenario.Name})
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -387,14 +349,14 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 			gomega.Expect(metadata.GetLabelsWithPrefix(updatedSnapshot, snapshotRerunLabel)).NotTo(gomega.BeEmpty())
 		})
 
-		ginkgo.When("An snapshot is updated with a re-run label for a given scenario", func() {
-			ginkgo.It("checks if the new integration pipelineRun started", ginkgo.Label("slow"), func() {
+		ginkgo.When("[APPLICATION] An snapshot is updated with a re-run label for a given scenario", func() {
+			ginkgo.It("[APPLICATION] checks if the new integration pipelineRun started", ginkgo.Label("slow"), func() {
 				reRunPipelineRun, err := f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(newIntegrationTestScenario.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(reRunPipelineRun).ShouldNot(gomega.BeNil())
 			})
 
-			ginkgo.It("checks if the re-run label was removed from the Snapshot", func() {
+			ginkgo.It("[APPLICATION] checks if the re-run label was removed from the Snapshot", func() {
 				gomega.Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					if err != nil {
@@ -408,11 +370,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, timeout, interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if all integration pipelineRuns finished successfully", ginkgo.Label("slow"), func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, componentGroupName, snapshot, []string{integrationTestScenario.Name, newIntegrationTestScenario.Name}, true)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if all integration pipelineRuns finished successfully", ginkgo.Label("slow"), func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForAllIntegrationPipelinesToBeFinished(testNamespace, applicationName, snapshot, []string{integrationTestScenario.Name, newIntegrationTestScenario.Name}, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the name of the re-triggered pipelinerun is reported in the Snapshot", ginkgo.FlakeAttempts(3), func() {
+			ginkgo.It("[APPLICATION] checks if the name of the re-triggered pipelinerun is reported in the Snapshot", ginkgo.FlakeAttempts(3), func() {
 				gomega.Eventually(func(g gomega.Gomega) {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					g.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -429,21 +391,21 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 				}, timeout, interval).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if snapshot is still marked as failed", func() {
+			ginkgo.It("[APPLICATION] checks if snapshot is still marked as failed", func() {
 				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 				gomega.Expect(gitops.HaveAppStudioTestsSucceeded(snapshot)).To(gomega.BeFalse(), "expected tests to fail for snapshot %s/%s", snapshot.GetNamespace(), snapshot.GetName())
 			})
 		})
 
-		ginkgo.It("creates an snapshot of push event", func() {
+		ginkgo.It("[APPLICATION] creates an snapshot of push event", func() {
 			sampleImage := "quay.io/redhat-appstudio/sample-image@sha256:841328df1b9f8c4087adbdcfec6cc99ac8308805dea83f6d415d6fb8d40227c1"
-			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, componentGroupName, testNamespace, sampleImage, componentBaseBranchName, true)
+			snapshotPush, err = f.AsKubeAdmin.IntegrationController.CreateSnapshotWithImage(componentName, applicationName, testNamespace, sampleImage, "", false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 		})
 
-		ginkgo.When("An snapshot of push event is created", func() {
-			ginkgo.It("checks no Release CRs are created", func() {
+		ginkgo.When("[APPLICATION] An snapshot of push event is created", func() {
+			ginkgo.It("[APPLICATION] checks no Release CRs are created", func() {
 				releases, err := f.AsKubeAdmin.ReleaseController.GetReleases(testNamespace)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred(), "Error when fetching the Releases")
 				gomega.Expect(releases.Items).To(gomega.BeEmpty(), "Expected no Release CRs to be present, but found some")
@@ -452,26 +414,16 @@ var _ = framework.IntegrationServiceSuiteDescribe("Integration Service E2E tests
 	})
 })
 
-func createCompGroup(f framework.Framework, testNamespace string, components []v1beta2.ComponentReference) string {
-	componentGroupName := fmt.Sprintf("integ-app-%s", utils.GenerateRandomString(4))
+func createApp(f framework.Framework, testNamespace string) string {
+	applicationName := fmt.Sprintf("integ-app-%s", utils.GenerateRandomString(4))
 
-	_, err := f.AsKubeAdmin.HasController.CreateComponentGroup(componentGroupName, testNamespace, components)
+	_, err := f.AsKubeAdmin.HasController.CreateApplication(applicationName, testNamespace)
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
-	return componentGroupName
+	return applicationName
 }
 
-func createComponentReference(name, kind, version string) v1beta2.ComponentReference {
-	return v1beta2.ComponentReference{
-		Name: name,
-		Kind: kind,
-		ComponentVersion: v1beta2.ComponentVersionReference{
-			Name: version,
-		},
-	}
-}
-
-func createComponent(f framework.Framework, testNamespace, componentRepoName, componentRepoURL string) (*appstudioApi.Component, string, string, string) {
+func createComponentApplication(f framework.Framework, testNamespace, applicationName, componentRepoName, componentRepoURL string) (*appstudioApi.Component, string, string, string) {
 	componentName := fmt.Sprintf("%s-%s", "test-component-pac", utils.GenerateRandomString(6))
 	pacBranchName := constants.PaCPullRequestBranchPrefix + componentName
 	componentBaseBranchName := fmt.Sprintf("base-%s", utils.GenerateRandomString(6))
@@ -486,20 +438,19 @@ func createComponent(f framework.Framework, testNamespace, componentRepoName, co
 	buildPipelineAnnotation := build.GetBuildPipelineBundleAnnotation(constants.DockerBuild)
 
 	componentObj := appstudioApi.ComponentSpec{
+		ComponentName: componentName,
+		Application:   applicationName,
 		Source: appstudioApi.ComponentSource{
 			ComponentSourceUnion: appstudioApi.ComponentSourceUnion{
-				GitURL: componentRepoURL,
-				Versions: []appstudioApi.ComponentVersion{
-					{
-						Name:     componentBaseBranchName,
-						Revision: componentBaseBranchName,
-					},
+				GitSource: &appstudioApi.GitSource{
+					URL:      componentRepoURL,
+					Revision: componentBaseBranchName,
 				},
 			},
 		},
 	}
 
-	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, componentName, testNamespace, "", "", "", false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
+	originalComponent, err := f.AsKubeAdmin.HasController.CreateComponentCheckImageRepository(componentObj, componentName, testNamespace, "", "", applicationName, false, utils.MergeMaps(utils.MergeMaps(constants.ComponentPaCRequestAnnotation, constants.ImageControllerAnnotationRequestPublicRepo), buildPipelineAnnotation))
 	gomega.Expect(err).NotTo(gomega.HaveOccurred())
 
 	return originalComponent, componentName, pacBranchName, componentBaseBranchName

--- a/e2e-tests/tests/integration-service/status-reporting-to-pullrequest-application.go
+++ b/e2e-tests/tests/integration-service/status-reporting-to-pullrequest-application.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integration tests", ginkgo.Label("integration-service", "github-status-reporting"), func() {
+var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integration tests", ginkgo.Label("integration-service", "applications", "github-status-reporting"), func() {
 	defer ginkgo.GinkgoRecover()
 
 	var f *framework.Framework
@@ -41,7 +41,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 	ginkgo.AfterEach(framework.ReportFailure(&f))
 
-	ginkgo.Describe("with status reporting of Integration tests in CheckRuns", ginkgo.Ordered, func() {
+	ginkgo.Describe("[APPLICATION] with status reporting of Integration tests in CheckRuns", ginkgo.Ordered, func() {
 		ginkgo.BeforeAll(func() {
 			if os.Getenv(constants.SKIP_PAC_TESTS_ENV) == "true" {
 				ginkgo.Skip("Skipping this test due to configuration issue with Spray proxy")
@@ -64,17 +64,17 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			}, time.Minute*2, time.Second*5).Should(gomega.Succeed(),
 				fmt.Sprintf("Application %s should be available in namespace %s", applicationName, testNamespace))
 
-			component, componentName, pacBranchName, componentBaseBranchName = createComponent(*f, testNamespace, applicationName, componentRepoNameForStatusReporting, componentGitSourceURLForStatusReporting)
+			component, componentName, pacBranchName, componentBaseBranchName = createComponentApplication(*f, testNamespace, applicationName, componentRepoNameForStatusReporting, componentGitSourceURLForStatusReporting)
 
-			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{})
+			integrationTestScenarioPass, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoPass, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{})
+			integrationTestScenarioFail, err = f.AsKubeAdmin.IntegrationController.CreateIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
-			integrationTestScenarioOptional, err = f.AsKubeAdmin.IntegrationController.CreateOptionalIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{})
+			integrationTestScenarioOptional, err = f.AsKubeAdmin.IntegrationController.CreateOptionalIntegrationTestScenario("", applicationName, testNamespace, gitURL, revision, pathInRepoFail, "", []string{}, false)
 			gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 
 			gomega.Eventually(func() error {
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", "", "")
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, testNamespace, "build", "", "")
 				if err != nil {
 					ginkgo.GinkgoWriter.Printf("Build PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 					return err
@@ -91,7 +91,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 		ginkgo.AfterAll(func() {
 			if !ginkgo.CurrentSpecReport().Failed() {
-				cleanup(*f, testNamespace, applicationName, componentName, snapshot)
+				cleanup(*f, testNamespace, applicationName, componentName, snapshot, false)
 			}
 
 			// Delete new branches created by PaC and a testing branch used as a component's base branch
@@ -105,12 +105,12 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			}
 		})
 
-		ginkgo.When("a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
-			ginkgo.It("does not contain an annotation with a Snapshot Name", func() {
+		ginkgo.When("[APPLICATION] a new Component with specified custom branch is created", ginkgo.Label("custom-branch"), func() {
+			ginkgo.It("[APPLICATION] does not contain an annotation with a Snapshot Name", func() {
 				gomega.Expect(pipelineRun.Annotations[snapshotAnnotation]).To(gomega.Equal(""))
 			})
 
-			ginkgo.It("should have a related PaC init PR created", func() {
+			ginkgo.It("[APPLICATION] should have a related PaC init PR created", func() {
 				gomega.Eventually(func() bool {
 					prs, err := f.AsKubeAdmin.CommonController.Github.ListPullRequests(componentRepoNameForStatusReporting)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -125,11 +125,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 					return false
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.BeTrue(), fmt.Sprintf("timed out when waiting for init PaC PR (branch name '%s') to be created in %s repository", pacBranchName, componentRepoNameForStatusReporting))
 				// in case the first pipelineRun attempt has failed and was retried, we need to update the value of pipelineRun variable
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", prHeadSha, "")
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, testNamespace, "build", prHeadSha, "")
 				gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("initialized integration test status is reported to github", func() {
+			ginkgo.It("[APPLICATION] initialized integration test status is reported to github", func() {
 				gomega.Eventually(func() error {
 					status, err := f.AsKubeAdmin.CommonController.Github.GetCheckRunStatus(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)
 					if status != "queued" || err != nil {
@@ -139,29 +139,29 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				}, longTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed(), fmt.Sprintf("timed out when waiting for the pending checkrun for the component  %s/%s and integrationTestScenarioPass %s", testNamespace, componentName, integrationTestScenarioPass.Name))
 			})
 
-			ginkgo.It("should lead to build PipelineRun finishing successfully", func() {
-				logs, err := f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineToBeFinished(testNamespace, applicationName, component.Name, "")
+			ginkgo.It("[APPLICATION] should lead to build PipelineRun finishing successfully", func() {
+				logs, err := f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineToBeFinished(testNamespace, applicationName, component.Name, "", false)
 				gomega.Expect(err).Should(gomega.Succeed(), fmt.Sprintf("build pipelinerun fails for NameSpace/Application/Component %s/%s/%s with logs: %s", testNamespace, applicationName, componentName, logs))
 			})
 		})
 
-		ginkgo.When("the PaC build pipelineRun run succeeded", func() {
-			ginkgo.It("checks if the BuildPipelineRun have the annotation of chains signed", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation)).To(gomega.Succeed())
+		ginkgo.When("[APPLICATION] the PaC build pipelineRun run succeeded", func() {
+			ginkgo.It("[APPLICATION] checks if the BuildPipelineRun have the annotation of chains signed", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, chainsSignedAnnotation, false)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the Snapshot is created", func() {
+			ginkgo.It("[APPLICATION] checks if the Snapshot is created", func() {
 				snapshot, err = f.AsKubeDeveloper.IntegrationController.WaitForSnapshotToGetCreated("", "", componentName, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 			})
 
-			ginkgo.It("checks if the Build PipelineRun got annotated with Snapshot name", func() {
-				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation)).To(gomega.Succeed())
+			ginkgo.It("[APPLICATION] checks if the Build PipelineRun got annotated with Snapshot name", func() {
+				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForBuildPipelineRunToGetAnnotated(testNamespace, applicationName, componentName, snapshotAnnotation, false)).To(gomega.Succeed())
 			})
 		})
 
-		ginkgo.When("the Snapshot was created", func() {
-			ginkgo.It("should find both the related Integration PipelineRuns", func() {
+		ginkgo.When("[APPLICATION] the Snapshot was created", func() {
+			ginkgo.It("[APPLICATION] should find both the related Integration PipelineRuns", func() {
 				testPipelinerun, err = f.AsKubeDeveloper.IntegrationController.WaitForIntegrationPipelineToGetStarted(integrationTestScenarioPass.Name, snapshot.Name, testNamespace)
 				gomega.Expect(err).ToNot(gomega.HaveOccurred())
 				gomega.Expect(testPipelinerun.Labels[snapshotAnnotation]).To(gomega.ContainSubstring(snapshot.Name))
@@ -179,21 +179,21 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			})
 		})
 
-		ginkgo.When("Integration PipelineRuns are created", func() {
-			ginkgo.It("should eventually complete successfully", func() {
+		ginkgo.When("[APPLICATION] Integration PipelineRuns are created", func() {
+			ginkgo.It("[APPLICATION] should eventually complete successfully", func() {
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioFail, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioOptional, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 			})
 		})
 
-		ginkgo.When("Integration PipelineRuns completes successfully", func() {
-			ginkgo.It("should lead to Snapshot CR being marked as failed", ginkgo.FlakeAttempts(3), func() {
+		ginkgo.When("[APPLICATION] Integration PipelineRuns completes successfully", func() {
+			ginkgo.It("[APPLICATION] should lead to Snapshot CR being marked as failed", ginkgo.FlakeAttempts(3), func() {
 				// Snapshot marked as Failed because one of its Integration test failed (as expected)
-				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", prHeadSha, "")
+				pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, testNamespace, "build", prHeadSha, "")
 				gomega.Expect(err).Should(gomega.Succeed())
 				gomega.Eventually(func() bool {
-					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, applicationName, testNamespace, "build", prHeadSha, "")
+					pipelineRun, err = f.AsKubeAdmin.HasController.GetComponentPipelineRunWithType(componentName, testNamespace, "build", prHeadSha, "")
 					if err != nil {
 						return false
 					}
@@ -202,19 +202,19 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				}, time.Minute*3, time.Second*5).Should(gomega.BeTrue(), fmt.Sprintf("Timed out waiting for Snapshot to be marked as failed %s/%s", snapshot.GetNamespace(), snapshot.GetName()))
 			})
 
-			ginkgo.It("eventually leads to the status reported at Checks tab for the successful Integration PipelineRun", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the status reported at Checks tab for the successful Integration PipelineRun", func() {
 				gomega.Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(gomega.Equal(constants.CheckrunConclusionSuccess))
 			})
 
-			ginkgo.It("eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
 				gomega.Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioFail.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(gomega.Equal(constants.CheckrunConclusionFailure))
 			})
 
-			ginkgo.It("eventually leads to the status reported at Checks tab for the optional Integration PipelineRun", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the status reported at Checks tab for the optional Integration PipelineRun", func() {
 				gomega.Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioOptional.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(gomega.Equal(constants.CheckrunConclusionNeutral))
 			})
 
-			ginkgo.It("checks if the optional Integration Test Scenario status is reported in the Snapshot", func() {
+			ginkgo.It("[APPLICATION] checks if the optional Integration Test Scenario status is reported in the Snapshot", func() {
 				gomega.Eventually(func() error {
 					snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 					gomega.Expect(err).ShouldNot(gomega.HaveOccurred())
@@ -229,11 +229,11 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				}, shortTimeout, constants.PipelineRunPollingInterval).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("checks if the finalizer was removed from the optional Integration PipelineRun", func() {
+			ginkgo.It("[APPLICATION] checks if the finalizer was removed from the optional Integration PipelineRun", func() {
 				gomega.Expect(f.AsKubeDeveloper.IntegrationController.WaitForFinalizerToGetRemovedFromIntegrationPipeline(integrationTestScenarioOptional, snapshot, testNamespace)).To(gomega.Succeed())
 			})
 
-			ginkgo.It("merging the PR, expected to succeed ", func() {
+			ginkgo.It("[APPLICATION] merging the PR, expected to succeed ", func() {
 				gomega.Eventually(func() error {
 					mergeResult, err = f.AsKubeAdmin.CommonController.Github.MergePullRequest(componentRepoNameForStatusReporting, prNumber)
 					return err
@@ -242,9 +242,9 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				ginkgo.GinkgoWriter.Printf("merged result sha: %s for PR #%d\n", mergeResultSha, prNumber)
 			})
 
-			ginkgo.It("leads to triggering a push PipelineRun", func() {
+			ginkgo.It("[APPLICATION] leads to triggering a push PipelineRun", func() {
 				gomega.Eventually(func() error {
-					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, applicationName, testNamespace, mergeResultSha)
+					pipelineRun, err := f.AsKubeAdmin.HasController.GetComponentPipelineRun(componentName, testNamespace, mergeResultSha)
 					if err != nil {
 						ginkgo.GinkgoWriter.Printf("Push PipelineRun has not been created yet for the component %s/%s\n", testNamespace, componentName)
 						return err
@@ -257,23 +257,23 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 
 			})
 
-			ginkgo.It("verifies that Push PipelineRuns completed", func() {
+			ginkgo.It("[APPLICATION] verifies that Push PipelineRuns completed", func() {
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioPass, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 				gomega.Expect(f.AsKubeAdmin.IntegrationController.WaitForIntegrationPipelineToBeFinished(integrationTestScenarioFail, snapshot, testNamespace)).To(gomega.Succeed(), fmt.Sprintf("Error when waiting for an integration pipelinerun for snapshot %s/%s to finish", testNamespace, snapshot.GetName()))
 			})
 
-			ginkgo.It("validates the Integration test scenario PipelineRun is reported to merge request CheckRuns, and it pass", func() {
+			ginkgo.It("[APPLICATION] validates the Integration test scenario PipelineRun is reported to merge request CheckRuns, and it pass", func() {
 				gomega.Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(gomega.Equal(constants.CheckrunConclusionSuccess))
 
 			})
 
-			ginkgo.It("eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
+			ginkgo.It("[APPLICATION] eventually leads to the status reported at Checks tab for the failed Integration PipelineRun", func() {
 				gomega.Expect(f.AsKubeAdmin.CommonController.Github.GetCheckRunConclusion(integrationTestScenarioFail.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)).To(gomega.Equal(constants.CheckrunConclusionFailure))
 			})
 		})
 
-		ginkgo.When("The git-provider annotation is missing", func() {
-			ginkgo.It("should set the git-reporting-failure annotation correctly", func() {
+		ginkgo.When("[APPLICATION] The git-provider annotation is missing", func() {
+			ginkgo.It("[APPLICATION] should set the git-reporting-failure annotation correctly", func() {
 				// Get snapshot from the cluster
 				snapshot, err = f.AsKubeAdmin.IntegrationController.GetSnapshot(snapshot.Name, "", "", testNamespace)
 				gomega.Expect(err).NotTo(gomega.HaveOccurred())
@@ -319,8 +319,8 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 			})
 		})
 
-		ginkgo.When("build pipelinerun fails", func() {
-			ginkgo.It("build pipelinerun is created but fails", func() {
+		ginkgo.When("[APPLICATION] build pipelinerun fails", func() {
+			ginkgo.It("[APPLICATION] build pipelinerun is created but fails", func() {
 				// delete snapshot creation report annotation to create a new build plr manually
 				delete(annotations, snapshotCreationReport)
 				failedPipelineRun = &tektonv1.PipelineRun{
@@ -365,7 +365,7 @@ var _ = framework.IntegrationServiceSuiteDescribe("Status Reporting of Integrati
 				gomega.Expect(f.AsKubeAdmin.TektonController.WatchPipelineRunSucceeded(failedPipelineRun.Name, testNamespace, pipelineRunTimeout)).Should(gomega.Succeed())
 			})
 
-			ginkgo.It("build pipelinerun failure is reported to integration test checkRun", func() {
+			ginkgo.It("[APPLICATION] build pipelinerun failure is reported to integration test checkRun", func() {
 				gomega.Eventually(func() error {
 					text, err := f.AsKubeAdmin.CommonController.Github.GetCheckRunText(integrationTestScenarioPass.Name, componentRepoNameForStatusReporting, prHeadSha, prNumber)
 					if err != nil || !strings.Contains(text, "Failed to create snapshot") {

--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -1343,7 +1343,8 @@ func SetOwnerReference(ctx context.Context, adapterClient client.Client, snapsho
 // IsContextValidForSnapshot checks the context and compares it against the Snapshot to determine if it applies
 func IsContextValidForSnapshot(scenarioContextName string, snapshot *applicationapiv1alpha1.Snapshot) bool {
 	// `application` context is supported for backwards-compatibility and considered the same as `all`
-	if scenarioContextName == "application" || scenarioContextName == "all" {
+	// TODO: remove "application" context after migration to componentGroups (ITS's with this context should be switched to "componentGroup")
+	if scenarioContextName == "application" || scenarioContextName == "componentgroup" || scenarioContextName == "all" {
 		return true
 	} else if scenarioContextName == "component" && IsComponentSnapshot(snapshot) {
 		return true


### PR DESCRIPTION
Duplicates the functionality of the integration tests in integration.go to support componentGroups. Does so in a way that allows easy removal of application-speficic code when that code is deprecated. Also updates several helper functions to have the same dual support

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
