### PR TITLE
feat(STONEINTG-1702): add integration_svc_gitlab_scenario_status_gauge

### DIFF
--- a/internal/controller/statusreport/statusreport_adapter.go
+++ b/internal/controller/statusreport/statusreport_adapter.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	applicationapiv1alpha1 "github.com/konflux-ci/application-api/api/v1alpha1"
+	"github.com/konflux-ci/integration-service/pkg/metrics"
 	"github.com/konflux-ci/integration-service/snapshot"
 	"github.com/konflux-ci/operator-toolkit/controller"
 	"k8s.io/client-go/util/retry"
@@ -521,7 +522,7 @@ func (a *Adapter) iterateIntegrationTestStatusDetailsInStatusReport(reporter sta
 	}
 	if !hasUpdatedIntegrationTest {
 		//integration test contains no changes
-		a.logger.Info("Integration Test doen't contain new status updates, no need to update status to git provider")
+		a.logger.Info("Integration Test doesn't contain new status updates, no need to update status to git provider")
 		return nil
 	}
 
@@ -632,6 +633,15 @@ func (a *Adapter) reportConsolidatedStatuses(
 	destinationSnapshot *applicationapiv1alpha1.Snapshot,
 	srs *status.SnapshotReportStatus,
 ) error {
+	// If reporter provider is GitLab, we track the number of statuses reported at the same time to gauge usage of the status API
+	if reporter.GetReporterName() == status.GitLabProvider {
+		numStatuses := len(integrationTestStatusDetails)
+		metrics.RegisterConsolidatedGitlabScenarioStatuses(float64(numStatuses))
+
+		defer func() {
+			metrics.UnregisterConsolidatedGitlabScenarioStatuses(float64(numStatuses))
+		}()
+	}
 	if statusCode, reportErr := reporter.ReportConsolidatedStatus(a.context, allReports); reportErr != nil {
 		if reporter.ReturnCodeIsUnrecoverable(statusCode) {
 			a.logger.Error(reportErr, "consolidated status report failed with unrecoverable error, skipping",
@@ -662,13 +672,22 @@ func (a *Adapter) reportPerScenarioStatuses(
 	destinationSnapshot *applicationapiv1alpha1.Snapshot,
 	srs *status.SnapshotReportStatus,
 ) error {
+	// If reporter provider is GitLab, we track the number of statuses reported at the same time to gauge usage of the status API
+	if reporter.GetReporterName() == status.GitLabProvider {
+		numStatuses := len(integrationTestStatusDetails)
+		metrics.RegisterIndividualGitlabScenarioStatuses(float64(numStatuses))
+
+		defer func() {
+			metrics.UnregisterIndividualGitlabScenarioStatuses(float64(numStatuses))
+		}()
+	}
 	for i, integrationTestStatusDetail := range integrationTestStatusDetails {
 		testReport := allReports[i]
 
 		if srs.IsNewer(integrationTestStatusDetail.ScenarioName, destinationSnapshot.Name, integrationTestStatusDetail.LastUpdateTime) {
 			a.logger.Info("Integration Test contains new status updates", "scenario.Name", integrationTestStatusDetail.ScenarioName, "destinationSnapshot.Name", destinationSnapshot.Name, "testedSnapshot", testedSnapshot.Name)
 		} else {
-			a.logger.Info("Integration Test doen't contain new status updates", "scenario.Name", integrationTestStatusDetail.ScenarioName)
+			a.logger.Info("Integration Test doesn't contain new status updates", "scenario.Name", integrationTestStatusDetail.ScenarioName)
 			continue
 		}
 

--- a/pkg/metrics/integration.go
+++ b/pkg/metrics/integration.go
@@ -74,6 +74,14 @@ var (
 			Buckets: []float64{0.5, 1, 2, 3, 4, 5, 6, 7, 10, 15, 30, 60, 120, 240, 300, 450, 600, 750, 900, 1050, 1200},
 		},
 	)
+
+	GitLabScenarioStatuses = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "integration_svc_gitlab_scenario_status_gauge",
+			Help: "The current number of concurrent GitLab scenario statuses being reported",
+		},
+		[]string{"reporting_mode"},
+	)
 )
 
 // IntegrationMetrics represents a collection of metrics to be registered on a
@@ -120,6 +128,26 @@ func RegisterReleaseLatency(startTime metav1.Time) {
 	ReleaseLatencySeconds.Observe(latency)
 }
 
+// RegisterConsolidatedGitlabScenarioStatuses registers consolidated GitLab statuses that are being reported to a given MR
+func RegisterConsolidatedGitlabScenarioStatuses(numStatuses float64) {
+	GitLabScenarioStatuses.With(prometheus.Labels{"reporting_mode": "consolidated"}).Add(numStatuses)
+}
+
+// RegisterIndividualGitlabScenarioStatuses registers an individual GitLab status that is being reported to a given MR
+func RegisterIndividualGitlabScenarioStatuses(numStatuses float64) {
+	GitLabScenarioStatuses.With(prometheus.Labels{"reporting_mode": "individual"}).Add(numStatuses)
+}
+
+// UnregisterConsolidatedGitlabScenarioStatuses unregisters consolidated GitLab statuses that are being reported to a given MR
+func UnregisterConsolidatedGitlabScenarioStatuses(numStatuses float64) {
+	GitLabScenarioStatuses.With(prometheus.Labels{"reporting_mode": "consolidated"}).Sub(numStatuses)
+}
+
+// UnregisterIndividualGitlabScenarioStatuses unregisters an individual GitLab status that is being reported to a given MR
+func UnregisterIndividualGitlabScenarioStatuses(numStatuses float64) {
+	GitLabScenarioStatuses.With(prometheus.Labels{"reporting_mode": "individual"}).Sub(numStatuses)
+}
+
 func (m *IntegrationMetrics) InitMetrics(registerer prometheus.Registerer) error {
 	registerer.MustRegister(
 		SnapshotCreatedToPipelineRunStartedSeconds,
@@ -128,6 +156,7 @@ func (m *IntegrationMetrics) InitMetrics(registerer prometheus.Registerer) error
 		SnapshotDurationSeconds,
 		SnapshotTotal,
 		ReleaseLatencySeconds,
+		GitLabScenarioStatuses,
 	)
 	for _, probe := range m.probes {
 		if err := registerer.Register(probe.AvailabilityGauge()); err != nil {

--- a/pkg/metrics/integration_suite_test.go
+++ b/pkg/metrics/integration_suite_test.go
@@ -19,8 +19,9 @@ package metrics
 import (
 	"context"
 	"fmt"
-	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -81,6 +82,18 @@ func createCounterReader(header inputHeader, labels string, renderHeader bool, c
 		readerData = fmt.Sprintf("# HELP %s %s\n# TYPE %s counter\n", header.Name, header.Help, header.Name)
 	}
 	readerData += fmt.Sprintf("%s{%s} %d\n", header.Name, labels, count)
+
+	return readerData
+}
+
+// createGaugeReader creates a prometheus gauge type string with the given parameters to be used as input data
+// for 'strings.NewReader' in Prometheus 'client_golang' function 'testutil.CollectAndCompare'.
+func createGaugeReader(header inputHeader, labels string, renderHeader bool, count float64) string {
+	readerData := ""
+	if renderHeader {
+		readerData = fmt.Sprintf("# HELP %s %s\n# TYPE %s gauge\n", header.Name, header.Help, header.Name)
+	}
+	readerData += fmt.Sprintf("%s{%s} %f\n", header.Name, labels, count)
 
 	return readerData
 }

--- a/pkg/metrics/integration_test.go
+++ b/pkg/metrics/integration_test.go
@@ -49,6 +49,10 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 			Name: "integration_svc_snapshot_attempt_total",
 			Help: "Total number of snapshots processed by the operator",
 		}
+		GitLabScenarioStatusesHeader = inputHeader{
+			Name: "integration_svc_gitlab_scenario_status_gauge",
+			Help: "The current number of concurrent GitLab scenario statuses being reported",
+		}
 	)
 
 	Context("When RegisterPipelineRunStarted is called", func() {
@@ -211,6 +215,67 @@ var _ = Describe("Metrics Integration", Ordered, func() {
 		It("measures latency for only one release", func() {
 			RegisterReleaseLatency(startTime)
 			Expect(testutil.CollectAndCount(ReleaseLatencySeconds)).To(Equal(1))
+		})
+	})
+
+	Context("When RegisterConsolidatedGitlabScenarioStatuses is called", func() {
+		BeforeAll(func() {
+			GitLabScenarioStatuses = prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Name: "integration_svc_gitlab_scenario_status_gauge",
+					Help: "The current number of concurrent GitLab scenario statuses being reported",
+				},
+				[]string{"reporting_mode"},
+			)
+			metrics.Registry.MustRegister(GitLabScenarioStatuses)
+		})
+
+		AfterAll(func() {
+			metrics.Registry.Unregister(GitLabScenarioStatuses)
+		})
+
+		labels := fmt.Sprintf(`reporting_mode="%s"`, "consolidated")
+
+		It("increments 'GitLabScenarioStatuses' in consolidated mode", func() {
+			RegisterConsolidatedGitlabScenarioStatuses(20)
+			readerData := createGaugeReader(GitLabScenarioStatusesHeader, labels, true, float64(20))
+			Expect(testutil.CollectAndCompare(GitLabScenarioStatuses, strings.NewReader(readerData))).To(Succeed())
+		})
+
+		It("decrements 'GitLabScenarioStatuses' in consolidated mode", func() {
+			UnregisterConsolidatedGitlabScenarioStatuses(20)
+			readerData := createGaugeReader(GitLabScenarioStatusesHeader, labels, true, float64(0))
+			Expect(testutil.CollectAndCompare(GitLabScenarioStatuses, strings.NewReader(readerData))).To(Succeed())
+		})
+	})
+
+	Context("When RegisterConsolidatedGitlabScenarioStatuses is called", func() {
+		BeforeAll(func() {
+			GitLabScenarioStatuses = prometheus.NewGaugeVec(
+				prometheus.GaugeOpts{
+					Name: "integration_svc_gitlab_scenario_status_gauge",
+					Help: "The current number of concurrent GitLab scenario statuses being reported",
+				},
+				[]string{"reporting_mode"},
+			)
+		})
+
+		AfterAll(func() {
+			metrics.Registry.Unregister(GitLabScenarioStatuses)
+		})
+
+		labels := fmt.Sprintf(`reporting_mode="%s"`, "individual")
+
+		It("increments 'GitLabScenarioStatuses' in individual mode", func() {
+			RegisterIndividualGitlabScenarioStatuses(20)
+			readerData := createGaugeReader(GitLabScenarioStatusesHeader, labels, true, float64(20))
+			Expect(testutil.CollectAndCompare(GitLabScenarioStatuses, strings.NewReader(readerData))).To(Succeed())
+		})
+
+		It("decrements 'GitLabScenarioStatuses' in consolidated mode", func() {
+			UnregisterIndividualGitlabScenarioStatuses(20)
+			readerData := createGaugeReader(GitLabScenarioStatusesHeader, labels, true, float64(0))
+			Expect(testutil.CollectAndCompare(GitLabScenarioStatuses, strings.NewReader(readerData))).To(Succeed())
 		})
 	})
 })


### PR DESCRIPTION
* Add metrics consolidating GitLab jobs via the integration_svc_gitlab_scenario_status_gauge in consolidated and individual modes
* Add the metric tracking the statusreport_adapter for GitLab reporter only

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
