### PR TITLE
chore(STONEINTG-1700): remove Gemini code review config

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,4 +1,0 @@
-code_review:
-  pull_request_opened:
-    summary: false
-    include_drafts: false


### PR DESCRIPTION
Removes .gemini/config.yaml which enabled automated Gemini code review on pull requests.
Following PR is for the removal of the file from the **integration-service** repo.