### PR TITLE
fix: grant bind verb on konflux-integration-runner CRole

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -106,6 +106,14 @@ rules:
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io
+  resourceNames:
+  - konflux-integration-runner
+  resources:
+  - clusterroles
+  verbs:
+  - bind
+- apiGroups:
+  - rbac.authorization.k8s.io
   resources:
   - rolebindings
   verbs:

--- a/internal/controller/scenario/scenario_controller.go
+++ b/internal/controller/scenario/scenario_controller.go
@@ -58,6 +58,7 @@ func NewScenarioReconciler(client client.Client, logger *logr.Logger, scheme *ru
 //+kubebuilder:rbac:groups="",resources=serviceaccounts,verbs=get;list;watch;create;update
 //+kubebuilder:rbac:groups="",resources=secrets,verbs=get;create
 //+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;watch;create
+//+kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=clusterroles,verbs=bind,resourceNames=konflux-integration-runner
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.


### PR DESCRIPTION
The scenario controller creates a RoleBinding for the konflux-integration-runner ClusterRole when an IntegrationTestScenario is created. This was failing with a privilege escalation error because Kubernetes prevents granting permissions the creator doesn't already hold.

Added the bind verb scoped to the konflux-integration-runner ClusterRole in the RBAC marker, which is the correct Kubernetes mechanism for this case — it allows creating the RoleBinding without requiring the IS controller manager to hold all the permissions the ClusterRole grants.

Bug discovered while working on [STONEINTG-1722](https://redhat.atlassian.net/browse/STONEINTG-1722)


[STONEINTG-1722]: https://redhat.atlassian.net/browse/STONEINTG-1722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ