### PR TITLE
fix: expand nudge entry MaxItems to 360

### DIFF
--- a/api/v1beta2/nudgeconfig_types.go
+++ b/api/v1beta2/nudgeconfig_types.go
@@ -68,7 +68,7 @@ type NudgeRelationship struct {
 // +kubebuilder:validation:XValidation:rule="!has(self.nudges) || self.nudges.all(i, self.nudges.exists_one(j, i.from == j.from && i.to == j.to))",message="duplicate (from, to) pair not allowed"
 type NudgeConfigSpec struct {
 	// Nudges is the list of component nudge relationships.
-	// +kubebuilder:validation:MaxItems=256
+	// +kubebuilder:validation:MaxItems=360
 	// +optional
 	Nudges []NudgeRelationship `json:"nudges,omitempty"`
 }

--- a/api/v1beta2/nudgeconfig_validation_test.go
+++ b/api/v1beta2/nudgeconfig_validation_test.go
@@ -211,8 +211,8 @@ var _ = Describe("NudgeConfig CEL validation", Ordered, func() {
 		Expect(errors.IsInvalid(err)).To(BeTrue())
 	})
 
-	It("should reject spec.nudges exceeding 256 items", func() {
-		nudges := make([]NudgeRelationship, 257)
+	It("should reject spec.nudges exceeding 360 items", func() {
+		nudges := make([]NudgeRelationship, 361)
 		for i := range nudges {
 			nudges[i] = NudgeRelationship{
 				From: fmt.Sprintf("src-%d", i),

--- a/config/crd/bases/appstudio.redhat.com_nudgeconfigs.yaml
+++ b/config/crd/bases/appstudio.redhat.com_nudgeconfigs.yaml
@@ -88,7 +88,7 @@ spec:
                   - from
                   - to
                   type: object
-                maxItems: 256
+                maxItems: 360
                 type: array
             type: object
             x-kubernetes-validations:


### PR DESCRIPTION
Signed-off-by: dirgim <kpavic@redhat.com>

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
