### PR TITLE
chore(STONEINTG-1732): find orphaned PLRs after controller restart

### DIFF
--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -387,6 +387,52 @@ func (a *Adapter) processSingleScenario(
 		return nil
 	}
 
+	// Crash-recovery: a PipelineRun may already exist in the cluster if the controller
+	// restarted after Create but before the Snapshot status annotation was persisted.
+	existingPipelineRuns, err := a.loader.GetAllPipelineRunsForSnapshotAndScenario(
+		a.context, a.client, a.snapshot, integrationTestScenario,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to list existing PipelineRuns for snapshot %s and scenario %s: %w",
+			a.snapshot.Name, integrationTestScenario.Name, err)
+	}
+	if len(*existingPipelineRuns) > 0 {
+		// Prefer the newest PipelineRun so re-runs are adopted over stale earlier runs.
+		slices.SortFunc(*existingPipelineRuns, func(p, q tektonv1.PipelineRun) int {
+			return q.CreationTimestamp.Compare(p.CreationTimestamp.Time)
+		})
+		existingPipelineRun := (*existingPipelineRuns)[0]
+		a.logger.Info("Found existing integrationPipelineRun in cluster missing from Snapshot status annotation; skipping creation",
+			"integrationTestScenario.Name", integrationTestScenario.Name,
+			"pipelineRun.Name", existingPipelineRun.Name,
+			"count", len(*existingPipelineRuns))
+
+		// Don't force InProgress if the orphaned PipelineRun already finished while we were down.
+		var scenarioStatus intgteststat.IntegrationTestStatus
+		var details string
+		if !h.HasPipelineRunFinished(&existingPipelineRun) {
+			scenarioStatus = intgteststat.IntegrationTestStatusInProgress
+			details = fmt.Sprintf("IntegrationTestScenario pipeline '%s' already exists", existingPipelineRun.Name)
+		} else if h.HasPipelineRunSucceeded(&existingPipelineRun) {
+			scenarioStatus = intgteststat.IntegrationTestStatusTestPassed
+			details = fmt.Sprintf("IntegrationTestScenario pipeline '%s' already completed successfully", existingPipelineRun.Name)
+		} else {
+			scenarioStatus = intgteststat.IntegrationTestStatusTestFail
+			details = fmt.Sprintf("IntegrationTestScenario pipeline '%s' already completed with failure", existingPipelineRun.Name)
+		}
+		testStatuses.UpdateTestStatusIfChanged(integrationTestScenario.Name, scenarioStatus, details)
+		if err = testStatuses.UpdateTestPipelineRunName(integrationTestScenario.Name, existingPipelineRun.Name); err != nil {
+			// it doesn't make sense to restart reconciliation here, it will be eventually updated by integrationpipeline adapter
+			a.logger.Error(err, "Failed to update pipelinerun name in test status")
+		}
+		if !h.HasPipelineRunFinished(&existingPipelineRun) && gitops.IsSnapshotNotStarted(a.snapshot) {
+			if err = gitops.MarkSnapshotIntegrationStatusAsInProgress(a.context, a.client, a.snapshot, "Snapshot starts being tested by the integrationPipelineRun"); err != nil {
+				a.logger.Error(err, "Failed to update integration status condition to in progress for snapshot")
+			}
+		}
+		return nil
+	}
+
 	// Create new pipeline run
 	pipelineRun, err := a.createIntegrationPipelineRun(integrationTestScenario)
 	if err != nil {

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -5217,13 +5217,27 @@ var _ = Describe("Dependent scenarios snapshot adapter scheduling", Ordered, fun
 		pipelineRuns, err := plrLoader.GetAllIntegrationPipelineRunsForSnapshot(ctx, k8sClient, sampleSnapshot)
 		Expect(err).NotTo(HaveOccurred())
 		for i := range pipelineRuns {
-			Expect(k8sClient.Delete(ctx, &pipelineRuns[i])).To(Succeed())
+			plr := &pipelineRuns[i]
+			if len(plr.Finalizers) > 0 {
+				plr.Finalizers = nil
+				Expect(k8sClient.Update(ctx, plr)).To(Succeed())
+			}
+			Expect(k8sClient.Delete(ctx, plr)).To(Succeed())
 		}
+		Eventually(func(g Gomega) {
+			remaining, err := plrLoader.GetAllIntegrationPipelineRunsForSnapshot(ctx, k8sClient, sampleSnapshot)
+			g.Expect(err).NotTo(HaveOccurred())
+			g.Expect(remaining).To(BeEmpty())
+		}, time.Second*10).Should(Succeed())
 		if sampleSnapshot.GetAnnotations() != nil {
 			patch := client.MergeFrom(sampleSnapshot.DeepCopy())
 			delete(sampleSnapshot.Annotations, gitops.SnapshotTestsStatusAnnotation)
 			Expect(k8sClient.Patch(ctx, sampleSnapshot, patch)).To(Succeed())
-			refreshSampleSnapshot()
+			Eventually(func(g Gomega) {
+				refreshSampleSnapshot()
+				_, hasStatus := sampleSnapshot.GetAnnotations()[gitops.SnapshotTestsStatusAnnotation]
+				g.Expect(hasStatus).To(BeFalse())
+			}, time.Second*10).Should(Succeed())
 		}
 	})
 
@@ -5472,6 +5486,151 @@ var _ = Describe("Dependent scenarios snapshot adapter scheduling", Ordered, fun
 					g.Expect(detail.Status).To(Equal(intgteststat.IntegrationTestStatusInProgress))
 					g.Expect(detail.TestPipelineRunName).NotTo(BeEmpty())
 				}).Should(Succeed())
+			})
+
+			Context("When an orphaned PipelineRun exists without annotation", func() {
+				var (
+					buf           bytes.Buffer
+					scenarios     []v1beta2.IntegrationTestScenario
+					newestPLR     *tektonv1.PipelineRun
+					olderPLR      *tektonv1.PipelineRun
+					newestPLRName string
+				)
+
+				BeforeEach(func() {
+					buf = bytes.Buffer{}
+					adapter := newSampleAdapter(sampleSnapshot, &buf)
+					scenarios = []v1beta2.IntegrationTestScenario{*scenarioRoot}
+
+					Expect(adapter.createEligibleIntegrationPipelineRuns(&scenarios)).NotTo(HaveOccurred())
+
+					Eventually(func(g Gomega) {
+						g.Expect(countSampleIntegrationPLRs(sampleSnapshot)).To(Equal(1))
+						refreshSampleSnapshot()
+						statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(sampleSnapshot)
+						g.Expect(err).NotTo(HaveOccurred())
+						detail, ok := statuses.GetScenarioStatus(scenarioRoot.Name)
+						g.Expect(ok).To(BeTrue())
+						g.Expect(detail.TestPipelineRunName).NotTo(BeEmpty())
+						newestPLRName = detail.TestPipelineRunName
+					}, time.Second*10).Should(Succeed())
+
+					newestPLR = &tektonv1.PipelineRun{}
+					Expect(k8sClient.Get(ctx, types.NamespacedName{
+						Name:      newestPLRName,
+						Namespace: sampleSnapshot.Namespace,
+					}, newestPLR)).To(Succeed())
+
+					// Older PipelineRun for the same snapshot+scenario (e.g. prior run before a re-run).
+					olderPLR = newestPLR.DeepCopy()
+					olderPLR.Name = newestPLRName + "-older"
+					olderPLR.ResourceVersion = ""
+					olderPLR.UID = ""
+					olderPLR.CreationTimestamp = metav1.NewTime(newestPLR.CreationTimestamp.Add(-time.Hour))
+					Expect(k8sClient.Create(ctx, olderPLR)).To(Succeed())
+
+					// Simulate crash between PipelineRun creation and annotation persistence.
+					refreshSampleSnapshot()
+					patch := client.MergeFrom(sampleSnapshot.DeepCopy())
+					delete(sampleSnapshot.Annotations, gitops.SnapshotTestsStatusAnnotation)
+					Expect(k8sClient.Patch(ctx, sampleSnapshot, patch)).To(Succeed())
+					Eventually(func(g Gomega) {
+						refreshSampleSnapshot()
+						_, hasStatus := sampleSnapshot.GetAnnotations()[gitops.SnapshotTestsStatusAnnotation]
+						g.Expect(hasStatus).To(BeFalse())
+					}, time.Second*10).Should(Succeed())
+
+					// CreationTimestamp is immutable in the API server, so set ages on the mocked list.
+					olderPLR.CreationTimestamp = metav1.NewTime(newestPLR.CreationTimestamp.Add(-time.Hour))
+				})
+
+				adoptOrphanedPLRs := func() {
+					buf.Reset()
+					log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+					adapter := NewAdapter(ctx, sampleSnapshot, sampleComponentGroup, log, loader.NewMockLoader(), k8sClient)
+					adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+						{
+							ContextKey: loader.ComponentGroupContextKey,
+							Resource:   sampleComponentGroup,
+						},
+						{
+							ContextKey: loader.ComponentContextKey,
+							Resource:   sampleComponent,
+						},
+						{
+							ContextKey: loader.SnapshotContextKey,
+							Resource:   sampleSnapshot,
+						},
+						{
+							ContextKey: loader.SnapshotComponentsContextKey,
+							Resource:   []applicationapiv1alpha1.Component{*sampleComponent},
+						},
+						{
+							ContextKey: loader.PipelineRunsContextKey,
+							Resource:   []tektonv1.PipelineRun{*olderPLR, *newestPLR},
+						},
+					})
+					Expect(adapter.createEligibleIntegrationPipelineRuns(&scenarios)).NotTo(HaveOccurred())
+					Expect(buf.String()).NotTo(ContainSubstring("Creating new pipelinerun for integrationTestscenario"))
+					Expect(buf.String()).To(ContainSubstring("Found existing integrationPipelineRun in cluster missing from Snapshot status annotation"))
+				}
+
+				It("should adopt the newest unfinished PipelineRun as InProgress", func() {
+					adoptOrphanedPLRs()
+
+					Eventually(func(g Gomega) {
+						g.Expect(countSampleIntegrationPLRs(sampleSnapshot)).To(Equal(2))
+						refreshSampleSnapshot()
+						statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(sampleSnapshot)
+						g.Expect(err).NotTo(HaveOccurred())
+						detail, ok := statuses.GetScenarioStatus(scenarioRoot.Name)
+						g.Expect(ok).To(BeTrue())
+						g.Expect(detail.Status).To(Equal(intgteststat.IntegrationTestStatusInProgress))
+						g.Expect(detail.TestPipelineRunName).To(Equal(newestPLRName))
+					}, time.Second*10).Should(Succeed())
+				})
+
+				It("should adopt a finished successful PipelineRun as TestPassed", func() {
+					newestPLR.Status.SetCondition(&apis.Condition{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionTrue,
+						Reason: "Succeeded",
+					})
+
+					adoptOrphanedPLRs()
+
+					Eventually(func(g Gomega) {
+						g.Expect(countSampleIntegrationPLRs(sampleSnapshot)).To(Equal(2))
+						refreshSampleSnapshot()
+						statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(sampleSnapshot)
+						g.Expect(err).NotTo(HaveOccurred())
+						detail, ok := statuses.GetScenarioStatus(scenarioRoot.Name)
+						g.Expect(ok).To(BeTrue())
+						g.Expect(detail.Status).To(Equal(intgteststat.IntegrationTestStatusTestPassed))
+						g.Expect(detail.TestPipelineRunName).To(Equal(newestPLRName))
+					}, time.Second*10).Should(Succeed())
+				})
+
+				It("should adopt a finished failed PipelineRun as TestFail", func() {
+					newestPLR.Status.SetCondition(&apis.Condition{
+						Type:   apis.ConditionSucceeded,
+						Status: corev1.ConditionFalse,
+						Reason: "Failed",
+					})
+
+					adoptOrphanedPLRs()
+
+					Eventually(func(g Gomega) {
+						g.Expect(countSampleIntegrationPLRs(sampleSnapshot)).To(Equal(2))
+						refreshSampleSnapshot()
+						statuses, err := gitops.NewSnapshotIntegrationTestStatusesFromSnapshot(sampleSnapshot)
+						g.Expect(err).NotTo(HaveOccurred())
+						detail, ok := statuses.GetScenarioStatus(scenarioRoot.Name)
+						g.Expect(ok).To(BeTrue())
+						g.Expect(detail.Status).To(Equal(intgteststat.IntegrationTestStatusTestFail))
+						g.Expect(detail.TestPipelineRunName).To(Equal(newestPLRName))
+					}, time.Second*10).Should(Succeed())
+				})
 			})
 		})
 


### PR DESCRIPTION
Add cluster query before PipelineRun creation to ensure idempotency. If a PipelineRun already exists for the snapshot+scenario, but isn't in the annotation, adopt it instead of creating a duplicate. This handles controller crashes between creation and annotation persistence.

## Maintainers will complete the following section

- [y] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [y] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
