### PR TITLE
fix(STONEINTG-1666): clarify SCM lookup errors

### DIFF
--- a/tekton/nudging/nudge_credentials.go
+++ b/tekton/nudging/nudge_credentials.go
@@ -445,12 +445,12 @@ func lookupSCMCredentials(ctx context.Context, c client.Client, namespace, repoH
 	}
 
 	if len(candidates) == 0 {
-		return "", "", fmt.Errorf("no SCM basic auth secrets found for host %q in namespace %s", repoHost, namespace)
+		return "", "", fmt.Errorf("no SCM basic auth secrets found for host %q in namespace %s; secrets must be BasicAuth and labeled %s=scm and %s=%s", repoHost, namespace, scmCredentialsSecretLabel, scmSecretHostnameLabel, repoHost)
 	}
 
 	best := bestMatchingSCMSecret(ctx, repoPath, candidates)
 	if best == nil {
-		return "", "", fmt.Errorf("no matching SCM secret found for repo %q in namespace %s", repoPath, namespace)
+		return "", "", fmt.Errorf("no matching SCM secret found for repo %q in namespace %s; set the %s annotation to the repository path", repoPath, namespace, scmSecretRepositoryAnnotation)
 	}
 
 	return string(best.Data[corev1.BasicAuthUsernameKey]),

--- a/tekton/nudging/nudge_credentials_test.go
+++ b/tekton/nudging/nudge_credentials_test.go
@@ -1025,6 +1025,12 @@ var _ = Describe("Nudge credentials", func() {
 			scheme = newCredentialScheme()
 		})
 
+		It("keeps operator-facing SCM metadata keys stable", func() {
+			Expect(scmCredentialsSecretLabel).To(Equal("appstudio.redhat.com/credentials"))
+			Expect(scmSecretHostnameLabel).To(Equal("appstudio.redhat.com/scm.host"))
+			Expect(scmSecretRepositoryAnnotation).To(Equal("appstudio.redhat.com/scm.repository"))
+		})
+
 		It("returns credentials from matching BasicAuth secret", func() {
 			scmSecret := &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1057,8 +1063,8 @@ var _ = Describe("Nudge credentials", func() {
 			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no SCM basic auth secrets found"))
-			Expect(err.Error()).To(ContainSubstring("appstudio.redhat.com/credentials=scm"))
-			Expect(err.Error()).To(ContainSubstring("appstudio.redhat.com/scm.host=github.com"))
+			Expect(err.Error()).To(ContainSubstring(scmCredentialsSecretLabel + "=scm"))
+			Expect(err.Error()).To(ContainSubstring(scmSecretHostnameLabel + "=github.com"))
 			Expect(err.Error()).To(ContainSubstring("BasicAuth"))
 		})
 
@@ -1107,7 +1113,7 @@ var _ = Describe("Nudge credentials", func() {
 			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no matching SCM secret found"))
-			Expect(err.Error()).To(ContainSubstring("appstudio.redhat.com/scm.repository"))
+			Expect(err.Error()).To(ContainSubstring(scmSecretRepositoryAnnotation))
 		})
 	})
 

--- a/tekton/nudging/nudge_credentials_test.go
+++ b/tekton/nudging/nudge_credentials_test.go
@@ -1057,6 +1057,9 @@ var _ = Describe("Nudge credentials", func() {
 			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no SCM basic auth secrets found"))
+			Expect(err.Error()).To(ContainSubstring("appstudio.redhat.com/credentials=scm"))
+			Expect(err.Error()).To(ContainSubstring("appstudio.redhat.com/scm.host=github.com"))
+			Expect(err.Error()).To(ContainSubstring("BasicAuth"))
 		})
 
 		It("skips non-BasicAuth secrets", func() {
@@ -1078,6 +1081,33 @@ var _ = Describe("Nudge credentials", func() {
 			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no SCM basic auth secrets found"))
+		})
+
+		It("explains the repository annotation when no secret matches the repo", func() {
+			scmSecret := &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "scm-secret",
+					Namespace: testNamespace,
+					Labels: map[string]string{
+						scmCredentialsSecretLabel: "scm",
+						scmSecretHostnameLabel:    "github.com",
+					},
+					Annotations: map[string]string{
+						scmSecretRepositoryAnnotation: "other/repo",
+					},
+				},
+				Type: corev1.SecretTypeBasicAuth,
+				Data: map[string][]byte{
+					corev1.BasicAuthUsernameKey: []byte("user"),
+					corev1.BasicAuthPasswordKey: []byte("token"),
+				},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(scmSecret).Build()
+
+			_, _, err := lookupSCMCredentials(ctx, c, testNamespace, "github.com", "org/repo")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("no matching SCM secret found"))
+			Expect(err.Error()).To(ContainSubstring("appstudio.redhat.com/scm.repository"))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- explain the required credentials and host labels when no BasicAuth SCM secret is found
- explain the `appstudio.redhat.com/scm.repository` annotation when no secret matches the requested repository
- add regression coverage for both lookup failure branches

Fixes #1666

## Root cause
`lookupSCMCredentials` applies a label selector and then filters to BasicAuth secrets, but its errors only reported the host/namespace. A second branch performs repository matching through the `appstudio.redhat.com/scm.repository` annotation without naming that contract. Operators therefore could not diagnose a skipped secret from the error alone.

## Validation
- `go test ./tekton/nudging -ginkgo.focus=lookupSCMCredentials -count=1`
- `go test ./tekton/nudging -count=1`
- `go vet ./tekton/nudging`
- `git diff --check`

## Contribution metadata
- Assisted-by: OpenAI Codex
- Commits are signed off under the Developer Certificate of Origin.
- No third-party code was copied.