### PR TITLE
fix(STONEINTG-1694): fix flaky test by adding AfterAll cleanup

### DIFF
--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -568,6 +568,21 @@ var _ = Describe("Loader", Ordered, func() {
 		Expect(k8sClient.Create(ctx, taskRunSample)).Should(Succeed())
 	})
 
+	deleteComponentGroup := func(cg *v1beta2.ComponentGroup) {
+		err := k8sClient.Delete(ctx, cg)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+
+		// Wait for the component group to be removed
+		Eventually(func() bool {
+			tmpCg := &v1beta2.ComponentGroup{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cg.Namespace,
+				Name:      cg.Name,
+			}, tmpCg)
+			return k8serrors.IsNotFound(err)
+		}, time.Second*10).Should(BeTrue())
+	}
+
 	AfterAll(func() {
 		_ = k8sClient.Delete(ctx, hasSnapshot)
 		_ = k8sClient.Delete(ctx, hasCGSnapshotForLoaderTests)
@@ -666,21 +681,6 @@ var _ = Describe("Loader", Ordered, func() {
 				Namespace: snapshot.Namespace,
 				Name:      snapshot.Name,
 			}, tmpSnapshot)
-			return k8serrors.IsNotFound(err)
-		}, time.Second*10).Should(BeTrue())
-	}
-
-	deleteComponentGroup := func(cg *v1beta2.ComponentGroup) {
-		err := k8sClient.Delete(ctx, cg)
-		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
-
-		// Wait for the component group to be removed
-		Eventually(func() bool {
-			tmpCg := &v1beta2.ComponentGroup{}
-			err := k8sClient.Get(ctx, types.NamespacedName{
-				Namespace: cg.Namespace,
-				Name:      cg.Name,
-			}, tmpCg)
 			return k8serrors.IsNotFound(err)
 		}, time.Second*10).Should(BeTrue())
 	}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -578,6 +578,9 @@ var _ = Describe("Loader", Ordered, func() {
 		_ = k8sClient.Delete(ctx, integrationTestScenarioCG)
 		_ = k8sClient.Delete(ctx, hasApp)
 		_ = k8sClient.Delete(ctx, hasComp)
+		_ = k8sClient.Delete(ctx, hasComponentGroup1)
+		_ = k8sClient.Delete(ctx, hasComponentGroup2)
+		_ = k8sClient.Delete(ctx, hasContainerCompGroup)
 	})
 
 	createReleasePlan := func(releasePlan *releasev1alpha1.ReleasePlan) {
@@ -1188,6 +1191,12 @@ var _ = Describe("Loader", Ordered, func() {
 				},
 			}
 			Expect(k8sClient.Create(ctx, hasCGSnapshot2)).Should(Succeed())
+		})
+
+		//Deleting Component Groups
+		AfterAll(func() {
+			_ = k8sClient.Delete(ctx, hasCompGroup1)
+			_ = k8sClient.Delete(ctx, hasCompGroup2)
 		})
 
 		const (

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -670,7 +670,7 @@ var _ = Describe("Loader", Ordered, func() {
 		}, time.Second*10).Should(BeTrue())
 	}
 
-	deleteComponentGroup := func (cg *v1beta2.ComponentGroup) {
+	deleteComponentGroup := func(cg *v1beta2.ComponentGroup) {
 		err := k8sClient.Delete(ctx, cg)
 		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
 
@@ -684,9 +684,6 @@ var _ = Describe("Loader", Ordered, func() {
 			return k8serrors.IsNotFound(err)
 		}, time.Second*10).Should(BeTrue())
 	}
-
-
-
 
 	It("ensures all Releases exists when HACBSTests succeeded", func() {
 		Expect(k8sClient).NotTo(BeNil())

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -578,9 +578,9 @@ var _ = Describe("Loader", Ordered, func() {
 		_ = k8sClient.Delete(ctx, integrationTestScenarioCG)
 		_ = k8sClient.Delete(ctx, hasApp)
 		_ = k8sClient.Delete(ctx, hasComp)
-		_ = k8sClient.Delete(ctx, hasComponentGroup1)
-		_ = k8sClient.Delete(ctx, hasComponentGroup2)
-		_ = k8sClient.Delete(ctx, hasContainerCompGroup)
+		deleteComponentGroup(hasComponentGroup1)
+		deleteComponentGroup(hasComponentGroup2)
+		deleteComponentGroup(hasContainerCompGroup)
 	})
 
 	createReleasePlan := func(releasePlan *releasev1alpha1.ReleasePlan) {
@@ -669,6 +669,24 @@ var _ = Describe("Loader", Ordered, func() {
 			return k8serrors.IsNotFound(err)
 		}, time.Second*10).Should(BeTrue())
 	}
+
+	deleteComponentGroup := func (cg *v1beta2.ComponentGroup) {
+		err := k8sClient.Delete(ctx, cg)
+		Expect(err == nil || k8serrors.IsNotFound(err)).To(BeTrue())
+
+		// Wait for the component group to be removed
+		Eventually(func() bool {
+			tmpCg := &v1beta2.ComponentGroup{}
+			err := k8sClient.Get(ctx, types.NamespacedName{
+				Namespace: cg.Namespace,
+				Name:      cg.Name,
+			}, tmpCg)
+			return k8serrors.IsNotFound(err)
+		}, time.Second*10).Should(BeTrue())
+	}
+
+
+
 
 	It("ensures all Releases exists when HACBSTests succeeded", func() {
 		Expect(k8sClient).NotTo(BeNil())
@@ -1193,10 +1211,12 @@ var _ = Describe("Loader", Ordered, func() {
 			Expect(k8sClient.Create(ctx, hasCGSnapshot2)).Should(Succeed())
 		})
 
-		//Deleting Component Groups
+		// Clean up ComponentGroups created in BeforeAll to prevent them leaking into subsequent test blocks
 		AfterAll(func() {
-			_ = k8sClient.Delete(ctx, hasCompGroup1)
-			_ = k8sClient.Delete(ctx, hasCompGroup2)
+			deleteComponentGroup(hasCompGroup1)
+			deleteComponentGroup(hasCompGroup2)
+			deleteSnapshot(hasCGSnapshot1)
+			deleteSnapshot(hasCGSnapshot2)
 		})
 
 		const (


### PR DESCRIPTION
Main Issue: **ComponentGroup** objects created in **BeforeAll** blocks in **loader/loader_test.go** were not being deleted in corresponding **AfterAll** blocks. This resulted in them leaking into following test blocks. This in turn, made the total count of ComponentGroup objects unpredictable, causing intermittent failures( Approx 2/5 times).

- Added a  cleanup of **hasComponentGroup1**, **hasComponentGroup2** and **hasContainerCompGroup** to the outer **AfterAll** function
-  new AfterAll block to clean up **hasCompGroup1** and **hasCompGroup2**.

Ran make test 5 times locally, all of them passed.
