### PR TITLE
feat(STONEINTG-1744); support commit comment push triggers

### DIFF
--- a/gitops/snapshot.go
+++ b/gitops/snapshot.go
@@ -181,6 +181,9 @@ const (
 	// PipelineAsCodePullRequestAnnotation is the git repository's pull request identifier
 	PipelineAsCodePullRequestAnnotation = PipelinesAsCodePrefix + "/pull-request"
 
+	// PipelineAsCodePullRequestLabel is the git repository's pull request identifier which has been provided in the label for discoverability
+	PipelineAsCodePullRequestLabel = PipelinesAsCodePrefix + "/pull-request"
+
 	// PipelineAsCodeSourceProjectIDAnnotation is the source project ID for gitlab
 	PipelineAsCodeSourceProjectIDAnnotation = PipelinesAsCodePrefix + "/source-project-id"
 
@@ -878,14 +881,20 @@ func IsSnapshotCreatedByPACMergeQueueEvent(snapshot *applicationapiv1alpha1.Snap
 	return false
 }
 
-// IsSnapshotCreatedByPACPushEvent checks if a snapshot has label PipelineAsCodeEventTypeLabel and with push value
-// if the label doesn't exist for some manual snapshot
+// IsSnapshotCreatedByPACPushEvent checks whether a Snapshot should follow
+// the push integration workflow (vs pull_request).
 func IsSnapshotCreatedByPACPushEvent(snapshot *applicationapiv1alpha1.Snapshot) bool {
-	return !IsSnapshotCreatedByPACMergeQueueEvent(snapshot) && !IsGroupSnapshot(snapshot) &&
-		(metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodePushType) ||
-			metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodeGLPushType) ||
-			!metadata.HasLabel(snapshot, PipelineAsCodeEventTypeLabel) ||
-			!metadata.HasLabel(snapshot, PipelineAsCodePullRequestAnnotation))
+	if IsSnapshotCreatedByPACMergeQueueEvent(snapshot) || IsGroupSnapshot(snapshot) {
+		return false
+	}
+	eventType := snapshot.Labels[PipelineAsCodeEventTypeLabel]
+	targetBranch := snapshot.Annotations[PipelineAsCodeTargetBranchAnnotation]
+	sourceBranch := snapshot.Annotations[PipelineAsCodeSourceBranchAnnotation]
+	return metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodePushType) ||
+		metadata.HasLabelWithValue(snapshot, PipelineAsCodeEventTypeLabel, PipelineAsCodeGLPushType) ||
+		!metadata.HasLabel(snapshot, PipelineAsCodeEventTypeLabel) ||
+		!metadata.HasLabel(snapshot, PipelineAsCodePullRequestAnnotation) ||
+		helpers.IsPACPushStyleGitOpsComment(eventType, targetBranch, sourceBranch)
 }
 
 // IsSnapshotAutoReleaseDisabled checks if a snapshot has a AutoReleaseLabel label and if its value is "false"

--- a/gitops/snapshot_test.go
+++ b/gitops/snapshot_test.go
@@ -1212,6 +1212,39 @@ var _ = Describe("Gitops functions for managing Snapshots", Ordered, func() {
 				Expect(gitops.IsSnapshotCreatedByPACPushEvent(snapshot)).To(BeFalse())
 			})
 
+			It("should treat commit-comment Snapshots as push even with a pull-request label", func() {
+				tempSnapshot := hasSnapshot.DeepCopy()
+				tempSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = "test-comment"
+				tempSnapshot.Labels[gitops.PipelineAsCodePullRequestLabel] = "42"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "main"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeTargetBranchAnnotation] = "main"
+				Expect(gitops.IsSnapshotCreatedByPACPushEvent(tempSnapshot)).To(BeTrue())
+			})
+			It("should not treat treat PR-comment Snapshots as push", func() {
+				tempSnapshot := hasSnapshot.DeepCopy()
+				tempSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = "test-comment"
+				tempSnapshot.Labels[gitops.PipelineAsCodePullRequestLabel] = "42"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "feature"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeTargetBranchAnnotation] = "main"
+				Expect(gitops.IsSnapshotCreatedByPACPushEvent(tempSnapshot)).To(BeFalse())
+			})
+			It("should treat tag commit-comment Snapshots as push", func() {
+				tempSnapshot := hasSnapshot.DeepCopy()
+				tempSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = "retest-all-comment"
+				tempSnapshot.Labels[gitops.PipelineAsCodePullRequestLabel] = "7"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "refs/tags/v1.0.0"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeTargetBranchAnnotation] = "refs/tags/v1.0.0"
+				Expect(gitops.IsSnapshotCreatedByPACPushEvent(tempSnapshot)).To(BeTrue())
+			})
+			It("should not treat ok-to-test as push-style even if branches match", func() {
+				tempSnapshot := hasSnapshot.DeepCopy()
+				tempSnapshot.Labels[gitops.PipelineAsCodeEventTypeLabel] = "ok-to-test-comment"
+				tempSnapshot.Labels[gitops.PipelineAsCodePullRequestLabel] = "42"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeSourceBranchAnnotation] = "main"
+				tempSnapshot.Annotations[gitops.PipelineAsCodeTargetBranchAnnotation] = "main"
+				Expect(gitops.IsSnapshotCreatedByPACPushEvent(tempSnapshot)).To(BeFalse())
+			})
+
 			It("Testing UnmarshalJSON", func() {
 				infoString := "[{\"namespace\":\"default\",\"component\":\"devfile-sample-java-springboot-basic-8969\",\"buildPipelineRun\":\"build-plr-java-qjfxz\",\"snapshot\":\"app-8969-bbn7d\"},{\"namespace\":\"default\",\"component\":\"devfile-sample-go-basic-8969\",\"buildPipelineRun\":\"build-plr-go-jmsjq\",\"snapshot\":\"app-8969-kzq2l\"}]"
 				componentSnapshotInfos, err := gitops.UnmarshalJSON([]byte(infoString))

--- a/helpers/build.go
+++ b/helpers/build.go
@@ -1,7 +1,22 @@
+/*
+Copyright 2026 Red Hat Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package helpers
 
 import (
 	"errors"
+	"strings"
 	"time"
 )
 
@@ -15,6 +30,19 @@ const (
 
 	// ChainsSignedCheckTimeout is how long after PLR completion we wait for Chains to sign before treating it as a failure
 	ChainsSignedCheckTimeout = 5 * time.Minute
+
+	// PAC GitOps comment event-type label values (from pipelines-as-code opscomments).
+
+	PipelineAsCodeTestCommentType      = "test-comment"
+	PipelineAsCodeTestAllCommentType   = "test-all-comment"
+	PipelineAsCodeRetestCommentType    = "retest-comment"
+	PipelineAsCodeRetestAllCommentType = "retest-all-comment"
+	PipelineAsCodeCancelCommentType    = "cancel-comment"
+	PipelineAsCodeCancelAllCommentType = "cancel-all-comment"
+	PipelineAsCodeOnCommentType        = "on-comment"
+
+	// GitRefBranchPrefix is the git prefix denoting a reference is a branch
+	GitRefBranchPrefix = "refs/heads/"
 )
 
 // ChainsNotSignedError indicates the PipelineRun is not yet signed by Chains.
@@ -31,4 +59,30 @@ func (e *ChainsNotSignedError) Error() string {
 func IsChainsNotSignedError(err error) bool {
 	var target *ChainsNotSignedError
 	return errors.As(err, &target)
+}
+
+// IsPACPushStyleGitOpsComment reports whether a PipelineRun looks like a
+// GitOps command on a pushed commit (commit_comment), as opposed to the same
+// command on a pull request (issue_comment).
+//
+// PAC rewrites EventType to ops strings for both paths, and may attach a
+// pull-request label to commit-comment runs when the SHA is linked to a PR.
+// Commit-comment handlers set HeadBranch == BaseBranch; PR handlers do not.
+func IsPACPushStyleGitOpsComment(eventType, targetBranch, sourceBranch string) bool {
+
+	if targetBranch == "" || sourceBranch == "" || strings.TrimPrefix(targetBranch, GitRefBranchPrefix) != strings.TrimPrefix(sourceBranch, GitRefBranchPrefix) {
+		return false
+	}
+	switch eventType {
+	case PipelineAsCodeTestCommentType,
+		PipelineAsCodeTestAllCommentType,
+		PipelineAsCodeRetestCommentType,
+		PipelineAsCodeRetestAllCommentType,
+		PipelineAsCodeCancelCommentType,
+		PipelineAsCodeCancelAllCommentType,
+		PipelineAsCodeOnCommentType:
+		return true
+	default:
+		return false
+	}
 }

--- a/helpers/build_test.go
+++ b/helpers/build_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 Red Hat Inc.
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package helpers_test
+
+import (
+	"github.com/konflux-ci/integration-service/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Helpers for build", func() {
+	Context("IsPACPushStyleGitOpsComment", func() {
+		DescribeTable("detects push-style GitOps comments from commit comments",
+			func(eventType, targetBranch, sourceBranch string, expected bool) {
+				Expect(helpers.IsPACPushStyleGitOpsComment(eventType, targetBranch, sourceBranch)).To(Equal(expected))
+			},
+			Entry("test-comment with matching branches", helpers.PipelineAsCodeTestCommentType, "main", "main", true),
+			Entry("test-comment with matching branches, but different branch prefixes", helpers.PipelineAsCodeTestCommentType, "refs/heads/main", "main", true),
+			Entry("test-comment with matching branches, and same branch prefixes", helpers.PipelineAsCodeTestCommentType, "refs/heads/main", "refs/heads/main", true),
+			Entry("test-comment with matching branches but different branch prefixes", helpers.PipelineAsCodeTestCommentType, "main", "refs/heads/main", true),
+			Entry("test-all-comment with matching branches", helpers.PipelineAsCodeTestAllCommentType, "main", "main", true),
+			Entry("retest-comment with matching branches", helpers.PipelineAsCodeRetestCommentType, "main", "main", true),
+			Entry("retest-all-comment with matching branches", helpers.PipelineAsCodeRetestAllCommentType, "main", "main", true),
+			Entry("cancel-comment with matching branches", helpers.PipelineAsCodeCancelCommentType, "main", "main", true),
+			Entry("cancel-all-comment with matching branches", helpers.PipelineAsCodeCancelAllCommentType, "main", "main", true),
+			Entry("on-comment with matching branches", helpers.PipelineAsCodeOnCommentType, "main", "main", true),
+			Entry("matching branches with refs/heads/ prefix on both", helpers.PipelineAsCodeTestCommentType, "refs/heads/main", "refs/heads/main", true),
+			Entry("matching branches with refs/heads/ prefix only on target", helpers.PipelineAsCodeTestCommentType, "refs/heads/main", "main", true),
+			Entry("matching branches with refs/heads/ prefix only on source", helpers.PipelineAsCodeTestCommentType, "main", "refs/heads/main", true),
+			Entry("matching tag refs", helpers.PipelineAsCodeRetestAllCommentType, "refs/tags/v1.0.0", "refs/tags/v1.0.0", true),
+			Entry("empty target branch", helpers.PipelineAsCodeTestCommentType, "", "main", false),
+			Entry("empty source branch", helpers.PipelineAsCodeTestCommentType, "main", "", false),
+			Entry("both branches empty", helpers.PipelineAsCodeTestCommentType, "", "", false),
+			Entry("mismatched branches for PR-style GitOps comment", helpers.PipelineAsCodeTestCommentType, "main", "feature", false),
+			Entry("ok-to-test-comment even with matching branches", "ok-to-test-comment", "main", "main", false),
+			Entry("native push event type", "push", "main", "main", false),
+			Entry("native pull_request event type", "pull_request", "main", "main", false),
+			Entry("unknown event type", "something-else", "main", "main", false),
+		)
+	})
+})

--- a/tekton/build_pipeline.go
+++ b/tekton/build_pipeline.go
@@ -116,17 +116,21 @@ func GenerateSHA(str string) string {
 	return fmt.Sprintf("%x", hash)[0:62]
 }
 
-// IsPLRCreatedByPACPushEvent checks if a PLR has label PipelineAsCodeEventTypeLabel and with push or Push value
+// IsPLRCreatedByPACPushEvent checks whether a build PipelineRun should follow
+// the push integration workflow (vs pull_request).
 func IsPLRCreatedByPACPushEvent(plr *tektonv1.PipelineRun) bool {
 	if branch, found := plr.Annotations[consts.PipelineAsCodeSourceBranchAnnotation]; found {
 		if strings.HasPrefix(strings.TrimPrefix(branch, consts.GitRefBranchPrefix), consts.PipelineAsCodeGitHubMergeQueueBranchPrefix) {
 			return false
 		}
 	}
-
+	eventType := plr.Labels[consts.PipelineAsCodeEventTypeLabel]
+	targetBranch := plr.Annotations[consts.PipelineAsCodeTargetBranchAnnotation]
+	sourceBranch := plr.Annotations[consts.PipelineAsCodeSourceBranchAnnotation]
 	return !metadata.HasLabel(plr, consts.PipelineAsCodePullRequestLabel) ||
 		metadata.HasLabelWithValue(plr, consts.PipelineAsCodeEventTypeLabel, consts.PipelineAsCodePushType) ||
-		metadata.HasLabelWithValue(plr, consts.PipelineAsCodeEventTypeLabel, consts.PipelineAsCodeGLPushType)
+		metadata.HasLabelWithValue(plr, consts.PipelineAsCodeEventTypeLabel, consts.PipelineAsCodeGLPushType) ||
+		h.IsPACPushStyleGitOpsComment(eventType, targetBranch, sourceBranch)
 }
 
 // IsLatestBuildPipelineRunInComponent return true if pipelineRun is the latest pipelineRun

--- a/tekton/build_pipeline_test.go
+++ b/tekton/build_pipeline_test.go
@@ -236,6 +236,39 @@ var _ = Describe("build pipeline", Ordered, func() {
 			Expect(tekton.IsPLRCreatedByPACPushEvent(buildPipelineRun)).To(BeFalse())
 		})
 
+		It("should treat commit-comment GitOps PipelineRuns as push even with a pull-request label", func() {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Labels[tektonconsts.PipelineAsCodeEventTypeLabel] = "test-comment"
+			plr.Labels[tektonconsts.PipelineAsCodePullRequestLabel] = "42"
+			plr.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "main"
+			plr.Annotations[tektonconsts.PipelineAsCodeTargetBranchAnnotation] = "main"
+			Expect(tekton.IsPLRCreatedByPACPushEvent(plr)).To(BeTrue())
+		})
+		It("should not treat PR-comment GitOps PipelineRuns as push", func() {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Labels[tektonconsts.PipelineAsCodeEventTypeLabel] = "test-comment"
+			plr.Labels[tektonconsts.PipelineAsCodePullRequestLabel] = "42"
+			plr.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "feature"
+			plr.Annotations[tektonconsts.PipelineAsCodeTargetBranchAnnotation] = "main"
+			Expect(tekton.IsPLRCreatedByPACPushEvent(plr)).To(BeFalse())
+		})
+		It("should treat tag commit-comment GitOps as push", func() {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Labels[tektonconsts.PipelineAsCodeEventTypeLabel] = "retest-all-comment"
+			plr.Labels[tektonconsts.PipelineAsCodePullRequestLabel] = "7"
+			plr.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "refs/tags/v1.0.0"
+			plr.Annotations[tektonconsts.PipelineAsCodeTargetBranchAnnotation] = "refs/tags/v1.0.0"
+			Expect(tekton.IsPLRCreatedByPACPushEvent(plr)).To(BeTrue())
+		})
+		It("should not treat ok-to-test as push-style even if branches match", func() {
+			plr := buildPipelineRun.DeepCopy()
+			plr.Labels[tektonconsts.PipelineAsCodeEventTypeLabel] = "ok-to-test-comment"
+			plr.Labels[tektonconsts.PipelineAsCodePullRequestLabel] = "42"
+			plr.Annotations[tektonconsts.PipelineAsCodeSourceBranchAnnotation] = "main"
+			plr.Annotations[tektonconsts.PipelineAsCodeTargetBranchAnnotation] = "main"
+			Expect(tekton.IsPLRCreatedByPACPushEvent(plr)).To(BeFalse())
+		})
+
 		It("can get the latest build pipelinerun for given component", func() {
 			plrs := []tektonv1.PipelineRun{*buildPipelineRun, *buildPipelineRun2}
 			Expect(tekton.IsLatestBuildPipelineRunInComponent(buildPipelineRun, &plrs)).To(BeTrue())

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -103,6 +103,11 @@ const (
 	// PipelineAsCodeGitHubMergeQueueBranchPrefix is the prefix added to temporary branches which are created for merge queues
 	PipelineAsCodeGitHubMergeQueueBranchPrefix = "gh-readonly-queue/"
 
+	// PipelineAsCodeTargetBranchAnnotation is the target/base branch for the event
+	// (pipelinesascode.tekton.dev/branch). For push/commit-comment events this equals
+	// source-branch; for pull_request events it differs.
+	PipelineAsCodeTargetBranchAnnotation = "pipelinesascode.tekton.dev/branch"
+
 	/*
 	 * Utils constants
 	 */


### PR DESCRIPTION
* Add IsPACPushStyleGitOpsComment which detects if an event is a [commit comment push command](https://pipelinesascode.com/docs/guides/gitops-commands/push-commands/) as opposed to an issue comment on a PR
* Treat build pipelineRuns and Snapshot which were created as a response to a commit comment as push-type to align with PaC's triggering type
* This is done by detecting the commit comment event type as well as checking if the target and source branches match (they do not match in case of PR/MR events)

Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
