### PR TITLE
fix(STONEINTG-1671): use IS-owned annotation and finalizer for nudge processing

### DIFF
--- a/helpers/finalizers.go
+++ b/helpers/finalizers.go
@@ -20,3 +20,7 @@ package helpers
 const IntegrationPipelineRunFinalizer string = "test.appstudio.openshift.io/pipelinerun"
 const IntegrationTestScenarioFinalizer string = "test.appstudio.openshift.io/scenario"
 const ComponentFinalizer string = "test.appstudio.openshift.io/component"
+
+// NudgePipelineRunFinalizer is the finalizer name added to build PipelineRuns while IS is
+// actively creating a nudge PipelineRun, preventing premature GC before nudging completes.
+const NudgePipelineRunFinalizer string = "test.appstudio.openshift.io/nudge-pipelinerun"

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -161,7 +161,22 @@ func (a *Adapter) EnsureNudgePipelineRunsExist() (controller.OperationResult, er
 		return controller.ContinueProcessing()
 	}
 
+	// Idempotency guard: nudge already processed. Remove the nudge finalizer if it somehow
+	// survived (e.g. IS crashed between nudge PLR creation and annotation write).
 	if metadata.HasAnnotation(a.pipelineRun, tektonconsts.NudgeProcessedAnnotation) {
+		if err := h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.NudgePipelineRunFinalizer); err != nil && !errors.IsNotFound(err) {
+			return controller.RequeueWithError(err)
+		}
+		return controller.ContinueProcessing()
+	}
+
+	// If the PLR is being deleted, nudging can no longer be completed. Remove any stale nudge
+	// finalizer (left by a crash between finalizer add and annotation write) so the PLR is
+	// not stuck in Terminating.
+	if a.pipelineRun.GetDeletionTimestamp() != nil {
+		if err := h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.NudgePipelineRunFinalizer); err != nil && !errors.IsNotFound(err) {
+			return controller.RequeueWithError(err)
+		}
 		return controller.ContinueProcessing()
 	}
 
@@ -247,9 +262,16 @@ func (a *Adapter) EnsureNudgePipelineRunsExist() (controller.OperationResult, er
 		return controller.ContinueProcessing()
 	}
 
+	// Add the nudge finalizer just before creating the nudge PLR so the build PLR cannot be
+	// GC'd between PLR creation and the annotation write that marks nudging as complete.
+	if err := h.AddFinalizerToPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.NudgePipelineRunFinalizer); err != nil {
+		return controller.RequeueWithError(err)
+	}
+
 	err = nudging.CreateNudgePipelineRun(a.context, a.client, a.pipelineRun, targets, buildResult, simpleBranchName)
 	if err != nil {
 		a.logger.Error(err, "Failed to create nudge PipelineRun")
+		// Keep the nudge finalizer so the PLR stays alive for the retry.
 		return controller.RequeueWithError(err)
 	}
 
@@ -261,6 +283,11 @@ func (a *Adapter) EnsureNudgePipelineRunsExist() (controller.OperationResult, er
 	err = tekton.AnnotateBuildPipelineRun(a.context, a.pipelineRun, tektonconsts.NudgeProcessedAnnotation, processedValue, a.client)
 	if err != nil {
 		a.logger.Error(err, "Failed to annotate build PLR as nudge-processed")
+		// Keep the nudge finalizer — the PLR must not be GC'd before the annotation lands.
+		return controller.RequeueWithError(err)
+	}
+
+	if err = h.RemoveFinalizerFromPipelineRun(a.context, a.client, a.logger, a.pipelineRun, h.NudgePipelineRunFinalizer); err != nil && !errors.IsNotFound(err) {
 		return controller.RequeueWithError(err)
 	}
 

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -4004,6 +4004,45 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(result.CancelRequest).To(BeFalse())
 		})
 
+		It("removes the stale nudge finalizer when PLR is already annotated as nudge-processed", func() {
+			// Simulate crash-recovery: IS crashed between nudge PLR creation and annotation
+			// write, leaving the finalizer on a PLR that already has the processed annotation.
+			// We use a unique name that is not on the server so the Patch returns NotFound,
+			// which the idempotency guard path handles gracefully (no requeue). The important
+			// invariant is that the in-memory finalizer is stripped and no error is returned.
+			crashPLR := makePushPLR()
+			crashPLR.Name = "pipelinerun-nudge-crash-nonexistent"
+			crashPLR.ResourceVersion = "1" // MergeFromWithOptimisticLock requires non-empty RV; server returns NotFound (handled gracefully)
+			crashPLR.Annotations[tektonconsts.NudgeProcessedAnnotation] = "component-b"
+			controllerutil.AddFinalizer(crashPLR, helpers.NudgePipelineRunFinalizer)
+			crashPLR.Status = buildPipelineRun.Status
+
+			adapter = NewAdapter(ctx, crashPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(controllerutil.ContainsFinalizer(crashPLR, helpers.NudgePipelineRunFinalizer)).To(BeFalse())
+		})
+
+		It("removes stale nudge finalizer from a deleting PLR with no nudge-processed annotation", func() {
+			// Simulate crash-recovery: IS crashed after adding the nudge finalizer but before
+			// writing the annotation, and the PLR was subsequently deleted. The PLR is stuck in
+			// Terminating. Verify the adapter removes the stale finalizer and returns without error.
+			deletingPLR := makePushPLR()
+			deletingPLR.Name = "pipelinerun-nudge-deleting-nonexistent"
+			deletingPLR.ResourceVersion = "1"
+			now := metav1.Now()
+			deletingPLR.DeletionTimestamp = &now
+			controllerutil.AddFinalizer(deletingPLR, helpers.NudgePipelineRunFinalizer)
+			deletingPLR.Status = buildPipelineRun.Status
+
+			adapter = NewAdapter(ctx, deletingPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)
+			result, err := adapter.EnsureNudgePipelineRunsExist()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(controllerutil.ContainsFinalizer(deletingPLR, helpers.NudgePipelineRunFinalizer)).To(BeFalse())
+		})
+
 		It("skips when NudgeConfig is not found", func() {
 			pushPLR := makePushPLR()
 			adapter = NewAdapter(ctx, pushPLR, hasComp, &[]v1beta2.ComponentGroup{*hasCompGroup}, logger, loader.NewMockLoader(), k8sClient)

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -145,11 +145,15 @@ const (
 	PipelineRunShouldReleaseResultName = "SHOULD_RELEASE"
 
 	/*
-	 * Nudge PipelineRun constants — build-service compatible annotation/label names
+	 * Nudge PipelineRun constants
 	 */
 
-	// NudgeProcessedAnnotation marks a build PLR as having already been processed for nudging
-	NudgeProcessedAnnotation = "build.appstudio.openshift.io/component-nudge-processed"
+	// NudgeProcessedAnnotation marks a build PLR as having already been processed for nudging.
+	// Renamed from build.appstudio.openshift.io/component-nudge-processed to avoid interference
+	// with build-service, which sets the old key unconditionally. PLRs annotated with the old key
+	// by IS before this change are not recognized by the idempotency guard, but any duplicate
+	// nudge PLR creation is safe because Renovate is idempotent.
+	NudgeProcessedAnnotation = "test.appstudio.openshift.io/component-nudge-processed"
 
 	// NudgeSimpleBranchAnnotation on a Component controls simplified branch naming for nudge PRs
 	NudgeSimpleBranchAnnotation = "build.appstudio.openshift.io/build-nudge-simple-branch"


### PR DESCRIPTION
build-service's removePipelineFinalizer() unconditionally sets build.appstudio.openshift.io/component-nudge-processed="true" when skipping nudging for a NudgeConfig namespace. IS bailed out on any non-empty value of that annotation, so Renovate PipelineRuns were never created when NudgeConfig was present.

Fix:
- Rename NudgeProcessedAnnotation from build.appstudio.openshift.io/component-nudge-processed to test.appstudio.openshift.io/component-nudge-processed so IS owns its marker independently of build-service's annotation (consistent with the existing IS annotation/finalizer domain)
- Add NudgePipelineRunFinalizer (test.appstudio.openshift.io/nudge-pipelinerun) to hold the build PLR open between nudge PLR creation and the annotation write, preventing premature GC on a succeeded PLR; finalizer is added just before CreateNudgePipelineRun and removed after the annotation lands successfully; the already-annotated early-exit path and the deleting-PLR path both clean it up on crash-recovery

Note: PLRs annotated with the old key by IS before this change are not recognized by the idempotency guard during rollout, but any resulting duplicate nudge PLR creation is safe because Renovate is idempotent.

Assisted-By: Claude-Code opus 4.6

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)