### PR TITLE
feat(STONEINTG-1763): option to always create group Snapshots for PRs

### DIFF
--- a/docs/build_pipeline_controller.md
+++ b/docs/build_pipeline_controller.md
@@ -29,7 +29,10 @@ continue[Continue processing]
 update_metadata(add PR group info to build pipelineRun metadata)
 notify_pr_group_failure(annotate Snapshots and in-flight builds in PR group with failure message)
 failed_group_pipeline_run{Pipeline failed?}
-update_integrationTestStatus_in_git_provider(Create checkRun/commitStatus in<br>git provider)
+report_component_integration_test_status(Report component snapshot<br>integration test status<br>to git provider)
+group_snapshot_enforcement_annotation{Application or ComponentGroup has<br>integration.konflux-ci.dev/always-create-group-snapshots: true?}
+check_group_snapshot_eligibility{Is group snapshot expected<br>for this PR group?<br>(>= 2 components with open PR/MR)}
+report_group_integration_test_status(Report group snapshot<br>integration test status<br>to git provider)
 update_build_plr_annotation(Update build pipelineRun annotation<br>test.appstudio.openshift.io/snapshot-creation-report<br>with the status)
 successful_pipeline(Successful build pipelinerun<br>from push event and is signed)
 update_GCL(Update Global Candidate List for the built component)
@@ -62,9 +65,14 @@ prep_snapshot                    --> check_chains
 check_chains               --Yes --> annotate_pipelineRun
 annotate_pipelineRun       --Yes --> remove_finalizer
 remove_finalizer                 --> continue
-need_to_set_integration_test  --Yes --> update_integrationTestStatus_in_git_provider
+need_to_set_integration_test  --Yes --> report_component_integration_test_status
 need_to_set_integration_test  --No  --> continue
-update_integrationTestStatus_in_git_provider --> update_build_plr_annotation
+report_component_integration_test_status --> group_snapshot_enforcement_annotation
+group_snapshot_enforcement_annotation --Yes--> report_group_integration_test_status
+group_snapshot_enforcement_annotation --No --> check_group_snapshot_eligibility
+check_group_snapshot_eligibility --Yes--> report_group_integration_test_status
+check_group_snapshot_eligibility --No --> update_build_plr_annotation
+report_group_integration_test_status --> update_build_plr_annotation
 update_build_plr_annotation --> continue
 
 successful_pipeline --> update_GCL

--- a/docs/snapshot-controller.md
+++ b/docs/snapshot-controller.md
@@ -119,28 +119,36 @@ flowchart TD
   %% Node definitions
   ensure5(Process further if: Snapshot has <b>neither</b> push event type label <br><b>nor</b> PRGroupCreation annotation)
   validate_build_pipelinerun{Did all gotten build pipelineRun <br>under the same group <br>succeed <b>and</b> <br>component snapshot are already created?}
+  enough_affected_components{Are enough components affected <br>by this PR group?<br>(>= 2, or >= 1 when <br>always-create-group-snapshots annotation <br>is set on Application or ComponentGroup)}
   annotate_component_snapshot(<b>Annotate</b> component snapshot)
   get_component_snapshots_and_sort(<b>Iterate</b> all application or componentGroup components and <br><b>get<b/> all component snapshots <br>for each component under the same pr group sha <br>then <b>sort</b> snapshots)
   can_find_snapshotComponent_from_latest_snapshot(<b>Can</b> find the latest snapshot with open pull/merge request?)
   add_snapshot_to_group_snapshot_candidate(<b>Add</b> snapshotComponent of component <br>to group snapshot components candidate)
   get_snapshotComponent_from_gcl(<b>Get</b> snapshotComponent from <br>Global Candidate List)
-  create_group_snapshot(<b>Create</b> group snapshot for snasphotComponents)
+  enough_valid_pr_snapshots{Are enough valid open PR/MR <br>component snapshots?<br>(>= 2, or >= 1 when <br>always-create-group-snapshots annotation <br>is set on Application or ComponentGroup)}
+  skip_group_snapshot_creation(<b>Skip</b> group snapshot creation)
+  create_group_snapshot(<b>Create</b> group snapshot for snapshotComponents)
   annotate_component_snapshots_under_prgroupsha(<b>Annotate<b> component snapshots which <b>have</b> <br>snapshotComponent added to group snapshot)
   continue_processing5(Controller continues processing...)
 
   %% Node connections
   predicate                              ---->    |"EnsureGroupSnapshotExist()"|ensure5
   ensure5                                -->      validate_build_pipelinerun
-  validate_build_pipelinerun             --Yes--> get_component_snapshots_and_sort
+  validate_build_pipelinerun             --Yes--> enough_affected_components
   validate_build_pipelinerun             --No-->  annotate_component_snapshot
+  enough_affected_components             --Yes--> get_component_snapshots_and_sort
+  enough_affected_components             --No-->  skip_group_snapshot_creation
   get_component_snapshots_and_sort       -->      can_find_snapshotComponent_from_latest_snapshot
-  can_find_snapshotComponent_from_latest_snapshot  --Yes--> add_snapshot_group_snapshot_candidate
+  can_find_snapshotComponent_from_latest_snapshot  --Yes--> add_snapshot_to_group_snapshot_candidate
   can_find_snapshotComponent_from_latest_snapshot  --No-->  get_snapshotComponent_from_gcl
-  add_snapshot_to_group_snapshot_candidate   -->        create_group_snapshot
-  get_snapshotComponent_from_gcl             -->        create_group_snapshot
+  add_snapshot_to_group_snapshot_candidate   -->        enough_valid_pr_snapshots
+  get_snapshotComponent_from_gcl             -->        enough_valid_pr_snapshots
+  enough_valid_pr_snapshots              --Yes--> create_group_snapshot
+  enough_valid_pr_snapshots              --No-->  skip_group_snapshot_creation
   create_group_snapshot                   -->        annotate_component_snapshots_under_prgroupsha
   annotate_component_snapshots_under_prgroupsha -->  continue_processing5
   annotate_component_snapshot                   -->  continue_processing5
+  skip_group_snapshot_creation                  -->  continue_processing5
 
   %% Assigning styles to nodes
   class predicate Amber;

--- a/helpers/component_group.go
+++ b/helpers/component_group.go
@@ -20,6 +20,11 @@ import (
 	"github.com/konflux-ci/integration-service/api/v1beta2"
 )
 
+const (
+	// AlwaysCreateGroupSnapshotAnnotationName controls if the integration service always creates group Snapshots for PRs
+	AlwaysCreateGroupSnapshotAnnotationName = "integration.konflux-ci.dev/always-create-group-snapshots"
+)
+
 func GetComponentGroupNames(componentGroups *[]v1beta2.ComponentGroup) []string {
 	names := []string{}
 	if componentGroups != nil {

--- a/internal/controller/buildpipeline/buildpipeline_adapter.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter.go
@@ -688,12 +688,19 @@ func (a *Adapter) reportIntegrationStatusAndHandleGroupsForApplication(integrati
 		return 0, 0, fmt.Errorf("failed to report status for expected group Snapshot: %w", err)
 	}
 
-	a.logger.Info("try to check if group snapshot is expected for build PLR")
-	isGroupSnapshotExpected, err := a.isGroupSnapshotExpectedForBuildPLR(a.pipelineRun, tempComponentSnapshot, a.application.Name, gitops.ApplicationNameLabel)
-	if err != nil {
-		a.logger.Error(err, "failed to check if group snapshot is expected")
-		return 0, 0, fmt.Errorf("failed to check if group snapshot is expected: %w", err)
+	isGroupSnapshotExpected := false
+	if metadata.HasAnnotationWithValue(a.application, h.AlwaysCreateGroupSnapshotAnnotationName, "true") {
+		a.logger.Info("group snapshot creation enforced by annotation on application")
+		isGroupSnapshotExpected = true
+	} else {
+		a.logger.Info("try to check if group snapshot is expected for build PLR")
+		isGroupSnapshotExpected, err = a.isGroupSnapshotExpectedForBuildPLR(a.pipelineRun, tempComponentSnapshot, a.application.Name, gitops.ApplicationNameLabel)
+		if err != nil {
+			a.logger.Error(err, "failed to check if group snapshot is expected")
+			return 0, 0, fmt.Errorf("failed to check if group snapshot is expected: %w", err)
+		}
 	}
+
 	if isGroupSnapshotExpected {
 		a.logger.Info("group snapshot is expected to be created for build pipelinerun, group integration test should be set for found context scenario", "pipelineRun.Name", a.pipelineRun.Name)
 		tempGroupSnapshot := a.prepareTempGroupSnapshot(a.pipelineRun, &a.application.ObjectMeta, true)
@@ -725,11 +732,18 @@ func (a *Adapter) reportIntegrationStatusAndHandleGroups(integrationTestStatus *
 		}
 		numComponentSnapshotScenarios += num
 
-		a.logger.Info("try to check if group snapshot is expected for build PLR")
-		isGroupSnapshotExpected, err := a.isGroupSnapshotExpectedForBuildPLR(a.pipelineRun, tempComponentSnapshot, componentGroup.Name, gitops.ComponentGroupNameLabel)
-		if err != nil {
-			return 0, 0, fmt.Errorf("failed to check if group snapshot is expected: %w", err)
+		isGroupSnapshotExpected := false
+		if metadata.HasAnnotationWithValue(&componentGroup, h.AlwaysCreateGroupSnapshotAnnotationName, "true") {
+			a.logger.Info("group snapshot creation enforced by annotation on componentGroup")
+			isGroupSnapshotExpected = true
+		} else {
+			a.logger.Info("try to check if group snapshot is expected for build PLR")
+			isGroupSnapshotExpected, err = a.isGroupSnapshotExpectedForBuildPLR(a.pipelineRun, tempComponentSnapshot, componentGroup.Name, gitops.ComponentGroupNameLabel)
+			if err != nil {
+				return 0, 0, fmt.Errorf("failed to check if group snapshot is expected: %w", err)
+			}
 		}
+
 		if isGroupSnapshotExpected {
 			a.logger.Info("group snapshot is expected to be created for build pipelinerun, group integration test should be set for found context scenario", "pipelineRun.Name", a.pipelineRun.Name)
 			tempGroupSnapshot := a.prepareTempGroupSnapshot(a.pipelineRun, &componentGroup.ObjectMeta, false)

--- a/internal/controller/buildpipeline/buildpipeline_adapter_test.go
+++ b/internal/controller/buildpipeline/buildpipeline_adapter_test.go
@@ -3254,6 +3254,50 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(result.RequeueRequest).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("should report group integration test when always-create-group-snapshots is set on Application", func() {
+			buildPipelineRun.Status = tektonv1.PipelineRunStatus{
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Running",
+							Status: "Unknown",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			appWithAnnotation := hasApp.DeepCopy()
+			if appWithAnnotation.Annotations == nil {
+				appWithAnnotation.Annotations = map[string]string{}
+			}
+			appWithAnnotation.Annotations[helpers.AlwaysCreateGroupSnapshotAnnotationName] = "true"
+
+			adapter = NewAdapterWithApplication(ctx, buildPipelineRun, hasComp, appWithAnnotation, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   appWithAnnotation,
+				},
+				{
+					ContextKey: loader.AllIntegrationTestScenariosContextKey,
+					Resource:   []v1beta2.IntegrationTestScenario{*integrationTestScenario, *groupIntegrationTestScenario},
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitProvider()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).Should(ContainSubstring("group snapshot is expected to be created for build pipelinerun"))
+			Expect(buf.String()).ShouldNot(ContainSubstring("less than 2, skipping group snapshot status report"))
+		})
 	})
 
 	When("a build PLR is triggered or retriggered, succeeded or failed", func() {
@@ -3599,6 +3643,60 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 			Expect(result.CancelRequest).To(BeFalse())
 			Expect(result.RequeueRequest).To(BeFalse())
 			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should report group integration test when always-create-group-snapshots is set on ComponentGroup", func() {
+			buildPipelineRun.Status = tektonv1.PipelineRunStatus{
+				Status: v1.Status{
+					Conditions: v1.Conditions{
+						apis.Condition{
+							Reason: "Running",
+							Status: "Unknown",
+							Type:   apis.ConditionSucceeded,
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, buildPipelineRun)).Should(Succeed())
+
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			compGroupWithAnnotation := hasCompGroup.DeepCopy()
+			if compGroupWithAnnotation.Annotations == nil {
+				compGroupWithAnnotation.Annotations = map[string]string{}
+			}
+			compGroupWithAnnotation.Annotations[helpers.AlwaysCreateGroupSnapshotAnnotationName] = "true"
+			compGroupWithAnnotation.Spec.Components = []v1beta2.ComponentReference{
+				{
+					Name: hasComp.Name,
+					ComponentVersion: v1beta2.ComponentVersionReference{
+						Name:     "v1",
+						Revision: "main",
+					},
+				},
+			}
+			componentGroups := []v1beta2.ComponentGroup{*compGroupWithAnnotation}
+
+			adapter = NewAdapter(ctx, buildPipelineRun, hasComp, &componentGroups, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupsContextKey,
+					Resource:   compGroupWithAnnotation,
+				},
+				{
+					ContextKey: loader.AllIntegrationTestScenariosForComponentGroupContextKey,
+					Resource:   []v1beta2.IntegrationTestScenario{*integrationTestScenario, *groupIntegrationTestScenario},
+				},
+			})
+
+			result, err := adapter.EnsureIntegrationTestReportedToGitProvider()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(buf.String()).Should(ContainSubstring("group snapshot is expected to be created for build pipelinerun"))
+			Expect(buf.String()).ShouldNot(ContainSubstring("less than 2, skipping group snapshot status report"))
 		})
 	})
 

--- a/internal/controller/snapshot/snapshot_adapter.go
+++ b/internal/controller/snapshot/snapshot_adapter.go
@@ -1271,12 +1271,13 @@ func (a *Adapter) prepareGroupSnapshot(prGroup, prGroupHash string) (*applicatio
 	ownerLabel := gitops.ComponentGroupNameLabel
 	namespace := a.componentGroup.Namespace
 	snapshotComponentsFromGCL, invalidComponents := snapshot.GetSnapshotComponentsFromGCL(a.componentGroup, a.logger)
+	isGroupSnapshotCreationEnforced := metadata.HasAnnotationWithValue(a.componentGroup, h.AlwaysCreateGroupSnapshotAnnotationName, "true")
 
 	componentsToCheck, err := a.loader.GetComponentsFromSnapshotForPRGroup(a.context, a.client, namespace, prGroupHash, ownerName, ownerLabel)
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(componentsToCheck) < 2 {
+	if len(componentsToCheck) < 2 && !isGroupSnapshotCreationEnforced {
 		a.logger.Info(fmt.Sprintf("The number %d of components affected by this PR group %s is less than 2, skipping group snapshot creation", len(componentsToCheck), prGroup))
 		return nil, nil, nil
 	}
@@ -1336,7 +1337,11 @@ func (a *Adapter) prepareGroupSnapshot(prGroup, prGroupHash string) (*applicatio
 	}
 
 	// if the valid component snapshot from open MR/PR is less than 2, won't create group snapshot
-	if len(componentSnapshotInfos) < 2 {
+	requiredComponentSnapshotInfos := 2
+	if isGroupSnapshotCreationEnforced {
+		requiredComponentSnapshotInfos = 1
+	}
+	if len(componentSnapshotInfos) < requiredComponentSnapshotInfos {
 		return nil, componentSnapshotInfos, nil
 	}
 
@@ -1369,11 +1374,13 @@ func (a *Adapter) prepareGroupSnapshotApplication(prGroup, prGroupHash string) (
 		return nil, nil, err
 	}
 
+	isGroupSnapshotCreationEnforced := metadata.HasAnnotationWithValue(a.application, h.AlwaysCreateGroupSnapshotAnnotationName, "true")
+
 	componentsToCheck, err := a.loader.GetComponentsFromSnapshotForPRGroup(a.context, a.client, namespace, prGroupHash, ownerName, ownerLabel)
 	if err != nil {
 		return nil, nil, err
 	}
-	if len(componentsToCheck) < 2 {
+	if len(componentsToCheck) < 2 && !isGroupSnapshotCreationEnforced {
 		a.logger.Info(fmt.Sprintf("The number %d of components affected by this PR group %s is less than 2, skipping group snapshot creation", len(componentsToCheck), prGroup))
 		return nil, nil, nil
 	}
@@ -1426,7 +1433,11 @@ func (a *Adapter) prepareGroupSnapshotApplication(prGroup, prGroupHash string) (
 	}
 
 	// if the valid component snapshot from open MR/PR is less than 2, won't create group snapshot
-	if len(componentSnapshotInfos) < 2 {
+	requiredComponentSnapshotInfos := 2
+	if isGroupSnapshotCreationEnforced {
+		requiredComponentSnapshotInfos = 1
+	}
+	if len(componentSnapshotInfos) < requiredComponentSnapshotInfos {
 		return nil, componentSnapshotInfos, nil
 	}
 

--- a/internal/controller/snapshot/snapshot_adapter_test.go
+++ b/internal/controller/snapshot/snapshot_adapter_test.go
@@ -3846,6 +3846,154 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should create group snapshot when always-create-group-snapshots is set on Application with single PR component", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockStatus := status.NewMockStatusInterface(ctrl)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(hasComSnapshot1, 0, nil)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
+
+			appWithAnnotation := hasApp.DeepCopy()
+			if appWithAnnotation.Annotations == nil {
+				appWithAnnotation.Annotations = map[string]string{}
+			}
+			appWithAnnotation.Annotations[helpers.AlwaysCreateGroupSnapshotAnnotationName] = "true"
+
+			sampleTuple := loader.Tuple{ComponentName: hasCom1.Name, ComponentVersion: ""}
+			adapter = NewAdapterWithApplication(ctx, hasComSnapshot1, appWithAnnotation, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   appWithAnnotation,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{},
+				},
+				{
+					ContextKey: loader.GetComponentsFromSnapshotForPRGroupKey,
+					Resource:   []loader.Tuple{sampleTuple},
+				},
+				{
+					ContextKey: loader.ApplicationComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasCom1},
+				},
+			})
+
+			groupSnapshotsBefore := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshotsBefore, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+				gitops.PRGroupHashLabel:  prGroupSha,
+			})).Should(Succeed())
+			groupSnapshotCountBefore := len(groupSnapshotsBefore.Items)
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).ShouldNot(ContainSubstring("less than 2, skipping group snapshot creation"))
+			Eventually(func() int {
+				groupSnapshots := &applicationapiv1alpha1.SnapshotList{}
+				err := k8sClient.List(adapter.context, groupSnapshots, client.InNamespace("default"), client.MatchingLabels{
+					gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+					gitops.PRGroupHashLabel:  prGroupSha,
+				})
+				if err != nil {
+					return 0
+				}
+				return len(groupSnapshots.Items)
+			}, time.Second*10).Should(Equal(groupSnapshotCountBefore + 1))
+
+			Eventually(func() bool {
+				err := k8sClient.Get(adapter.context, types.NamespacedName{
+					Name:      hasComSnapshot1.Name,
+					Namespace: "default",
+				}, hasComSnapshot1)
+				return err == nil && gitops.HasPRGroupProcessed(hasComSnapshot1)
+			}, time.Second*10).Should(BeTrue())
+
+			buf.Reset()
+			result, err = adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).Should(ContainSubstring("The PR group info has been processed for this component snapshot"))
+
+			groupSnapshots := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshots, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+				gitops.PRGroupHashLabel:  prGroupSha,
+			})).Should(Succeed())
+			Expect(groupSnapshots.Items).To(HaveLen(groupSnapshotCountBefore + 1))
+		})
+
+		It("should not create group snapshot when always-create-group-snapshots is set on Application but no valid PR component snapshot exists", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockStatus := status.NewMockStatusInterface(ctrl)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, nil)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
+
+			appWithAnnotation := hasApp.DeepCopy()
+			if appWithAnnotation.Annotations == nil {
+				appWithAnnotation.Annotations = map[string]string{}
+			}
+			appWithAnnotation.Annotations[helpers.AlwaysCreateGroupSnapshotAnnotationName] = "true"
+
+			sampleTuple := loader.Tuple{ComponentName: hasCom1.Name, ComponentVersion: ""}
+			adapter = NewAdapterWithApplication(ctx, hasComSnapshot1, appWithAnnotation, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ApplicationContextKey,
+					Resource:   appWithAnnotation,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{},
+				},
+				{
+					ContextKey: loader.GetComponentsFromSnapshotForPRGroupKey,
+					Resource:   []loader.Tuple{sampleTuple},
+				},
+				{
+					ContextKey: loader.ApplicationComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasCom1},
+				},
+			})
+
+			groupSnapshotsBefore := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshotsBefore, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+			})).Should(Succeed())
+			groupSnapshotCountBefore := len(groupSnapshotsBefore.Items)
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).ShouldNot(ContainSubstring("PR/MR in snapshot is opened"))
+
+			groupSnapshotsAfter := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshotsAfter, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+			})).Should(Succeed())
+			Expect(groupSnapshotsAfter.Items).To(HaveLen(groupSnapshotCountBefore))
+		})
+
 		It("Ensure group snapshot can be created", func() {
 			var buf bytes.Buffer
 			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
@@ -4267,6 +4415,172 @@ var _ = Describe("Snapshot Adapter", Ordered, func() {
 			Expect(result.RequeueRequest).To(BeFalse())
 			Expect(buf.String()).Should(ContainSubstring("The number 1 of components affected by this PR group feature1 is less than 2, skipping group snapshot creation"))
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should create group snapshot when always-create-group-snapshots is set on ComponentGroup with single PR component", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockStatus := status.NewMockStatusInterface(ctrl)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(hasComSnapshot1, 0, nil)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
+
+			compGroupWithAnnotation := hasCompGroup.DeepCopy()
+			if compGroupWithAnnotation.Annotations == nil {
+				compGroupWithAnnotation.Annotations = map[string]string{}
+			}
+			compGroupWithAnnotation.Annotations[helpers.AlwaysCreateGroupSnapshotAnnotationName] = "true"
+			compGroupWithAnnotation.Spec.Components = []v1beta2.ComponentReference{
+				{
+					Name: hasCom1.Name,
+					ComponentVersion: v1beta2.ComponentVersionReference{
+						Name:     "v1",
+						Revision: "main",
+					},
+				},
+			}
+
+			sampleTuple := loader.Tuple{ComponentName: hasCom1.Name, ComponentVersion: "v1"}
+			adapter = NewAdapter(ctx, hasComSnapshot1, compGroupWithAnnotation, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupsContextKey,
+					Resource:   compGroupWithAnnotation,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{},
+				},
+				{
+					ContextKey: loader.GetComponentsFromSnapshotForPRGroupKey,
+					Resource:   []loader.Tuple{sampleTuple},
+				},
+				{
+					ContextKey: loader.ComponentGroupComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasCom1},
+				},
+			})
+
+			groupSnapshotsBefore := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshotsBefore, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+				gitops.PRGroupHashLabel:  prGroupSha,
+			})).Should(Succeed())
+			groupSnapshotCountBefore := len(groupSnapshotsBefore.Items)
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).ShouldNot(ContainSubstring("less than 2, skipping group snapshot creation"))
+			Eventually(func() int {
+				groupSnapshots := &applicationapiv1alpha1.SnapshotList{}
+				err := k8sClient.List(adapter.context, groupSnapshots, client.InNamespace("default"), client.MatchingLabels{
+					gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+					gitops.PRGroupHashLabel:  prGroupSha,
+				})
+				if err != nil {
+					return 0
+				}
+				return len(groupSnapshots.Items)
+			}, time.Second*10).Should(Equal(groupSnapshotCountBefore + 1))
+
+			Eventually(func() bool {
+				err := k8sClient.Get(adapter.context, types.NamespacedName{
+					Name:      hasComSnapshot1.Name,
+					Namespace: "default",
+				}, hasComSnapshot1)
+				return err == nil && gitops.HasPRGroupProcessed(hasComSnapshot1)
+			}, time.Second*10).Should(BeTrue())
+
+			buf.Reset()
+			result, err = adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).Should(ContainSubstring("The PR group info has been processed for this component snapshot"))
+
+			groupSnapshots := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshots, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+				gitops.PRGroupHashLabel:  prGroupSha,
+			})).Should(Succeed())
+			Expect(groupSnapshots.Items).To(HaveLen(groupSnapshotCountBefore + 1))
+		})
+
+		It("should not create group snapshot when always-create-group-snapshots is set on ComponentGroup but no valid PR component snapshot exists", func() {
+			var buf bytes.Buffer
+			log := helpers.IntegrationLogger{Logger: buflogr.NewWithBuffer(&buf)}
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockStatus := status.NewMockStatusInterface(ctrl)
+			mockStatus.EXPECT().FindSnapshotWithOpenedPR(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil, 0, nil)
+			mockStatus.EXPECT().IsPRMRInSnapshotOpened(gomock.Any(), gomock.Any()).AnyTimes()
+
+			compGroupWithAnnotation := hasCompGroup.DeepCopy()
+			if compGroupWithAnnotation.Annotations == nil {
+				compGroupWithAnnotation.Annotations = map[string]string{}
+			}
+			compGroupWithAnnotation.Annotations[helpers.AlwaysCreateGroupSnapshotAnnotationName] = "true"
+			compGroupWithAnnotation.Spec.Components = []v1beta2.ComponentReference{
+				{
+					Name: hasCom1.Name,
+					ComponentVersion: v1beta2.ComponentVersionReference{
+						Name:     "v1",
+						Revision: "main",
+					},
+				},
+			}
+
+			sampleTuple := loader.Tuple{ComponentName: hasCom1.Name, ComponentVersion: "v1"}
+			adapter = NewAdapter(ctx, hasComSnapshot1, compGroupWithAnnotation, log, loader.NewMockLoader(), k8sClient)
+			adapter.status = mockStatus
+			adapter.context = toolkit.GetMockedContext(ctx, []toolkit.MockData{
+				{
+					ContextKey: loader.ComponentGroupsContextKey,
+					Resource:   compGroupWithAnnotation,
+				},
+				{
+					ContextKey: loader.SnapshotContextKey,
+					Resource:   hasComSnapshot1,
+				},
+				{
+					ContextKey: loader.GetBuildPLRContextKey,
+					Resource:   []tektonv1.PipelineRun{},
+				},
+				{
+					ContextKey: loader.GetComponentsFromSnapshotForPRGroupKey,
+					Resource:   []loader.Tuple{sampleTuple},
+				},
+				{
+					ContextKey: loader.ComponentGroupComponentsContextKey,
+					Resource:   []applicationapiv1alpha1.Component{*hasCom1},
+				},
+			})
+
+			groupSnapshotsBefore := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshotsBefore, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+			})).Should(Succeed())
+			groupSnapshotCountBefore := len(groupSnapshotsBefore.Items)
+
+			result, err := adapter.EnsureGroupSnapshotExist()
+			Expect(result.CancelRequest).To(BeFalse())
+			Expect(result.RequeueRequest).To(BeFalse())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(buf.String()).ShouldNot(ContainSubstring("PR/MR in snapshot is opened"))
+
+			groupSnapshotsAfter := &applicationapiv1alpha1.SnapshotList{}
+			Expect(k8sClient.List(adapter.context, groupSnapshotsAfter, client.InNamespace("default"), client.MatchingLabels{
+				gitops.SnapshotTypeLabel: gitops.SnapshotGroupType,
+			})).Should(Succeed())
+			Expect(groupSnapshotsAfter.Items).To(HaveLen(groupSnapshotCountBefore))
 		})
 
 		It("Ensure group snapshot can be created", func() {


### PR DESCRIPTION
Support an optional annotation on componentGroup and application CRs which controls if the integration service always creates group Snapshots for PRs.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
