### PR TITLE
fix(STONEINTG-1771): gate Qodo reviews behind /qodo-review

### DIFF
--- a/.github/workflows/fullsend.yaml
+++ b/.github/workflows/fullsend.yaml
@@ -40,7 +40,10 @@ jobs:
       cancel-in-progress: false
     if: >-
       github.event_name != 'issue_comment'
-      || github.event.comment.user.type != 'Bot'
+      || (
+        github.event.comment.user.type != 'Bot'
+        && github.event.comment.body != '/qodo-review'
+      )
     uses: konflux-ci/.fullsend/.github/workflows/dispatch.yml@701e62a9c6f104ed68f8d4085d9c3b8bad3a82e4 # main
     with:
       event_action: ${{ github.event.action }}

--- a/.github/workflows/qodo-review.yaml
+++ b/.github/workflows/qodo-review.yaml
@@ -1,0 +1,66 @@
+# STONEINTG-1771: manual Qodo review trigger for integration team members.
+# Complements .pr_agent.toml (auto-disable) by gating /qodo-review.
+# Authorization read from .github/CODEOWNERS on the default branch.
+
+name: qodo-review
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  # Single job: authorize commenter, then allow or deny.
+  qodo-review:
+    if: >-
+      github.event_name == 'issue_comment'
+      && github.event.issue.pull_request
+      && github.event.comment.user.type != 'Bot'
+      && github.event.comment.body == '/qodo-review'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+    steps:
+
+      - name: Checkout CODEOWNERS from default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Check integration team membership
+        id: auth
+        env:
+          USER: ${{ github.event.comment.user.login }}
+        run: |
+          owners=$(grep -oE '@[[:alnum:]_-]+' .github/CODEOWNERS | tr -d '@')
+          if echo "$owners" | grep -Fqx -- "$USER"; then
+            echo "authorized=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "authorized=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Trigger Qodo Code review
+        if: steps.auth.outputs.authorized == 'true'
+        env:
+          GH_TOKEN: ${{ github.token}}
+          PR_NUMBER: ${{ github.event.issue.number}}
+          REPO: ${{ github.repository}}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body ":white_check_mark: Qodo code review requested.
+          /agentic_review"
+
+      - name: Notify unauthorized user
+        if: steps.auth.outputs.authorized != 'true'
+        env:
+          GH_TOKEN: ${{ github.token}}
+          PR_NUMBER: ${{ github.event.issue.number}}
+          REPO: ${{ github.repository}}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "$REPO" \
+            --body ":no_entry: \`/qodo-review\` is restricted to konflux integration team members."

--- a/.github/workflows/qodo-review.yaml
+++ b/.github/workflows/qodo-review.yaml
@@ -37,7 +37,7 @@ jobs:
         env:
           USER: ${{ github.event.comment.user.login }}
         run: |
-          owners=$(grep -oE '@[[:alnum:]_-]+' .github/CODEOWNERS | tr -d '@')
+          owners=$(grep '^[*]' .github/CODEOWNERS | grep -oE '@[[:alnum:]_-]+' | tr -d '@')
           if echo "$owners" | grep -Fqx -- "$USER"; then
             echo "authorized=true" >> "$GITHUB_OUTPUT"
           else
@@ -47,9 +47,9 @@ jobs:
       - name: Trigger Qodo Code review
         if: steps.auth.outputs.authorized == 'true'
         env:
-          GH_TOKEN: ${{ github.token}}
-          PR_NUMBER: ${{ github.event.issue.number}}
-          REPO: ${{ github.repository}}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
             --body ":white_check_mark: Qodo code review requested.
@@ -58,9 +58,9 @@ jobs:
       - name: Notify unauthorized user
         if: steps.auth.outputs.authorized != 'true'
         env:
-          GH_TOKEN: ${{ github.token}}
-          PR_NUMBER: ${{ github.event.issue.number}}
-          REPO: ${{ github.repository}}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          REPO: ${{ github.repository }}
         run: |
           gh pr comment "$PR_NUMBER" --repo "$REPO" \
             --body ":no_entry: \`/qodo-review\` is restricted to konflux integration team members."

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -2,7 +2,12 @@
 # Docs: https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file
 
 [github_app]
-ignore_pr_authors = ["red-hat-konflux", "release-service-bot", "dependabot[bot]"]
+ignore_pr_authors = [
+  "red-hat-konflux",
+  "release-service-bot",
+  "dependabot[bot]",
+  "fullsend-ai-review[bot]",
+]
 
 # Manual trigger via /qodo-review (see .github/workflows/qodo-review.yaml).
 pr_commands = []

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,40 @@
+# Qodo PR-Agent configuration
+# Docs: https://docs.qodo.ai/install-and-configure/configuration-overview/configuration-file
+
+[github_app]
+ignore_pr_authors = ["red-hat-konflux", "release-service-bot", "dependabot[bot]"]
+
+# Manual trigger via /qodo-review (see .github/workflows/qodo-review.yaml).
+pr_commands = []
+
+# do not re-run Qodo on every push to an open PR.
+handle_push_trigger = false
+
+[review_agent]
+comments_location_policy = "both"
+inline_comments_severity_threshold = 3
+enable_commitable_suggestions = true
+
+# On re-review, focus on changes since the last run instead of the whole PR.
+enable_incremental_review = true
+
+issues_user_guidelines = """
+- Provide up to 3 high-signal inline review comments per PR.
+- Prefer actionable findings over style nits or linter-duplicated feedback.
+- Before suggesting a change, verify whether the PR already includes it.
+- Do not repeat previously rejected suggestions if the thread was resolved without action.
+- Read project conventions and architecture at:
+  https://raw.githubusercontent.com/konflux-ci/integration-service/refs/heads/main/AGENTS.md
+"""
+
+# Repo specific conventions for rule/compliance checks during review.
+compliance_user_guidelines = """
+- Domain logic belongs in adapter methods, not controllers.
+- Use IntegrationLogger for logging and fmt.Errorf("context: %w", err) for error wrapping.
+- API changes require make generate manifests.
+"""
+
+[review_agent_ux]
+finding_overflow_count = 3
+resolved_overflow_count = 3
+show_persistent_review_section = true


### PR DESCRIPTION
Qodo AI reviews were running automatically on every PR open/update, which is expensive and noisy. This change makes review on demand only, gated to integration team members, with feedback when unauthorized users attempt to trigger it.

Disabled automatic Qodo triggers (.pr_agent.toml). Set **pr_commands** = [] and **handle_push_trigger** = false so Qodo does not run on PR open, reopen, ready-for-review, or push. Automated execution on PR open/update is disabled.

Manual trigger workflow (**.github/workflows/qodo-review.yaml**). Integration team members comment `/qodo-review` on a PR to request a review. Authorization is read from .github/CODEOWNERS on the default branch. Unauthorized users receive a denial comment; authorized users trigger Qodo via /agentic_review.

Fullsend changes were handled separately in konflux-ci/.fullsend (different repo and config). See [here](https://github.com/konflux-ci/.fullsend/pull/44).

For testing, a test PR will be created once this PR is merged to main. This will verify:

no automatic Qodo review on open/push
/qodo-review works for integration team members
unauthorized users receive the expected denial message
Please see [STONEINTG-1771](https://redhat.atlassian.net/browse/STONEINTG-1771) for full story details/links.

## Maintainers will complete the following section

- [ ] Commit messages are descriptive enough ([hints](https://www.freecodecamp.org/news/how-to-write-better-git-commit-messages/))
- [ ] Code coverage from testing does not decrease and new code is covered ([check the PR coverage on codecov](https://app.codecov.io/gh/konflux-ci/integration-service/pulls))
- [ ] [Controllers diagrams](https://github.com/konflux-ci/integration-service/tree/main/docs) are updated when PR changes controllers code  (if applicable)


[STONEINTG-1771]: https://redhat.atlassian.net/browse/STONEINTG-1771?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ