### PR TITLE
fix(STONEINTG-1695): updatedComponentIs checks component label

### DIFF
--- a/gitops/release.go
+++ b/gitops/release.go
@@ -123,29 +123,23 @@ func (sf snapshotCELFunctions) shouldReleaseFn(args ...ref.Val) ref.Val {
 }
 
 func (sf snapshotCELFunctions) updatedComponentIs(arg ref.Val) ref.Val {
-	name, ok := arg.Value().(string)
+	// Note: does not work for group snapshots, they are always PR snapshots so auto-release does not apply.
+	name := arg.Value().(string)
+
+	// Check the snapshot.metadata.labels for updated component
+	meta, ok := sf.snapshot["metadata"].(map[string]any)
 	if !ok {
 		return types.Bool(false)
 	}
-	// Navigate snapshot.spec.components[].name
-	spec, ok := sf.snapshot["spec"].(map[string]any)
+	labels, ok := meta["labels"].(map[string]any)
 	if !ok {
 		return types.Bool(false)
 	}
-	components, ok := spec["components"].([]any)
+	compName, ok := labels[SnapshotComponentLabel].(string)
 	if !ok {
 		return types.Bool(false)
 	}
-	for _, c := range components {
-		cm, ok := c.(map[string]any)
-		if !ok {
-			continue
-		}
-		if compName, ok := cm["name"].(string); ok && compName == name {
-			return types.Bool(true)
-		}
-	}
-	return types.Bool(false)
+	return types.Bool(compName == name)
 }
 
 // convertToCELObjectMap marshals the typed object to JSON and back to a

--- a/gitops/release_test.go
+++ b/gitops/release_test.go
@@ -105,10 +105,57 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 
 	It("returns true when the updated component is 'component-sample'", func() {
 		snapshotCopy := hasSnapshot.DeepCopy()
+		if snapshotCopy.Labels == nil {
+			snapshotCopy.Labels = make(map[string]string)
+		}
+		snapshotCopy.Labels["appstudio.openshift.io/component"] = "component-sample" //updating label to trigger the CEL expression
 		autoReleaseAnnotation := "updatedComponentIs('component-sample')"
 		allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(autoReleaseAnnotation, snapshotCopy, true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(allowed).To(BeTrue())
+	})
+
+	// Verifies that updatedComponentIs() uses the appstudio.openshift.io/component label
+	// to identify the triggering component, not spec.components which contains all components.
+	Context("updatedComponentIs() with multi-component snapshots", func() {
+
+		It("returns true when the label matches the requested component in the snapshot", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			snapshotCopy.Spec.Components = append(snapshotCopy.Spec.Components, applicationapiv1alpha1.SnapshotComponent{
+				Name:           "backend",
+				ContainerImage: "quay.io/redhat-appstudio/backend-image:latest",
+			})
+			if snapshotCopy.Labels == nil {
+				snapshotCopy.Labels = make(map[string]string)
+			}
+			snapshotCopy.Labels["appstudio.openshift.io/component"] = "frontend"
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("updatedComponentIs('frontend')", snapshotCopy, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue())
+		})
+
+		It("returns false when the label points to a different component", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			snapshotCopy.Spec.Components = append(snapshotCopy.Spec.Components, applicationapiv1alpha1.SnapshotComponent{
+				Name:           "backend",
+				ContainerImage: "quay.io/redhat-appstudio/backend-image:latest",
+			})
+			if snapshotCopy.Labels == nil {
+				snapshotCopy.Labels = make(map[string]string)
+			}
+			snapshotCopy.Labels["appstudio.openshift.io/component"] = "frontend"
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("updatedComponentIs('backend')", snapshotCopy, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeFalse())
+		})
+
+		It("returns false when no component label is set", func() {
+			snapshotCopy := hasSnapshot.DeepCopy()
+			delete(snapshotCopy.Labels, "appstudio.openshift.io/component")
+			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation("updatedComponentIs('frontend')", snapshotCopy, true)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeFalse())
+		})
 	})
 
 	It("returns error and false when the auto-release annotation is an invalid CEL expression", func() {
@@ -147,6 +194,10 @@ var _ = Describe("Auto-release annotation evaluation", Ordered, func() {
 
 		It("composes with updatedComponentIs", func() {
 			snapshotCopy := hasSnapshot.DeepCopy()
+			if snapshotCopy.Labels == nil {
+				snapshotCopy.Labels = make(map[string]string)
+			}
+			snapshotCopy.Labels["appstudio.openshift.io/component"] = "component-sample"
 			expr := "shouldRelease() && updatedComponentIs('component-sample')"
 			allowed, err := gitops.EvaluateSnapshotAutoReleaseAnnotation(expr, snapshotCopy, true)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary
Fixes a bug in the `updatedComponentIs()` custom CEL function used in ReleasePlan auto-release annotation expressions.

## Root Cause
The function was iterating over `spec.components[]` to check if a component with the given name existed in the snapshot. 

Since every snapshot contains all components in the application (the newly built component plus all others from the Global Candidate List), the function returned` true` for any component name, regardless of which component actually triggered the build.

## Fix
Updated `updatedComponentIs()` to read the `appstudio.openshift.io/component` label on the snapshot instead. This label is set at snapshot creation time and identifies the specific component that triggered the build, making it the correct source of truth.

*Also added a comment noting the function does not apply to group snapshots, as they are always pull request snapshots where auto-release is not applicable.*

## Tests
Updated existing tests to set the `appstudio.openshift.io/component` label on snapshot copies. Added a new `Context` block with three test cases covering:
* Label matches requested component $\rightarrow$ `true`
* Label points to a different component (even though both exist in `spec.components`) $\rightarrow$ `false`
* Component label absent but other labels present $\rightarrow$ `false`

## Links
* **Jira:** https://redhat.atlassian.net/jira/software/c/projects/BMPTEMP/boards/9424?selectedIssue=STONEINTG-1695.
*https://onsi.github.io/ginkgo/

---

### Maintainers will complete the following section

- [ ] Commit messages are descriptive enough (hints)
- [ ] Code coverage from testing does not decrease and new code is covered (check the PR coverage on codecov)
- [ ] Controllers diagrams are updated when PR changes controllers code (if applicable)

