### PR TITLE
fix(STONEINTG-1710): read trusted-ca from integration-service namespace

### DIFF
--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -4427,7 +4427,9 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(k8sClient.Status().Update(ctx, nudgeConfig)).Should(Succeed())
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(nudgeConfig), nudgeConfig)).To(Succeed())
-				g.Expect(meta.FindStatusCondition(nudgeConfig.Status.Conditions, helpers.StaleReferencesStatusCondition).Status).To(Equal(metav1.ConditionTrue))
+				cond := meta.FindStatusCondition(nudgeConfig.Status.Conditions, helpers.StaleReferencesStatusCondition)
+				g.Expect(cond).NotTo(BeNil())
+				g.Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			}, time.Second*5).Should(Succeed())
 
 			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -225,11 +225,8 @@ const (
 	CaVolumeMountName = "trusted-ca"
 
 	/*
-	 * Build-service namespace and PaC secret constants (for GitHub App auth)
+	 * Build-service PaC secret constants (for GitHub App auth)
 	 */
-
-	// BuildServiceNamespaceName is the namespace where build-service is deployed
-	BuildServiceNamespaceName = "build-service"
 
 	// PipelinesAsCodeGitHubAppSecretName is the global PaC secret for GitHub App auth
 	PipelinesAsCodeGitHubAppSecretName = "pipelines-as-code-secret"

--- a/tekton/nudging/nudge_pipeline.go
+++ b/tekton/nudging/nudge_pipeline.go
@@ -348,13 +348,17 @@ func CreateNudgePipelineRun(ctx context.Context, c client.Client, nudgingPLR *te
 		return nil
 	}
 
-	// Look for a CA bundle ConfigMap in the build-service namespace.
+	operatorNamespace := os.Getenv("INTEGRATION_NS")
+	if operatorNamespace == "" {
+		operatorNamespace = "integration-service"
+	}
+
 	allCaConfigMaps := &corev1.ConfigMapList{}
 	if err := c.List(ctx, allCaConfigMaps,
-		client.InNamespace(tektonconsts.BuildServiceNamespaceName),
+		client.InNamespace(operatorNamespace),
 		client.MatchingLabels{tektonconsts.CaConfigMapLabel: "true"},
 	); err != nil {
-		return fmt.Errorf("listing CA config maps in %s namespace: %w", tektonconsts.BuildServiceNamespaceName, err)
+		return fmt.Errorf("listing CA config maps in %s namespace: %w", operatorNamespace, err)
 	}
 	caConfigData := ""
 	if len(allCaConfigMaps.Items) > 0 {

--- a/tekton/nudging/nudge_pipeline_test.go
+++ b/tekton/nudging/nudge_pipeline_test.go
@@ -653,7 +653,7 @@ var _ = Describe("Nudge Pipeline", func() {
 		})
 
 		Context("with CA bundle", func() {
-			It("mounts the CA ConfigMap volume when a CA bundle exists in build-service namespace", func() {
+			It("mounts the CA ConfigMap volume when a CA bundle exists in the operator namespace", func() {
 				scheme := nudgeTestScheme()
 
 				sa := &corev1.ServiceAccount{
@@ -663,7 +663,7 @@ var _ = Describe("Nudge Pipeline", func() {
 				caCM := &corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      "trusted-ca-bundle",
-						Namespace: tektonconsts.BuildServiceNamespaceName,
+						Namespace: "integration-service",
 						Labels:    map[string]string{tektonconsts.CaConfigMapLabel: "true"},
 					},
 					Data: map[string]string{
@@ -671,13 +671,9 @@ var _ = Describe("Nudge Pipeline", func() {
 					},
 				}
 
-				buildNS := &corev1.Namespace{
-					ObjectMeta: metav1.ObjectMeta{Name: tektonconsts.BuildServiceNamespaceName},
-				}
-
 				caFakeClient := fake.NewClientBuilder().
 					WithScheme(scheme).
-					WithObjects(sa, caCM, buildNS).
+					WithObjects(sa, caCM).
 					Build()
 
 				err := nudging.CreateNudgePipelineRun(testCtx, caFakeClient, nudgingPLR, targets, buildResult, false)


### PR DESCRIPTION
CA ConfigMap lookup for nudge PipelineRuns was reading from the build-service namespace, creating a cross-namespace dependency. Integration-service already has its own trusted-ca ConfigMap (same rh-certs component, same label, same content), so read from the operator's own namespace instead.

Removes BuildServiceNamespaceName constant from consts.go.

Assisted-By: Claude code

[STONEINTG-1710](https://redhat.atlassian.net/browse/STONEINTG-1710)

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


[STONEINTG-1710]: https://redhat.atlassian.net/browse/STONEINTG-1710?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ