### PR TITLE
fix(KONFLUX-15531): override ITS revision for private GitLab repos

### DIFF
--- a/helpers/integration.go
+++ b/helpers/integration.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	neturl "net/url"
 	"reflect"
 	"sort"
 	"strings"
@@ -531,8 +532,60 @@ func IsObjectYoungerThanThreshold(obj metav1.Object, threshold time.Duration) bo
 
 // UrlToGitUrl appends `.git` to the URL if it doesn't already have it
 func UrlToGitUrl(url string) string {
+	url = strings.TrimSuffix(url, "/")
 	if strings.HasSuffix(url, ".git") {
 		return url
 	}
-	return strings.TrimSuffix(url, "/") + ".git"
+	return url + ".git"
+}
+
+// ConstructGitUrl constructs a git URL from server URL, org and repository
+func ConstructGitUrl(serverUrl, org, repo string) string {
+	url := strings.TrimSuffix(serverUrl, "/")
+	return UrlToGitUrl(fmt.Sprintf("%s/%s/%s", url, org, repo))
+}
+
+// IsForkGitRepository reports whether source and target repo URLs refer to different repositories.
+func IsForkGitRepository(sourceRepoUrl, targetRepoUrl string) bool {
+	if sourceRepoUrl == "" || targetRepoUrl == "" {
+		return false
+	}
+	return UrlToGitUrl(sourceRepoUrl) != UrlToGitUrl(targetRepoUrl)
+}
+
+// ParseGitHttpsUrl parses an https git repository URL into server URL, org and repo.
+// For nested GitLab groups, org contains the namespace path (e.g. group/subgroup).
+func ParseGitHttpsUrl(gitUrl string) (serverUrl, org, repo string, err error) {
+	normalized := strings.TrimSuffix(UrlToGitUrl(gitUrl), ".git")
+	parsedUrl, err := neturl.Parse(normalized)
+	if err != nil {
+		return "", "", "", fmt.Errorf("failed to parse git url: %w", err)
+	}
+	if parsedUrl.Scheme != "https" {
+		return "", "", "", fmt.Errorf("unsupported git url scheme: %s", parsedUrl.Scheme)
+	}
+	path := strings.Trim(parsedUrl.Path, "/")
+	if path == "" {
+		return "", "", "", fmt.Errorf("git url path is empty")
+	}
+	segments := strings.Split(path, "/")
+	if len(segments) < 2 {
+		return "", "", "", fmt.Errorf("git url path must contain org and repo")
+	}
+	repo = strings.TrimSuffix(segments[len(segments)-1], ".git")
+	org = strings.Join(segments[:len(segments)-1], "/")
+	serverUrl = fmt.Sprintf("%s://%s", parsedUrl.Scheme, parsedUrl.Host)
+	return serverUrl, org, repo, nil
+}
+
+// ForkGitResolverOrgRepo returns org and repo parsed from the fork source URL when source and target differ.
+func ForkGitResolverOrgRepo(sourceRepoUrl, targetRepoUrl string) (org, repo string, ok bool) {
+	if !IsForkGitRepository(sourceRepoUrl, targetRepoUrl) {
+		return "", "", false
+	}
+	_, org, repo, err := ParseGitHttpsUrl(sourceRepoUrl)
+	if err != nil {
+		return "", "", false
+	}
+	return org, repo, true
 }

--- a/helpers/integration_test.go
+++ b/helpers/integration_test.go
@@ -1095,10 +1095,73 @@ var _ = Describe("Pipeline Adapter", Ordered, func() {
 		normalizedGitUrl = helpers.UrlToGitUrl(gitUrl)
 		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
 
+		gitUrl = "https://github.com/konflux-ci/integration-service.git/"
+		normalizedGitUrl = helpers.UrlToGitUrl(gitUrl)
+		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
+
 		expectedGitUrl = "git@github.com:konflux-ci/integration-service.git"
 		gitUrl = "git@github.com:konflux-ci/integration-service.git"
 		normalizedGitUrl = helpers.UrlToGitUrl(gitUrl)
 		Expect(normalizedGitUrl).To(Equal(expectedGitUrl))
+	})
+
+	It("constructs git URLs from server URL, org and repo", func() {
+		Expect(helpers.ConstructGitUrl("https://github.com", "konflux-ci", "integration-service")).To(Equal("https://github.com/konflux-ci/integration-service.git"))
+		Expect(helpers.ConstructGitUrl("https://github.com/", "konflux-ci", "integration-service")).To(Equal("https://github.com/konflux-ci/integration-service.git"))
+	})
+
+	It("detects fork git repositories", func() {
+		sourceRepoUrl := "https://github.com/test/integration-examples"
+		targetRepoUrl := "https://github.com/redhat-appstudio/integration-examples"
+
+		Expect(helpers.IsForkGitRepository(sourceRepoUrl, targetRepoUrl)).To(BeTrue())
+		Expect(helpers.IsForkGitRepository(sourceRepoUrl+"/", targetRepoUrl)).To(BeTrue())
+		Expect(helpers.IsForkGitRepository(sourceRepoUrl, sourceRepoUrl)).To(BeFalse())
+		Expect(helpers.IsForkGitRepository(sourceRepoUrl+"/", sourceRepoUrl)).To(BeFalse())
+		Expect(helpers.IsForkGitRepository("", targetRepoUrl)).To(BeFalse())
+		Expect(helpers.IsForkGitRepository(sourceRepoUrl, "")).To(BeFalse())
+	})
+
+	It("parses https git repository URLs", func() {
+		serverUrl, org, repo, err := helpers.ParseGitHttpsUrl("https://github.com/konflux-ci/integration-service")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serverUrl).To(Equal("https://github.com"))
+		Expect(org).To(Equal("konflux-ci"))
+		Expect(repo).To(Equal("integration-service"))
+
+		serverUrl, org, repo, err = helpers.ParseGitHttpsUrl("https://gitlab.com/group/subgroup/project.git")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serverUrl).To(Equal("https://gitlab.com"))
+		Expect(org).To(Equal("group/subgroup"))
+		Expect(repo).To(Equal("project"))
+
+		serverUrl, org, repo, err = helpers.ParseGitHttpsUrl("https://github.com/konflux-ci/integration-service.git/")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(serverUrl).To(Equal("https://github.com"))
+		Expect(org).To(Equal("konflux-ci"))
+		Expect(repo).To(Equal("integration-service"))
+
+		_, _, _, err = helpers.ParseGitHttpsUrl("http://github.com/konflux-ci/integration-service")
+		Expect(err).To(HaveOccurred())
+
+		_, _, _, err = helpers.ParseGitHttpsUrl("git@github.com:konflux-ci/integration-service.git")
+		Expect(err).To(HaveOccurred())
+	})
+
+	It("returns fork org and repo from source URL when repos differ", func() {
+		sourceRepoUrl := "https://github.com/test/integration-examples"
+		targetRepoUrl := "https://github.com/redhat-appstudio/integration-examples"
+
+		org, repo, ok := helpers.ForkGitResolverOrgRepo(sourceRepoUrl, targetRepoUrl)
+		Expect(ok).To(BeTrue())
+		Expect(org).To(Equal("test"))
+		Expect(repo).To(Equal("integration-examples"))
+
+		_, _, ok = helpers.ForkGitResolverOrgRepo(sourceRepoUrl, sourceRepoUrl)
+		Expect(ok).To(BeFalse())
+
+		_, _, ok = helpers.ForkGitResolverOrgRepo("git@github.com:test/integration-examples.git", targetRepoUrl)
+		Expect(ok).To(BeFalse())
 	})
 
 })

--- a/tekton/consts/consts.go
+++ b/tekton/consts/consts.go
@@ -34,28 +34,37 @@ const (
 	// CustomLabelPrefix contains the prefix applied to custom user-defined labels and annotations.
 	CustomLabelPrefix = "custom.appstudio.openshift.io"
 
-	// resource labels for snapshot, application and component
+	// ResourceLabelSuffix is the resource label suffix for snapshot, application and component
 	ResourceLabelSuffix = "appstudio.openshift.io"
 
 	// PipelineTypeTest is the type for PipelineRuns created to run an integration Pipeline
 	PipelineTypeTest = "test"
 
-	// Name of tekton resolver for git
+	// TektonResolverGit is the name of tekton resolver for git
 	TektonResolverGit = "git"
 
 	// TektonResolverBundle is the name of Tekton resolver for bundles
 	TektonResolverBundle = "bundle"
 
-	// Name of tekton git resolver param url
+	// TektonResolverGitParamURL is the name  of tekton git resolver param url
 	TektonResolverGitParamURL = "url"
 
-	// Name of tekton git resolver param revision
+	// TektonResolverGitParamServerUrl is the name of tekton git resolver param serverURL
+	TektonResolverGitParamServerUrl = "serverURL"
+
+	// TektonResolverGitParamOrg is the name of tekton git resolver param org
+	TektonResolverGitParamOrg = "org"
+
+	// TektonResolverGitParamRepo is the name of tekton git resolver param repo
+	TektonResolverGitParamRepo = "repo"
+
+	// TektonResolverGitParamRevision is the name  of tekton git resolver param revision
 	TektonResolverGitParamRevision = "revision"
 
-	// Value of ResourceKind field for remote pipelines
+	// ResourceKindPipeline is the value of ResourceKind field for remote pipelines
 	ResourceKindPipeline = "pipeline"
 
-	// Value of ResourceKind field for remote pipelineruns
+	// ResourceKindPipelineRun is the value of ResourceKind field for remote pipelineruns
 	ResourceKindPipelineRun = "pipelinerun"
 
 	// DefaultIntegrationPipelineServiceAccount denotes the service account which is used by default in integration pipelines

--- a/tekton/integration_pipeline.go
+++ b/tekton/integration_pipeline.go
@@ -65,14 +65,24 @@ func (r *IntegrationPipelineRun) AsPipelineRun() *tektonv1.PipelineRun {
 func ReplaceGitResolverUpdateMap(snapshot *applicationapiv1alpha1.Snapshot, resolverParams []v1beta2.ResolverParameter) []v1beta2.ResolverParameter {
 	annotations := snapshot.GetAnnotations()
 
+	sourceRepoUrl := annotations[gitops.PipelineAsCodeGitSourceURLAnnotation]
+	targetRepoUrl := annotations[gitops.PipelineAsCodeRepoURLAnnotation]
+	forkOrg, forkRepo, isFork := h.ForkGitResolverOrgRepo(sourceRepoUrl, targetRepoUrl)
+
 	for paramIndex, param := range resolverParams {
 		if param.Name == consts.TektonResolverGitParamURL {
 			// use the original index to update the value, we cannot update value given by range directly
-			resolverParams[paramIndex].Value = h.UrlToGitUrl(annotations[gitops.PipelineAsCodeGitSourceURLAnnotation]) // should have .git in url for consistency and compatibility
+			resolverParams[paramIndex].Value = h.UrlToGitUrl(sourceRepoUrl) // should have .git in url for consistency and compatibility
 		}
 		if param.Name == consts.TektonResolverGitParamRevision {
 			// use the original index to update the value, we cannot update value given by range directly
 			resolverParams[paramIndex].Value = annotations[gitops.PipelineAsCodeSHAAnnotation]
+		}
+		if isFork && param.Name == consts.TektonResolverGitParamOrg {
+			resolverParams[paramIndex].Value = forkOrg
+		}
+		if isFork && param.Name == consts.TektonResolverGitParamRepo {
+			resolverParams[paramIndex].Value = forkRepo
 		}
 	}
 	return resolverParams
@@ -348,10 +358,18 @@ func updateTaskGitResolver(originalTask *tektonv1.PipelineTask, params map[strin
 // getGitResolverUpdateMap extracts the git resolver annotations from the Snapshot
 func getGitResolverUpdateMap(snapshot *applicationapiv1alpha1.Snapshot) map[string]string {
 	annotations := snapshot.GetAnnotations()
-	return map[string]string{
-		consts.TektonResolverGitParamURL:      h.UrlToGitUrl(annotations[gitops.PipelineAsCodeGitSourceURLAnnotation]), // should have .git in url for consistency and compatibility
+	sourceRepoUrl := annotations[gitops.PipelineAsCodeGitSourceURLAnnotation]
+	targetRepoUrl := annotations[gitops.PipelineAsCodeRepoURLAnnotation]
+
+	updates := map[string]string{
+		consts.TektonResolverGitParamURL:      h.UrlToGitUrl(sourceRepoUrl), // should have .git in url for consistency and compatibility
 		consts.TektonResolverGitParamRevision: annotations[gitops.PipelineAsCodeSHAAnnotation],
 	}
+	if forkOrg, forkRepo, ok := h.ForkGitResolverOrgRepo(sourceRepoUrl, targetRepoUrl); ok {
+		updates[consts.TektonResolverGitParamOrg] = forkOrg
+		updates[consts.TektonResolverGitParamRepo] = forkRepo
+	}
+	return updates
 }
 
 // doTargetAndSourceRevisionParamsMatch checks if the target revision matches the resolver's source parameter
@@ -364,10 +382,21 @@ func doTargetAndSourceRevisionParamsMatch(annotations map[string]string, params 
 		return false
 	}
 
+	// When url parameter is used, normalize the URL and match against the component's git source
 	if urlVal, ok := params[consts.TektonResolverGitParamURL]; ok {
 		// urlVal may or may not have git suffix specified
 		return annotations[gitops.PipelineAsCodeRepoURLAnnotation] != "" &&
 			h.UrlToGitUrl(urlVal) == h.UrlToGitUrl(annotations[gitops.PipelineAsCodeRepoURLAnnotation])
+	}
+
+	// When org/repo/serverURL are used, construct the URL from those params and match against the component's git source
+	if serverUrl, ok := params[consts.TektonResolverGitParamServerUrl]; ok {
+		if orgVal, ok := params[consts.TektonResolverGitParamOrg]; ok {
+			if repoVal, ok := params[consts.TektonResolverGitParamRepo]; ok {
+				return annotations[gitops.PipelineAsCodeRepoURLAnnotation] != "" &&
+					h.ConstructGitUrl(serverUrl, orgVal, repoVal) == h.UrlToGitUrl(annotations[gitops.PipelineAsCodeRepoURLAnnotation])
+			}
+		}
 	}
 
 	// undefined state, no idea what was configured in resolver, don't touch it

--- a/tekton/integration_pipeline_test.go
+++ b/tekton/integration_pipeline_test.go
@@ -76,6 +76,15 @@ func getParamValue(params tektonv1.Params, name string) string {
 	return ""
 }
 
+func getResolverParamValue(params []v1beta2.ResolverParameter, name string) string {
+	for _, p := range params {
+		if p.Name == name {
+			return p.Value
+		}
+	}
+	return ""
+}
+
 var _ = Describe("Integration pipeline", Ordered, func() {
 
 	const (
@@ -1079,6 +1088,274 @@ var _ = Describe("Integration pipeline", Ordered, func() {
 			// We expect the second task in the finally block to not be updated since it originates from a different repo
 			Expect(result.Spec.PipelineSpec.Finally[1].TaskRef.Params[0].Value.StringVal).To(Equal("https://github.com/someotherrepo/repo.git"))
 			Expect(result.Spec.PipelineSpec.Finally[1].TaskRef.Params[1].Value.StringVal).To(Equal("main"))
+		})
+	})
+
+	Context("When testing git resolver updates with org/repo/serverURL params", func() {
+		const (
+			forkSourceRepoUrl  = "https://github.com/test/integration-examples"
+			forkTargetRepoUrl  = "https://github.com/redhat-appstudio/integration-examples"
+			forkTargetOrg      = "redhat-appstudio"
+			forkTargetRepo     = "integration-examples"
+			forkSourceOrg      = "test"
+			forkSourceRevision = "abcdef0123456789abcdef0123456789abcdef01"
+		)
+
+		It("updates org and repo in ReplaceGitResolverUpdateMap for fork PR snapshots", func() {
+			snapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						gitops.PipelineAsCodeGitSourceURLAnnotation: forkSourceRepoUrl,
+						gitops.PipelineAsCodeRepoURLAnnotation:      forkTargetRepoUrl,
+						gitops.PipelineAsCodeSHAAnnotation:          forkSourceRevision,
+					},
+				},
+			}
+			resolverParams := []v1beta2.ResolverParameter{
+				{Name: tektonconsts.TektonResolverGitParamServerUrl, Value: "https://github.com"},
+				{Name: tektonconsts.TektonResolverGitParamOrg, Value: forkTargetOrg},
+				{Name: tektonconsts.TektonResolverGitParamRepo, Value: forkTargetRepo},
+				{Name: tektonconsts.TektonResolverGitParamRevision, Value: "main"},
+			}
+
+			result := tekton.ReplaceGitResolverUpdateMap(snapshot, resolverParams)
+			Expect(getResolverParamValue(result, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkSourceOrg))
+			Expect(getResolverParamValue(result, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getResolverParamValue(result, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
+
+			resultAgain := tekton.ReplaceGitResolverUpdateMap(snapshot, result)
+			Expect(resultAgain).To(Equal(result))
+			Expect(getResolverParamValue(resultAgain, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkSourceOrg))
+			Expect(getResolverParamValue(resultAgain, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getResolverParamValue(resultAgain, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
+		})
+
+		It("does not update org and repo in ReplaceGitResolverUpdateMap for same-repo PR snapshots", func() {
+			snapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						gitops.PipelineAsCodeGitSourceURLAnnotation: forkTargetRepoUrl,
+						gitops.PipelineAsCodeRepoURLAnnotation:      forkTargetRepoUrl,
+						gitops.PipelineAsCodeSHAAnnotation:          forkSourceRevision,
+					},
+				},
+			}
+			resolverParams := []v1beta2.ResolverParameter{
+				{Name: tektonconsts.TektonResolverGitParamServerUrl, Value: "https://github.com"},
+				{Name: tektonconsts.TektonResolverGitParamOrg, Value: forkTargetOrg},
+				{Name: tektonconsts.TektonResolverGitParamRepo, Value: forkTargetRepo},
+				{Name: tektonconsts.TektonResolverGitParamRevision, Value: "main"},
+			}
+
+			result := tekton.ReplaceGitResolverUpdateMap(snapshot, resolverParams)
+			Expect(getResolverParamValue(result, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkTargetOrg))
+			Expect(getResolverParamValue(result, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getResolverParamValue(result, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
+		})
+
+		It("returns true from ShouldUpdateIntegrationPipelineGitResolver when org/repo/serverURL match the target repo", func() {
+			scenario := &v1beta2.IntegrationTestScenario{
+				Spec: v1beta2.IntegrationTestScenarioSpec{
+					ResolverRef: v1beta2.ResolverRef{
+						Resolver: tektonconsts.TektonResolverGit,
+						Params: []v1beta2.ResolverParameter{
+							{Name: tektonconsts.TektonResolverGitParamServerUrl, Value: "https://github.com"},
+							{Name: tektonconsts.TektonResolverGitParamOrg, Value: forkTargetOrg},
+							{Name: tektonconsts.TektonResolverGitParamRepo, Value: forkTargetRepo},
+							{Name: tektonconsts.TektonResolverGitParamRevision, Value: "main"},
+						},
+					},
+				},
+			}
+			snapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						gitops.PipelineAsCodePullRequestAnnotation: "1",
+						gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+					},
+					Annotations: map[string]string{
+						gitops.PipelineAsCodeRepoURLAnnotation:      forkTargetRepoUrl,
+						gitops.PipelineAsCodeGitSourceURLAnnotation: forkSourceRepoUrl,
+						gitops.PipelineAsCodeTargetBranchAnnotation: "main",
+						gitops.PipelineAsCodeSHAAnnotation:          forkSourceRevision,
+					},
+				},
+			}
+
+			Expect(tekton.ShouldUpdateIntegrationPipelineGitResolver(scenario, snapshot)).To(BeTrue())
+		})
+
+		It("returns false from ShouldUpdateIntegrationPipelineGitResolver when org/repo/serverURL do not match the target repo", func() {
+			scenario := &v1beta2.IntegrationTestScenario{
+				Spec: v1beta2.IntegrationTestScenarioSpec{
+					ResolverRef: v1beta2.ResolverRef{
+						Resolver: tektonconsts.TektonResolverGit,
+						Params: []v1beta2.ResolverParameter{
+							{Name: tektonconsts.TektonResolverGitParamServerUrl, Value: "https://github.com"},
+							{Name: tektonconsts.TektonResolverGitParamOrg, Value: "other-org"},
+							{Name: tektonconsts.TektonResolverGitParamRepo, Value: forkTargetRepo},
+							{Name: tektonconsts.TektonResolverGitParamRevision, Value: "main"},
+						},
+					},
+				},
+			}
+			snapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						gitops.PipelineAsCodePullRequestAnnotation: "1",
+						gitops.PipelineAsCodeEventTypeLabel:        gitops.PipelineAsCodePullRequestType,
+					},
+					Annotations: map[string]string{
+						gitops.PipelineAsCodeRepoURLAnnotation:      forkTargetRepoUrl,
+						gitops.PipelineAsCodeGitSourceURLAnnotation: forkSourceRepoUrl,
+						gitops.PipelineAsCodeTargetBranchAnnotation: "main",
+						gitops.PipelineAsCodeSHAAnnotation:          forkSourceRevision,
+					},
+				},
+			}
+
+			Expect(tekton.ShouldUpdateIntegrationPipelineGitResolver(scenario, snapshot)).To(BeFalse())
+		})
+
+		It("updates org and repo in WithUpdatedPipelineGitResolver for fork PR snapshots", func() {
+			pipelineRun := &tekton.IntegrationPipelineRun{
+				tektonv1.PipelineRun{
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineRef: &tektonv1.PipelineRef{
+							ResolverRef: tektonv1.ResolverRef{
+								Resolver: tektonv1.ResolverName(tektonconsts.TektonResolverGit),
+								Params: []tektonv1.Param{
+									{
+										Name: tektonconsts.TektonResolverGitParamServerUrl,
+										Value: tektonv1.ParamValue{
+											Type:      tektonv1.ParamTypeString,
+											StringVal: "https://github.com",
+										},
+									},
+									{
+										Name: tektonconsts.TektonResolverGitParamOrg,
+										Value: tektonv1.ParamValue{
+											Type:      tektonv1.ParamTypeString,
+											StringVal: forkTargetOrg,
+										},
+									},
+									{
+										Name: tektonconsts.TektonResolverGitParamRepo,
+										Value: tektonv1.ParamValue{
+											Type:      tektonv1.ParamTypeString,
+											StringVal: forkTargetRepo,
+										},
+									},
+									{
+										Name: tektonconsts.TektonResolverGitParamRevision,
+										Value: tektonv1.ParamValue{
+											Type:      tektonv1.ParamTypeString,
+											StringVal: "main",
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			snapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						gitops.PipelineAsCodeGitSourceURLAnnotation: forkSourceRepoUrl,
+						gitops.PipelineAsCodeRepoURLAnnotation:      forkTargetRepoUrl,
+						gitops.PipelineAsCodeTargetBranchAnnotation: "main",
+						gitops.PipelineAsCodeSHAAnnotation:          forkSourceRevision,
+					},
+				},
+			}
+
+			result := pipelineRun.WithUpdatedPipelineGitResolver(snapshot)
+			Expect(result).NotTo(BeNil())
+			Expect(getParamValue(result.Spec.PipelineRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkSourceOrg))
+			Expect(getParamValue(result.Spec.PipelineRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getParamValue(result.Spec.PipelineRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
+
+			resultAgain := result.WithUpdatedPipelineGitResolver(snapshot)
+			Expect(resultAgain).To(BeIdenticalTo(result))
+			Expect(getParamValue(resultAgain.Spec.PipelineRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkSourceOrg))
+			Expect(getParamValue(resultAgain.Spec.PipelineRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getParamValue(resultAgain.Spec.PipelineRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
+		})
+
+		It("updates org and repo in WithUpdatedTasksGitResolver for fork PR snapshots", func() {
+			pipelineRun := &tekton.IntegrationPipelineRun{
+				tektonv1.PipelineRun{
+					Spec: tektonv1.PipelineRunSpec{
+						PipelineSpec: &tektonv1.PipelineSpec{
+							Tasks: []tektonv1.PipelineTask{
+								{
+									Name: "some-task",
+									TaskRef: &tektonv1.TaskRef{
+										ResolverRef: tektonv1.ResolverRef{
+											Resolver: tektonv1.ResolverName(tektonconsts.TektonResolverGit),
+											Params: []tektonv1.Param{
+												{
+													Name: tektonconsts.TektonResolverGitParamServerUrl,
+													Value: tektonv1.ParamValue{
+														Type:      tektonv1.ParamTypeString,
+														StringVal: "https://github.com",
+													},
+												},
+												{
+													Name: tektonconsts.TektonResolverGitParamOrg,
+													Value: tektonv1.ParamValue{
+														Type:      tektonv1.ParamTypeString,
+														StringVal: forkTargetOrg,
+													},
+												},
+												{
+													Name: tektonconsts.TektonResolverGitParamRepo,
+													Value: tektonv1.ParamValue{
+														Type:      tektonv1.ParamTypeString,
+														StringVal: forkTargetRepo,
+													},
+												},
+												{
+													Name: tektonconsts.TektonResolverGitParamRevision,
+													Value: tektonv1.ParamValue{
+														Type:      tektonv1.ParamTypeString,
+														StringVal: "main",
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			snapshot := &applicationapiv1alpha1.Snapshot{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						gitops.PipelineAsCodeGitSourceURLAnnotation: forkSourceRepoUrl,
+						gitops.PipelineAsCodeRepoURLAnnotation:      forkTargetRepoUrl,
+						gitops.PipelineAsCodeTargetBranchAnnotation: "main",
+						gitops.PipelineAsCodeSHAAnnotation:          forkSourceRevision,
+					},
+				},
+			}
+
+			result := pipelineRun.WithUpdatedTasksGitResolver(snapshot)
+			Expect(result).NotTo(BeNil())
+			Expect(getParamValue(result.Spec.PipelineSpec.Tasks[0].TaskRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkSourceOrg))
+			Expect(getParamValue(result.Spec.PipelineSpec.Tasks[0].TaskRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getParamValue(result.Spec.PipelineSpec.Tasks[0].TaskRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
+
+			resultAgain := result.WithUpdatedTasksGitResolver(snapshot)
+			Expect(resultAgain).To(BeIdenticalTo(result))
+			Expect(getParamValue(resultAgain.Spec.PipelineSpec.Tasks[0].TaskRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamOrg)).To(Equal(forkSourceOrg))
+			Expect(getParamValue(resultAgain.Spec.PipelineSpec.Tasks[0].TaskRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRepo)).To(Equal(forkTargetRepo))
+			Expect(getParamValue(resultAgain.Spec.PipelineSpec.Tasks[0].TaskRef.ResolverRef.Params, tektonconsts.TektonResolverGitParamRevision)).To(Equal(forkSourceRevision))
 		})
 	})
 })


### PR DESCRIPTION
When org/repo/serverURL are used in ITS Pipeline, PipelineRun or Task definitions, construct the git URL from those params and match it against the component's git source
when determining if the revision should be overriden.

If the change is coming from a fork, parse the URL in order to detect it and then override the org and repo so it matches the behavior when handling simple git urls.

## Maintainers will complete the following section

- [x] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [x] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [x] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)
